### PR TITLE
TDD workflow + CI enforcement, plus dashboard/transaction UI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
     name: mutation (incremental)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    # Non-blocking for now. Stryker is verified working against the
+    # testcontainers suite locally (score 67% >= 60 break threshold), but a
+    # full cold-cache run over lib+actions+queries has not been timed in CI.
+    # It runs and reports; it does not gate merges. Flip to blocking (remove
+    # this) once a full run is observed green and acceptably fast in CI.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11.5.2
 
       - uses: actions/setup-node@v4
         with:
@@ -52,7 +52,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11.5.2
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: typecheck · lint · test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm typecheck
+
+      - run: pnpm lint
+
+      # Integration tests start Postgres via testcontainers; Docker is
+      # preinstalled on ubuntu-latest. No secrets required.
+      - run: pnpm test
+
+  mutation:
+    name: mutation (incremental)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Restore the incremental baseline so unchanged files are not re-mutated.
+      - uses: actions/cache@v4
+        with:
+          path: reports/mutation/.stryker-incremental.json
+          key: stryker-${{ github.head_ref }}-${{ github.sha }}
+          restore-keys: |
+            stryker-${{ github.head_ref }}-
+            stryker-
+
+      - run: pnpm test:mutate:incremental

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,22 @@ See the design spec for full schema with indexes and constraints.
 - Bug fix: 2-3 regression tests proving the fix
 - Refactor: 0 new tests (existing tests must pass)
 
-**CI pipeline order:** typecheck → lint → vitest → stryker (incremental) → playwright
+### TDD Workflow (new work)
+
+New features and bugfixes start **test-first** (superpowers `test-driven-development` skill). The red-green-refactor loop, mapped to this repo:
+
+1. **Red** — write the smallest failing test next to the code (`*.test.ts` colocated, or `tests/integration/` if it needs the DB). Run it and watch it fail:
+   - `pnpm test:changed` — runs only tests related to your changed files (fast loop)
+   - or `pnpm test:watch` for continuous feedback
+2. **Green** — write the minimal code to pass. Re-run until green.
+3. **Refactor** — clean up with tests staying green.
+4. **Commit** — the `pre-commit` hook (`simple-git-hooks` + `lint-staged`) runs `eslint --fix` + `vitest related --run` on changed files. A failing related test blocks the commit. (DB-related changes pull in integration tests, which need Docker running.)
+
+Enforcement layers, fast → slow: `test:changed`/watch → pre-commit hook → CI. If CI is red, the merge is blocked (once branch protection requires the `test` check).
+
+**Time in tests:** never hardcode absolute dates that must fall in a "recent" window — queries compute windows from `new Date()`, so hardcoded dates silently rot as the calendar moves. Derive fixture dates relative to now (see `dashboard-queries.test.ts`).
+
+**CI pipeline order:** typecheck → lint → vitest → stryker (incremental). Wired in `.github/workflows/ci.yml` (runs on push to `main` + all PRs; mutation is PR-only). Playwright is not yet in the blocking job.
 
 ## Auto-Categorization Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,9 +173,9 @@ New features and bugfixes start **test-first** (superpowers `test-driven-develop
    - or `pnpm test:watch` for continuous feedback
 2. **Green** — write the minimal code to pass. Re-run until green.
 3. **Refactor** — clean up with tests staying green.
-4. **Commit** — the `pre-commit` hook (`simple-git-hooks` + `lint-staged`) runs `eslint --fix` + `vitest related --run` on changed files. A failing related test blocks the commit. (DB-related changes pull in integration tests, which need Docker running.)
+4. **Commit** — the `pre-commit` hook (`simple-git-hooks` + `lint-staged`) runs `eslint --fix` on changed files (fast, no Docker). Run tests yourself before committing via `test:changed`/`test:watch`.
 
-Enforcement layers, fast → slow: `test:changed`/watch → pre-commit hook → CI. If CI is red, the merge is blocked (once branch protection requires the `test` check).
+Enforcement layers, fast → slow: `test:changed`/watch (you, locally) → pre-commit hook (lint) → CI (full suite). The test gate lives in CI — integration tests need Docker and are too heavy for a pre-commit hook — so red blocks the merge once branch protection requires the `test` check.
 
 **Time in tests:** never hardcode absolute dates that must fall in a "recent" window — queries compute windows from `new Date()`, so hardcoded dates silently rot as the calendar moves. Derive fixture dates relative to now (see `dashboard-queries.test.ts`).
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "db:setup": "pnpm db:generate && pnpm db:migrate",
     "db:studio": "drizzle-kit studio",
     "rotate-keys": "node --env-file-if-exists=.env --import tsx scripts/rotate-keys.ts",
+    "backfill-clean-names": "node --env-file-if-exists=.env --import tsx scripts/backfill-clean-names.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,20 @@
     "test:e2e:ui": "playwright test --ui",
     "test:mutate": "stryker run",
     "test:mutate:incremental": "stryker run --incremental",
+    "test:changed": "vitest related --run $(git diff --name-only HEAD)",
+    "prepare": "simple-git-hooks",
     "build:mcp-widgets": "tsx src/lib/mcp/apps/build.ts",
     "dev:db": "docker compose up db -d",
     "dev:setup": "pnpm dev:db && until pg_isready -h localhost -p 5432 2>/dev/null; do sleep 1; done && pnpm db:migrate && pnpm dev"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "pnpm exec lint-staged"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "vitest related --run"
+    ]
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.76",
@@ -58,12 +69,6 @@
     "uuid": "^14.0.0",
     "zod": "^4.4.3"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "sharp",
-      "unrs-resolver"
-    ]
-  },
   "devDependencies": {
     "@fast-check/vitest": "^0.4.1",
     "@playwright/test": "^1.59.1",
@@ -88,7 +93,9 @@
     "eslint-config-next": "16.2.6",
     "fast-check": "^4.7.0",
     "jsdom": "^29.1.1",
+    "lint-staged": "^17.0.8",
     "msw": "^2.14.5",
+    "simple-git-hooks": "^2.13.1",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,7 @@
     "pre-commit": "pnpm exec lint-staged"
   },
   "lint-staged": {
-    "*.{ts,tsx}": [
-      "eslint --fix",
-      "vitest related --run"
-    ]
+    "*.{ts,tsx}": "eslint --fix"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.76",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,9 +174,15 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
+      lint-staged:
+        specifier: ^17.0.8
+        version: 17.0.8
       msw:
         specifier: ^2.14.5
         version: 2.14.5(@types/node@20.19.40)(typescript@5.9.3)
+      simple-git-hooks:
+        specifier: ^2.13.1
+        version: 2.13.1
       tailwindcss:
         specifier: ^4
         version: 4.3.0
@@ -188,7 +194,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -2634,6 +2640,10 @@ packages:
     resolution: {integrity: sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==}
     engines: {node: '>= 14'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -3002,6 +3012,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
@@ -3465,6 +3479,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -4128,6 +4146,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -4455,6 +4477,15 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lint-staged@17.0.8:
+    resolution: {integrity: sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==}
+    engines: {node: '>=22.22.1'}
+    hasBin: true
+
+  listr2@10.2.2:
+    resolution: {integrity: sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==}
+    engines: {node: '>=22.13.0'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -4473,6 +4504,10 @@ packages:
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
   long@5.3.2:
@@ -5199,6 +5234,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
   rolldown@1.0.0-rc.18:
     resolution: {integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5337,8 +5375,20 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5396,6 +5446,10 @@ packages:
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -5407,6 +5461,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -5546,6 +5604,10 @@ packages:
 
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
@@ -5914,6 +5976,10 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -5921,6 +5987,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -5949,6 +6019,11 @@ packages:
 
   yaml@2.8.4:
     resolution: {integrity: sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -6795,7 +6870,7 @@ snapshots:
   '@fast-check/vitest@0.4.1(vitest@4.1.5)':
     dependencies:
       fast-check: 4.7.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -7580,7 +7655,7 @@ snapshots:
       '@stryker-mutator/util': 9.6.1
       semver: 7.8.0
       tslib: 2.8.1
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -7992,7 +8067,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -8003,14 +8078,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))':
+  '@vitest/mocker@4.1.5(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.14.5(@types/node@20.19.40)(typescript@5.9.3)
-      vite: 8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -8080,6 +8155,10 @@ snapshots:
       require-from-string: 2.0.2
 
   angular-html-parser@10.4.0: {}
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
 
   ansi-regex@5.0.1: {}
 
@@ -8311,7 +8390,7 @@ snapshots:
       pg: 8.20.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -8453,6 +8532,11 @@ snapshots:
       restore-cursor: 5.1.0
 
   cli-spinners@2.9.2: {}
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.1
 
   cli-width@4.1.0: {}
 
@@ -8800,6 +8884,8 @@ snapshots:
   entities@8.0.0: {}
 
   env-paths@2.2.1: {}
+
+  environment@1.1.0: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -9720,6 +9806,10 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -10003,6 +10093,23 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lint-staged@17.0.8:
+    dependencies:
+      listr2: 10.2.2
+      picomatch: 4.0.4
+      string-argv: 0.3.2
+      tinyexec: 1.2.4
+    optionalDependencies:
+      yaml: 2.9.0
+
+  listr2@10.2.2:
+    dependencies:
+      cli-truncate: 5.2.0
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 10.0.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -10019,6 +10126,14 @@ snapshots:
     dependencies:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   long@5.3.2: {}
 
@@ -10784,6 +10899,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rfdc@1.4.1: {}
+
   rolldown@1.0.0-rc.18:
     dependencies:
       '@oxc-project/types': 0.128.0
@@ -11040,7 +11157,19 @@ snapshots:
       simple-concat: 1.0.1
     optional: true
 
+  simple-git-hooks@2.13.1: {}
+
   sisteransi@1.0.5: {}
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   source-map-js@1.2.1: {}
 
@@ -11096,6 +11225,8 @@ snapshots:
 
   strict-event-emitter@0.5.1: {}
 
+  string-argv@0.3.2: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -11111,6 +11242,11 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.1:
+    dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
@@ -11307,6 +11443,8 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
     dependencies:
@@ -11558,7 +11696,7 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4):
+  vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -11571,12 +11709,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
-      yaml: 2.8.4
+      yaml: 2.9.0
 
-  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@20.19.40)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4))
+      '@vitest/mocker': 4.1.5(msw@2.14.5(@types/node@20.19.40)(typescript@5.9.3))(vite@8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -11593,7 +11731,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.4)
+      vite: 8.0.11(@types/node@20.19.40)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -11679,6 +11817,12 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.2.0
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -11689,6 +11833,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
@@ -11709,6 +11859,9 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.8.4: {}
+
+  yaml@2.9.0:
+    optional: true
 
   yargs-parser@21.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,5 +5,6 @@ allowBuilds:
   msw: true
   protobufjs: true
   sharp: true
+  simple-git-hooks: false
   ssh2: true
   unrs-resolver: true

--- a/scripts/backfill-clean-names.ts
+++ b/scripts/backfill-clean-names.ts
@@ -1,0 +1,18 @@
+/**
+ * Operator entry point for cleaning up raw transaction display names.
+ * Usage: pnpm backfill-clean-names
+ * Re-derives `name` from `originalName` for rows that still hold the raw bank
+ * description. Requires DATABASE_URL (loaded from .env when present).
+ */
+import { backfillCleanTransactionNames } from "@/lib/jobs/backfill-clean-names";
+
+async function main() {
+  const { scanned, updated } = await backfillCleanTransactionNames();
+  console.log(`[backfill-clean-names] scanned=${scanned} updated=${updated}`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -6,6 +6,7 @@ import {
   getCashFlow,
   getRecentTransactions,
   getInvestmentsSummary,
+  getLatestActivityMonth,
 } from "@/queries/dashboard";
 import { getAccounts } from "@/queries/accounts";
 import { getBudgetForMonth } from "@/queries/budgets";
@@ -20,7 +21,7 @@ import type { DashboardData } from "@/components/organisms/dashboard-grid";
 export default async function DashboardPage() {
   const [session, householdId] = await Promise.all([getSession(), getHouseholdId()]);
 
-  const [summary, netWorthHistory, monthlySpending, cashFlow, recentTransactions, allAccounts, budgetData, upcomingBills, investmentsData, savedLayout] =
+  const [summary, netWorthHistory, monthlySpending, cashFlow, recentTransactions, allAccounts, budgetData, upcomingBills, investmentsData, latestActivityMonth, savedLayout] =
     await Promise.all([
       getDashboardSummary(householdId),
       getNetWorthHistory(householdId, "6M"),
@@ -31,8 +32,14 @@ export default async function DashboardPage() {
       getBudgetForMonth(householdId, getCurrentMonth()),
       getUpcomingBills(householdId, { limit: 5 }),
       getInvestmentsSummary(householdId),
+      getLatestActivityMonth(householdId),
       session ? getLayoutForUser(session.user.id) : null,
     ]);
+
+  // The Spending widget's initial month must match the data getMonthlySpending
+  // resolved to (latest activity month when the current month is empty), so the
+  // widget doesn't open on an empty current month.
+  const spendingMonth = latestActivityMonth ?? getCurrentMonth();
 
   const accounts = allAccounts
     .filter((a) => !a.isHidden)
@@ -44,6 +51,7 @@ export default async function DashboardPage() {
     summary,
     netWorthHistory,
     monthlySpending,
+    spendingMonth,
     cashFlow,
     recentTransactions,
     accounts,

--- a/src/components/molecules/category-pill-label.test.ts
+++ b/src/components/molecules/category-pill-label.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { categoryPillLabel } from "./category-pill-label";
+
+describe("categoryPillLabel", () => {
+  it("shows the category name when one is assigned", () => {
+    expect(categoryPillLabel("Restaurants", false)).toEqual({
+      text: "Restaurants",
+      variant: "category",
+    });
+  });
+
+  it("labels an uncategorized transfer as Transfer, not Uncategorized", () => {
+    expect(categoryPillLabel(null, true)).toEqual({
+      text: "Transfer",
+      variant: "transfer",
+    });
+  });
+
+  it("labels a genuinely uncategorized (non-transfer) row as Uncategorized", () => {
+    expect(categoryPillLabel(null, false)).toEqual({
+      text: "Uncategorized",
+      variant: "uncategorized",
+    });
+  });
+
+  it("prefers an assigned category name even for a transfer", () => {
+    // A user can still categorize a transfer; the real category wins.
+    expect(categoryPillLabel("Credit Card Payment", true)).toEqual({
+      text: "Credit Card Payment",
+      variant: "category",
+    });
+  });
+});

--- a/src/components/molecules/category-pill-label.ts
+++ b/src/components/molecules/category-pill-label.ts
@@ -1,0 +1,16 @@
+export type CategoryPillVariant = "category" | "transfer" | "uncategorized";
+
+/**
+ * Decides what a transaction's category pill should read. Transfers (CC
+ * autopay, inter-account moves, P2P) legitimately have no spending category,
+ * so an uncategorized transfer reads "Transfer" rather than "Uncategorized" —
+ * it isn't a categorization gap. An assigned category always wins.
+ */
+export function categoryPillLabel(
+  categoryName: string | null,
+  isTransfer: boolean,
+): { text: string; variant: CategoryPillVariant } {
+  if (categoryName) return { text: categoryName, variant: "category" };
+  if (isTransfer) return { text: "Transfer", variant: "transfer" };
+  return { text: "Uncategorized", variant: "uncategorized" };
+}

--- a/src/components/molecules/category-pill.tsx
+++ b/src/components/molecules/category-pill.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Command, CommandInput, CommandList, CommandEmpty } from "@/components/ui/command";
 import { CategoryCommandItems } from "@/components/molecules/category-command-items";
+import { categoryPillLabel } from "@/components/molecules/category-pill-label";
 import type { CategoryGroup } from "@/queries/categories";
 import { cn } from "@/lib/utils";
 
@@ -16,6 +17,7 @@ interface CategoryPillProps {
   currentCategoryName: string | null;
   categories: CategoryGroup[];
   disabled?: boolean;
+  isTransfer?: boolean;
   onCategoryChange?: (categoryId: string | null, categoryName: string | null) => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -26,6 +28,7 @@ export function CategoryPill({
   currentCategoryName,
   categories,
   disabled = false,
+  isTransfer = false,
   onCategoryChange,
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
@@ -79,9 +82,15 @@ export function CategoryPill({
         }
       >
         <Badge variant="outline" className="text-xs truncate">
-          {categoryName ?? (
-            <span className="italic text-muted-foreground">Uncategorized</span>
-          )}
+          {(() => {
+            const { text, variant } = categoryPillLabel(categoryName, isTransfer);
+            if (variant === "category") return text;
+            return (
+              <span className={cn("text-muted-foreground", variant === "uncategorized" && "italic")}>
+                {text}
+              </span>
+            );
+          })()}
         </Badge>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-[220px] p-0">

--- a/src/components/molecules/review-card.tsx
+++ b/src/components/molecules/review-card.tsx
@@ -73,6 +73,7 @@ export function ReviewCard({
           currentCategoryId={transaction.categoryId}
           currentCategoryName={transaction.categoryName}
           categories={categories}
+          isTransfer={transaction.isTransfer}
           onCategoryChange={onCategoryChange}
           open={categoryOpen}
           onOpenChange={onCategoryOpenChange}

--- a/src/components/molecules/transaction-row.tsx
+++ b/src/components/molecules/transaction-row.tsx
@@ -109,6 +109,7 @@ export const TransactionRow = memo(function TransactionRow({
           currentCategoryName={txn.categoryName}
           categories={categories}
           disabled={txn.hasSplits}
+          isTransfer={txn.isTransfer}
         />
       </div>
 

--- a/src/components/organisms/dashboard-grid.tsx
+++ b/src/components/organisms/dashboard-grid.tsx
@@ -29,6 +29,7 @@ export interface DashboardData {
   summary: DashboardSummary;
   netWorthHistory: NetWorthPoint[];
   monthlySpending: MonthlySpendingRow[];
+  spendingMonth: string;
   cashFlow: CashFlowRow[];
   recentTransactions: TransactionRow[];
   accounts: { id: string; name: string; type: AccountType; currentBalance: number | null; currency: string | null }[];
@@ -52,7 +53,7 @@ export function DashboardGrid({ layout, data }: DashboardGridProps) {
   const [nwRange, setNwRange] = useState("6M");
   const [nwData, setNwData] = useState(data.netWorthHistory);
   const [nwLoading, startNwTransition] = useTransition();
-  const [spendMonth, setSpendMonth] = useState(() => new Date().toISOString().slice(0, 7));
+  const [spendMonth, setSpendMonth] = useState(data.spendingMonth);
   const [spendData, setSpendData] = useState(data.monthlySpending);
   const [spendLoading, startSpendTransition] = useTransition();
 

--- a/src/components/organisms/transaction-detail-panel.tsx
+++ b/src/components/organisms/transaction-detail-panel.tsx
@@ -126,6 +126,7 @@ export function TransactionDetailPanel({
               currentCategoryId={txn.categoryId}
               currentCategoryName={txn.categoryName}
               categories={categories}
+              isTransfer={txn.isTransfer}
             />
           </div>
         )}

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -3,17 +3,17 @@ import * as React from "react"
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  // useSyncExternalStore subscribes to the media query without calling
+  // setState inside an effect (react-hooks/set-state-in-effect). The server
+  // snapshot defaults to false so SSR renders the desktop layout, then the
+  // client snapshot corrects it on hydration.
+  return React.useSyncExternalStore(
+    (onChange) => {
+      const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+      mql.addEventListener("change", onChange)
+      return () => mql.removeEventListener("change", onChange)
+    },
+    () => window.innerWidth < MOBILE_BREAKPOINT,
+    () => false,
+  )
 }

--- a/src/lib/account-utils.test.ts
+++ b/src/lib/account-utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "vitest";
+import { classifyAccountType, ASSET_TYPES, LIABILITY_TYPES } from "./account-utils";
+
+describe("classifyAccountType", () => {
+  test("liability types classify as liability", () => {
+    for (const type of LIABILITY_TYPES) {
+      expect(classifyAccountType(type)).toBe("liability");
+    }
+  });
+
+  test("asset types classify as asset", () => {
+    for (const type of ASSET_TYPES) {
+      expect(classifyAccountType(type)).toBe("asset");
+    }
+  });
+
+  test("unknown types default to asset", () => {
+    expect(classifyAccountType("mystery")).toBe("asset");
+    expect(classifyAccountType("")).toBe("asset");
+  });
+
+  test("asset and liability type sets are disjoint", () => {
+    for (const type of ASSET_TYPES) {
+      expect(LIABILITY_TYPES.has(type)).toBe(false);
+    }
+  });
+});

--- a/src/lib/import/clean-name.test.ts
+++ b/src/lib/import/clean-name.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { cleanTransactionName } from "./clean-name";
+
+describe("cleanTransactionName", () => {
+  it("strips ACH type prefix, date/time, and reference numbers", () => {
+    expect(
+      cleanTransactionName("ACH ELECTRONIC DEBIT May11 05:25a 0000 CHASE CREDIT CRD AUTOPAY"),
+    ).toBe("Chase Credit CRD Autopay");
+  });
+
+  it("preserves short acronyms while title-casing long ALL-CAPS words", () => {
+    expect(
+      cleanTransactionName("ACH Electronic Credit APPLE GS SAVINGS TRANSFER 910181695826"),
+    ).toBe("Apple GS Savings Transfer");
+  });
+
+  it("strips a trailing reference number and its lone check digit", () => {
+    expect(
+      cleanTransactionName("ACH Electronic Debit - CITI AUTOPAY PAYMENT 271941385710279 1"),
+    ).toBe("Citi Autopay Payment");
+  });
+
+  it("falls back to a friendly label when only boilerplate remains", () => {
+    expect(cleanTransactionName("ZELLE DEBIT May11 02:08p 9054")).toBe("Zelle");
+  });
+
+  it("extracts the payee from a Zelle NAME: field", () => {
+    expect(
+      cleanTransactionName("Zelle Credit PAY ID:BACAqiovd7b1 ORG ID:BAC NAME:BAHAR RABIEI"),
+    ).toBe("Bahar Rabiei");
+  });
+
+  it("strips a POS prefix and MM/DD date", () => {
+    expect(cleanTransactionName("POS DEBIT 04/12 STARBUCKS STORE 1234")).toBe("Starbucks Store");
+  });
+
+  it.each(["Amazon", "In-N-Out Burger", "Netflix", "CVS Pharmacy"])(
+    "leaves an already-clean name unchanged: %s",
+    (name) => {
+      expect(cleanTransactionName(name)).toBe(name);
+    },
+  );
+
+  it("never returns an empty string, even for pure boilerplate", () => {
+    expect(cleanTransactionName("")).toBe("");
+    expect(cleanTransactionName("   0000 1234   ").length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/import/clean-name.ts
+++ b/src/lib/import/clean-name.ts
@@ -1,0 +1,86 @@
+/**
+ * Turn a raw bank/CSV transaction description into a human-readable payee name.
+ *
+ * Bank feeds bury the merchant inside boilerplate: a transaction-type prefix
+ * ("ACH ELECTRONIC DEBIT"), embedded date/time stamps ("May11 05:25a"),
+ * card/check/reference numbers, and Zelle-style ID fields. This strips that
+ * noise and normalises casing, while never returning an empty string.
+ *
+ * The raw description is always preserved separately in `originalName`, so this
+ * is purely a display/search/rule-matching improvement — nothing is lost.
+ */
+
+// Leading transaction-type prefixes. `label` is a friendly fallback used when
+// nothing meaningful survives stripping (e.g. a bare "ZELLE DEBIT 9054").
+const TYPE_PREFIXES: { pattern: RegExp; label?: string }[] = [
+  { pattern: /^ACH\s+ELECTRONIC\s+(?:DEBIT|CREDIT)\s*-?\s*/i },
+  { pattern: /^ACH\s+(?:DEBIT|CREDIT)\s*-?\s*/i },
+  { pattern: /^ZELLE\s+(?:DEBIT|CREDIT)\s*-?\s*/i, label: "Zelle" },
+  { pattern: /^INSTANT\s+PAYMENT\s+(?:DEBIT|CREDIT)\s*-?\s*/i },
+  { pattern: /^POS\s+(?:DEBIT|PURCHASE)\s*-?\s*/i },
+  { pattern: /^DEBIT\s+CARD\s+PURCHASE\s*-?\s*/i },
+  { pattern: /^CHECKCARD\s+/i },
+  { pattern: /^RECURRING\s+PAYMENT\s*-?\s*/i },
+  { pattern: /^(?:EXTERNAL|PREAUTHORIZED)\s+(?:WITHDRAWAL|DEPOSIT|CREDIT|DEBIT)\s*-?\s*/i },
+  { pattern: /^BILL\s+PAY(?:MENT)?\s*-?\s*/i },
+];
+
+function stripNoise(s: string): string {
+  return s
+    .replace(/\S*:\S*/g, " ") // colon fields: HH:MMa times, ID:xxx, PAY ID:xxx
+    .replace(/\b(?:JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)\d{1,2}\b/gi, " ") // May11
+    .replace(/\b\d{1,2}\/\d{1,2}(?:\/\d{2,4})?\b/g, " ") // 04/12, 04/12/26
+    .replace(/\b\d{3,}[A-Za-z0-9]*\b/g, " ") // long reference / alphanumeric ref tokens
+    .replace(/\b\d+\b/g, " ") // any remaining standalone numeric token
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+function caseToken(token: string): string {
+  if (/[a-z]/.test(token)) return token; // already has lowercase — leave as authored
+  if (!/[A-Z]/.test(token)) return token; // no letters (numbers/symbols) — leave
+  // All-uppercase: keep short tokens as acronyms (GS, TY, IRS, CVS, CRD),
+  // title-case longer words (CHASE -> Chase, AUTOPAY -> Autopay).
+  const letters = token.replace(/[^A-Za-z]/g, "");
+  if (letters.length <= 3) return token;
+  return token.charAt(0).toUpperCase() + token.slice(1).toLowerCase();
+}
+
+function cleanTokens(s: string): string {
+  return s
+    .split(/\s+/)
+    .map((t) => t.replace(/^[-–—:.,]+|[-–—:.,]+$/g, "")) // strip edge punctuation
+    .filter(Boolean)
+    .map(caseToken)
+    .join(" ")
+    .trim();
+}
+
+export function cleanTransactionName(raw: string): string {
+  const original = raw.trim();
+  if (!original) return "";
+
+  // Zelle / person-to-person feeds put the real party in a NAME: field.
+  const nameField = original.match(/\bNAME:\s*([A-Za-z][A-Za-z .'-]*)/i);
+  if (nameField) {
+    const extracted = cleanTokens(nameField[1]);
+    if (extracted) return extracted;
+  }
+
+  let label: string | undefined;
+  let s = original;
+  for (const { pattern, label: l } of TYPE_PREFIXES) {
+    if (pattern.test(s)) {
+      s = s.replace(pattern, "");
+      label = l;
+      break;
+    }
+  }
+
+  const cleaned = cleanTokens(stripNoise(s));
+  if (cleaned) return cleaned;
+
+  // Nothing meaningful survived — prefer the prefix's friendly label, else the
+  // best-effort cleaned original, else the raw original (never empty).
+  return label ?? (cleanTokens(original) || original);
+}

--- a/src/lib/import/dedup.test.ts
+++ b/src/lib/import/dedup.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "vitest";
+import { generateDedupHash } from "./dedup";
+
+describe("generateDedupHash", () => {
+  test("is stable for identical input", () => {
+    const row = { date: "2026-07-07", amount: 1250, description: "Coffee" };
+    expect(generateDedupHash(row)).toBe(generateDedupHash(row));
+  });
+
+  test("returns a 16-char hex slice", () => {
+    const hash = generateDedupHash({ date: "2026-07-07", amount: 1250, description: "Coffee" });
+    expect(hash).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  test("is case-insensitive and whitespace-insensitive on description", () => {
+    const a = generateDedupHash({ date: "2026-07-07", amount: 1250, description: "  COFFEE  " });
+    const b = generateDedupHash({ date: "2026-07-07", amount: 1250, description: "coffee" });
+    expect(a).toBe(b);
+  });
+
+  test("differs when any of date, amount, or description changes", () => {
+    const base = generateDedupHash({ date: "2026-07-07", amount: 1250, description: "Coffee" });
+    expect(generateDedupHash({ date: "2026-07-08", amount: 1250, description: "Coffee" })).not.toBe(base);
+    expect(generateDedupHash({ date: "2026-07-07", amount: 1251, description: "Coffee" })).not.toBe(base);
+    expect(generateDedupHash({ date: "2026-07-07", amount: 1250, description: "Tea" })).not.toBe(base);
+  });
+});

--- a/src/lib/import/normalize.test.ts
+++ b/src/lib/import/normalize.test.ts
@@ -47,4 +47,22 @@ describe("normalizeImportedRows", () => {
     expect(result[0].householdId).toBe(householdId);
     expect(result[0].accountId).toBe(accountId);
   });
+
+  test("skips rows missing a date or description", () => {
+    const rows = [
+      { Date: "", Amount: "1.00", Description: "No date" },
+      { Date: "2024-01-15", Amount: "1.00", Description: "" },
+      { Date: "2024-01-15", Amount: "1.00", Description: "Kept" },
+    ];
+    const result = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Kept");
+  });
+
+  test("trims surrounding whitespace from the description", () => {
+    const rows = [{ Date: "2024-01-15", Amount: "1.00", Description: "  Coffee  " }];
+    const result = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
+    expect(result[0].name).toBe("Coffee");
+    expect(result[0].originalName).toBe("Coffee");
+  });
 });

--- a/src/lib/import/normalize.ts
+++ b/src/lib/import/normalize.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from "uuid";
 import type { ValidatedMapping } from "./mapper";
 import { parseToCents } from "@/lib/money";
+import { cleanTransactionName } from "./clean-name";
 
 export type AmountConvention = "positive_is_expense" | "positive_is_income";
 
@@ -68,7 +69,7 @@ export function normalizeImportedRows(
       householdId,
       date: parseDateToISO(dateStr),
       originalName: description.trim(),
-      name: description.trim(),
+      name: cleanTransactionName(description),
       amount: amountCents,
       externalId: null,
     });

--- a/src/lib/jobs/backfill-clean-names.ts
+++ b/src/lib/jobs/backfill-clean-names.ts
@@ -1,0 +1,34 @@
+import { eq } from "drizzle-orm";
+import { db as defaultDb, type LedgrDb } from "@/db";
+import { transactions } from "@/db/schema";
+import { cleanTransactionName } from "@/lib/import/clean-name";
+
+/**
+ * Re-derives the display `name` from `originalName` for transactions that still
+ * carry the raw bank description (i.e. `name === originalName`), applying the
+ * same cleanup new imports get.
+ *
+ * Only rows whose name still equals their original are touched, so any name a
+ * user edited (or that a merchant match already cleaned) is left untouched.
+ * `originalName` is never modified.
+ */
+export async function backfillCleanTransactionNames(
+  db: LedgrDb = defaultDb,
+): Promise<{ scanned: number; updated: number }> {
+  const rows = await db
+    .select({ id: transactions.id, name: transactions.name, originalName: transactions.originalName })
+    .from(transactions)
+    .where(eq(transactions.name, transactions.originalName));
+
+  let updated = 0;
+  for (const row of rows) {
+    if (!row.originalName) continue;
+    const cleaned = cleanTransactionName(row.originalName);
+    if (cleaned && cleaned !== row.name) {
+      await db.update(transactions).set({ name: cleaned }).where(eq(transactions.id, row.id));
+      updated += 1;
+    }
+  }
+
+  return { scanned: rows.length, updated };
+}

--- a/src/lib/mcp/tool-result.test.ts
+++ b/src/lib/mcp/tool-result.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "vitest";
+import { jsonResult, errorResult } from "./tool-result";
+
+describe("jsonResult", () => {
+  test("wraps data as pretty-printed JSON text content", () => {
+    const result = jsonResult({ total: 42, items: ["a"] });
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+    expect(JSON.parse(result.content[0].text)).toEqual({ total: 42, items: ["a"] });
+    // pretty-printed → contains newlines/indentation
+    expect(result.content[0].text).toContain("\n");
+    expect(result).not.toHaveProperty("isError");
+  });
+});
+
+describe("errorResult", () => {
+  test("wraps the message in an error envelope flagged isError", () => {
+    const result = errorResult("household not found");
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text)).toEqual({ error: "household not found" });
+  });
+});

--- a/src/lib/plaid/schemas.test.ts
+++ b/src/lib/plaid/schemas.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "vitest";
+import {
+  mapSecurityType,
+  SECURITY_TYPE_MAP,
+  PlaidTransactionSchema,
+  PlaidSyncResponseSchema,
+} from "./schemas";
+
+describe("mapSecurityType", () => {
+  test("maps every known Plaid security type", () => {
+    for (const [plaidType, expected] of Object.entries(SECURITY_TYPE_MAP)) {
+      expect(mapSecurityType(plaidType)).toBe(expected);
+    }
+  });
+
+  test("is case-insensitive", () => {
+    expect(mapSecurityType("EQUITY")).toBe("stock");
+    expect(mapSecurityType("Mutual Fund")).toBe("mutual_fund");
+  });
+
+  test("null or unknown types fall back to other", () => {
+    expect(mapSecurityType(null)).toBe("other");
+    expect(mapSecurityType("derivative")).toBe("other");
+  });
+});
+
+describe("PlaidTransactionSchema", () => {
+  test("accepts a minimal valid transaction (optional fields omitted)", () => {
+    const parsed = PlaidTransactionSchema.parse({
+      transaction_id: "t1",
+      account_id: "a1",
+      amount: 12.5,
+      iso_currency_code: "USD",
+      date: "2026-07-07",
+      name: "Coffee",
+      pending: false,
+    });
+    expect(parsed.transaction_id).toBe("t1");
+    expect(parsed.merchant_name).toBeUndefined();
+  });
+
+  test("rejects when a required field is missing or mistyped", () => {
+    expect(() =>
+      PlaidTransactionSchema.parse({
+        transaction_id: "t1",
+        account_id: "a1",
+        amount: "not-a-number",
+        iso_currency_code: null,
+        date: "2026-07-07",
+        name: "Coffee",
+        pending: false,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("PlaidSyncResponseSchema", () => {
+  test("parses a sync response with empty change sets", () => {
+    const parsed = PlaidSyncResponseSchema.parse({
+      added: [],
+      modified: [],
+      removed: [],
+      has_more: false,
+      next_cursor: "cursor_abc",
+    });
+    expect(parsed.has_more).toBe(false);
+    expect(parsed.next_cursor).toBe("cursor_abc");
+  });
+});

--- a/src/lib/plaid/sync.ts
+++ b/src/lib/plaid/sync.ts
@@ -17,6 +17,7 @@ import {
   TRANSIENT_ERROR_CODES,
   retryWithBackoff,
 } from "./utils";
+import { cleanTransactionName } from "@/lib/import/clean-name";
 import type { LedgrDb } from "@/db";
 import {
   plaidItems,
@@ -180,7 +181,7 @@ export function processBatch(
       plaidAccountId: txn.account_id,
       date: txn.date,
       originalName: txn.name,
-      name: txn.merchant_name ? titleCase(txn.merchant_name) : txn.name,
+      name: txn.merchant_name ? titleCase(txn.merchant_name) : cleanTransactionName(txn.name),
       amount: amountCents,
       normalizedAmount: normalizedAmt,
       currency: txn.iso_currency_code ?? "USD",

--- a/src/lib/plaid/utils.test.ts
+++ b/src/lib/plaid/utils.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import {
+  mapPlaidAccountType,
+  extractPlaidErrorCode,
+  extractPlaidErrorMessage,
+  titleCase,
+  retryWithBackoff,
+  REAUTH_ERROR_CODES,
+  TRANSIENT_ERROR_CODES,
+  SKIP_ERROR_CODES,
+} from "./utils";
+
+describe("mapPlaidAccountType", () => {
+  test("depository maps to savings only when subtype is savings", () => {
+    expect(mapPlaidAccountType("depository", "savings")).toBe("savings");
+    expect(mapPlaidAccountType("depository", "checking")).toBe("checking");
+    expect(mapPlaidAccountType("depository", null)).toBe("checking");
+  });
+
+  test("maps the remaining known types", () => {
+    expect(mapPlaidAccountType("credit", null)).toBe("credit");
+    expect(mapPlaidAccountType("loan", null)).toBe("loan");
+    expect(mapPlaidAccountType("investment", null)).toBe("investment");
+  });
+
+  test("unknown type falls back to other", () => {
+    expect(mapPlaidAccountType("brokerage", null)).toBe("other");
+    expect(mapPlaidAccountType("", null)).toBe("other");
+  });
+});
+
+describe("extractPlaidErrorCode", () => {
+  test("returns the code from a well-formed Plaid error", () => {
+    const err = { response: { data: { error_code: "ITEM_LOGIN_REQUIRED" } } };
+    expect(extractPlaidErrorCode(err)).toBe("ITEM_LOGIN_REQUIRED");
+  });
+
+  test("returns null for non-Plaid or malformed shapes", () => {
+    expect(extractPlaidErrorCode(null)).toBeNull();
+    expect(extractPlaidErrorCode(undefined)).toBeNull();
+    expect(extractPlaidErrorCode("boom")).toBeNull();
+    expect(extractPlaidErrorCode(new Error("boom"))).toBeNull();
+    expect(extractPlaidErrorCode({ response: {} })).toBeNull();
+    expect(extractPlaidErrorCode({ response: { data: {} } })).toBeNull();
+  });
+
+  test("treats an empty error_code as absent", () => {
+    expect(extractPlaidErrorCode({ response: { data: { error_code: "" } } })).toBeNull();
+  });
+});
+
+describe("extractPlaidErrorMessage", () => {
+  test("returns the message when present", () => {
+    const err = { response: { data: { error_message: "the item is locked" } } };
+    expect(extractPlaidErrorMessage(err)).toBe("the item is locked");
+  });
+
+  test("returns undefined for non-Plaid or missing message", () => {
+    expect(extractPlaidErrorMessage(null)).toBeUndefined();
+    expect(extractPlaidErrorMessage("boom")).toBeUndefined();
+    expect(extractPlaidErrorMessage({ response: { data: {} } })).toBeUndefined();
+  });
+});
+
+describe("titleCase", () => {
+  test("trims, lowercases, and capitalizes each word", () => {
+    expect(titleCase("  WHOLE FOODS market  ")).toBe("Whole Foods Market");
+    expect(titleCase("acme")).toBe("Acme");
+  });
+
+  test("capitalizes the first letter following non-word boundaries", () => {
+    expect(titleCase("mcdonald's")).toBe("Mcdonald'S");
+    expect(titleCase("at&t store")).toBe("At&T Store");
+  });
+
+  test("empty string stays empty", () => {
+    expect(titleCase("")).toBe("");
+  });
+});
+
+describe("error-code sets", () => {
+  test("classification buckets are disjoint", () => {
+    for (const code of REAUTH_ERROR_CODES) {
+      expect(TRANSIENT_ERROR_CODES.has(code)).toBe(false);
+      expect(SKIP_ERROR_CODES.has(code)).toBe(false);
+    }
+    for (const code of TRANSIENT_ERROR_CODES) {
+      expect(SKIP_ERROR_CODES.has(code)).toBe(false);
+    }
+  });
+
+  test("known codes land in the expected bucket", () => {
+    expect(REAUTH_ERROR_CODES.has("ITEM_LOGIN_REQUIRED")).toBe(true);
+    expect(TRANSIENT_ERROR_CODES.has("RATE_LIMIT_EXCEEDED")).toBe(true);
+    expect(SKIP_ERROR_CODES.has("PRODUCT_NOT_READY")).toBe(true);
+  });
+});
+
+describe("retryWithBackoff", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("returns the value without retrying on success", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    await expect(retryWithBackoff(fn)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("rethrows non-rate-limit errors immediately", async () => {
+    const err = { response: { data: { error_code: "ITEM_LOGIN_REQUIRED" } } };
+    const fn = vi.fn().mockRejectedValue(err);
+    await expect(retryWithBackoff(fn)).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries rate-limit errors then succeeds", async () => {
+    vi.useFakeTimers();
+    const rateLimit = { response: { data: { error_code: "RATE_LIMIT_EXCEEDED" } } };
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(rateLimit)
+      .mockResolvedValueOnce("recovered");
+
+    const promise = retryWithBackoff(fn);
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test("gives up after maxAttempts and rethrows", async () => {
+    vi.useFakeTimers();
+    const rateLimit = { response: { data: { error_code: "RATE_LIMIT_EXCEEDED" } } };
+    const fn = vi.fn().mockRejectedValue(rateLimit);
+
+    const promise = retryWithBackoff(fn, 3);
+    const assertion = expect(promise).rejects.toBe(rateLimit);
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/lib/query-helpers.test.ts
+++ b/src/lib/query-helpers.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect } from "vitest";
+import { encodeCursor, decodeCursor } from "./query-helpers";
+
+describe("cursor encode/decode", () => {
+  test("round-trips a date + id", () => {
+    const cursor = encodeCursor("2026-07-07", "txn_123");
+    expect(decodeCursor(cursor)).toEqual({ date: "2026-07-07", id: "txn_123" });
+  });
+
+  test("encoded cursor is opaque base64 (no raw delimiters)", () => {
+    const cursor = encodeCursor("2026-07-07", "txn_123");
+    expect(cursor).not.toContain("2026-07-07");
+    expect(() => Buffer.from(cursor, "base64")).not.toThrow();
+  });
+
+  test("returns null for non-base64 / non-JSON garbage", () => {
+    expect(decodeCursor("!!!not base64!!!")).toBeNull();
+    expect(decodeCursor("")).toBeNull();
+  });
+
+  test("returns null when decoded JSON is missing required fields", () => {
+    const missingId = Buffer.from(JSON.stringify({ date: "2026-07-07" })).toString("base64");
+    const wrongType = Buffer.from(JSON.stringify({ date: 1, id: "x" })).toString("base64");
+    expect(decodeCursor(missingId)).toBeNull();
+    expect(decodeCursor(wrongType)).toBeNull();
+  });
+});

--- a/src/queries/dashboard.ts
+++ b/src/queries/dashboard.ts
@@ -24,6 +24,34 @@ export interface DashboardSummary {
   monthlyNet: number;
 }
 
+/**
+ * YYYY-MM of the household's most recent non-pending transaction, or null when
+ * there is no activity. Used to resolve the "effective" dashboard month so a
+ * returning user whose latest data is from an earlier month doesn't land on an
+ * all-zero current month.
+ */
+export async function getLatestActivityMonth(
+  householdId: string,
+  db: LedgrDb = defaultDb
+): Promise<string | null> {
+  const scoped = scopedQuery(householdId, db);
+
+  const rows = await db
+    .select({ date: transactions.date })
+    .from(transactions)
+    .where(
+      scoped.where(
+        transactions,
+        notDeleted(transactions),
+        eq(transactions.pending, false)
+      )
+    )
+    .orderBy(desc(transactions.date))
+    .limit(1);
+
+  return rows.length > 0 ? rows[0].date.slice(0, 7) : null;
+}
+
 export async function getDashboardSummary(
   householdId: string,
   db: LedgrDb = defaultDb
@@ -47,7 +75,8 @@ export async function getDashboardSummary(
     }
   }
 
-  const { from: dateFrom, to: dateTo } = monthBounds(getCurrentMonth());
+  const effectiveMonth = (await getLatestActivityMonth(householdId, db)) ?? getCurrentMonth();
+  const { from: dateFrom, to: dateTo } = monthBounds(effectiveMonth);
 
   // Monthly transactions (non-pending, non-deleted)
   const monthlyTxns = await db
@@ -152,19 +181,25 @@ export async function getNetWorthHistory(
       netWorth: assets - liabilities,
     }));
 
-  // Synthetic today point from live currentBalance
+  // Synthetic today point from live currentBalance. Only emit it when at least
+  // one account carries a balance — otherwise there is no net worth to plot and
+  // a zero point would render as a degenerate chart instead of an empty state.
   const today = todayDateString();
   // Remove any existing today entry from history (will be replaced by live)
   const withoutToday = result.filter((p) => p.date !== today);
 
+  const accountsWithBalance = allAccounts.filter((a) => a.currentBalance !== null);
+  if (accountsWithBalance.length === 0) {
+    return withoutToday;
+  }
+
   let todayAssets = 0;
   let todayLiabilities = 0;
-  for (const account of allAccounts) {
-    if (account.currentBalance === null) continue;
+  for (const account of accountsWithBalance) {
     if (classifyAccountType(account.type) === "asset") {
-      todayAssets += account.currentBalance;
+      todayAssets += account.currentBalance!;
     } else {
-      todayLiabilities += account.currentBalance;
+      todayLiabilities += account.currentBalance!;
     }
   }
 
@@ -193,7 +228,7 @@ export async function getMonthlySpending(
   month?: string,
   db: LedgrDb = defaultDb
 ): Promise<MonthlySpendingRow[]> {
-  const targetMonth = month ?? getCurrentMonth();
+  const targetMonth = month ?? (await getLatestActivityMonth(householdId, db)) ?? getCurrentMonth();
   const { from: dateFrom, to: dateTo } = monthBounds(targetMonth);
 
   const filters: ReportFilters = { dateFrom, dateTo };

--- a/src/queries/recurring.ts
+++ b/src/queries/recurring.ts
@@ -1,4 +1,4 @@
-import { eq, asc, like } from "drizzle-orm";
+import { eq, asc, ilike } from "drizzle-orm";
 import { db as defaultDb, type LedgrDb } from "@/db";
 import { recurringTransactions, merchants, categories } from "@/db/schema";
 import { scopedQuery } from "@/lib/scoped-query";
@@ -33,7 +33,7 @@ export async function getUpcomingBills(
   ];
 
   if (opts.search) {
-    conditions.push(like(recurringTransactions.name, `%${opts.search}%`));
+    conditions.push(ilike(recurringTransactions.name, `%${opts.search}%`));
   }
 
   let builder = db

--- a/src/queries/reports.ts
+++ b/src/queries/reports.ts
@@ -179,7 +179,7 @@ export async function getCategoryTrends(
     .from(transactions)
     .leftJoin(categories, eq(transactions.categoryId, categories.id))
     .where(scoped.where(transactions, ...nonSplitConditions))
-    .groupBy(sql`substring(${transactions.date} from 1 for 7)`, transactions.categoryId);
+    .groupBy(sql`substring(${transactions.date} from 1 for 7)`, transactions.categoryId, categories.name);
 
   const trendMap = new Map<string, number>(); // "YYYY-MM|catId" -> total
 

--- a/src/queries/reports.ts
+++ b/src/queries/reports.ts
@@ -173,13 +173,11 @@ export async function getCategoryTrends(
     .select({
       month: sql<string>`substring(${transactions.date} from 1 for 7)`,
       categoryId: transactions.categoryId,
-      categoryName: categories.name,
       total: sumAbs(transactions.normalizedAmount),
     })
     .from(transactions)
-    .leftJoin(categories, eq(transactions.categoryId, categories.id))
     .where(scoped.where(transactions, ...nonSplitConditions))
-    .groupBy(sql`substring(${transactions.date} from 1 for 7)`, transactions.categoryId, categories.name);
+    .groupBy(sql`substring(${transactions.date} from 1 for 7)`, transactions.categoryId);
 
   const trendMap = new Map<string, number>(); // "YYYY-MM|catId" -> total
 

--- a/src/queries/transactions.ts
+++ b/src/queries/transactions.ts
@@ -1,4 +1,4 @@
-import { eq, like, gte, lte, lt, gt, isNull, desc, sql, inArray, type SQL } from "drizzle-orm";
+import { eq, ilike, gte, lte, lt, gt, isNull, desc, sql, inArray, type SQL } from "drizzle-orm";
 import { db as defaultDb, type LedgrDb } from "@/db";
 import { transactions, categories, categoryGroups, merchants, accounts, transactionSplits, type CategorySource } from "@/db/schema";
 import { scopedQuery } from "@/lib/scoped-query";
@@ -112,7 +112,7 @@ function buildTransactionConditions(filters: TransactionFilters): (SQL | undefin
     conditions.push(eq(transactions.reviewed, filters.reviewed));
   }
   if (filters.search) {
-    conditions.push(like(transactions.name, `%${filters.search}%`));
+    conditions.push(ilike(transactions.name, `%${filters.search}%`));
   }
   if (filters.amountMin !== undefined) {
     conditions.push(sql`abs(${transactions.normalizedAmount}) >= ${filters.amountMin}`);

--- a/tests/integration/backfill-clean-names.test.ts
+++ b/tests/integration/backfill-clean-names.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./setup";
+import { insertHousehold, insertAccount, insertTransaction } from "./helpers";
+import { transactions } from "../../src/db/schema";
+import { backfillCleanTransactionNames } from "../../src/lib/jobs/backfill-clean-names";
+import type { LedgrDb } from "../../src/db";
+
+let db: LedgrDb;
+let close: () => Promise<void>;
+
+beforeEach(async () => {
+  ({ db, close } = await createTestDb());
+});
+
+afterEach(async () => {
+  await close();
+});
+
+const RAW = "ACH ELECTRONIC DEBIT May11 05:25a 0000 CHASE CREDIT CRD AUTOPAY";
+
+describe("backfillCleanTransactionNames", () => {
+  it("re-derives name from originalName for untouched raw rows", async () => {
+    const { householdId } = await insertHousehold(db);
+    const { accountId } = await insertAccount(db, householdId);
+    const { transactionId } = await insertTransaction(db, householdId, accountId, {
+      name: RAW,
+      originalName: RAW,
+    });
+
+    const result = await backfillCleanTransactionNames(db);
+
+    const [row] = await db.select().from(transactions).where(eq(transactions.id, transactionId));
+    expect(row.name).toBe("Chase Credit CRD Autopay");
+    expect(row.originalName).toBe(RAW); // raw is always preserved
+    expect(result.updated).toBe(1);
+  });
+
+  it("never overwrites a name that was edited away from originalName", async () => {
+    const { householdId } = await insertHousehold(db);
+    const { accountId } = await insertAccount(db, householdId);
+    const { transactionId } = await insertTransaction(db, householdId, accountId, {
+      name: "Rent — Landlord",
+      originalName: RAW,
+    });
+
+    const result = await backfillCleanTransactionNames(db);
+
+    const [row] = await db.select().from(transactions).where(eq(transactions.id, transactionId));
+    expect(row.name).toBe("Rent — Landlord");
+    expect(result.updated).toBe(0);
+  });
+
+  it("leaves already-clean names unchanged and does not count them", async () => {
+    const { householdId } = await insertHousehold(db);
+    const { accountId } = await insertAccount(db, householdId);
+    await insertTransaction(db, householdId, accountId, { name: "Amazon", originalName: "Amazon" });
+
+    const result = await backfillCleanTransactionNames(db);
+
+    expect(result.updated).toBe(0);
+  });
+});

--- a/tests/integration/dashboard-queries.test.ts
+++ b/tests/integration/dashboard-queries.test.ts
@@ -79,14 +79,23 @@ describe("getNetWorthHistory", () => {
       currentBalance: 20000,
     });
 
-    await db.insert(balanceHistory).values({ id: uuid(), accountId: checkingId, date: "2026-04-01", balance: 70000 });
-    await db.insert(balanceHistory).values({ id: uuid(), accountId: creditId, date: "2026-04-01", balance: 15000 });
+    // A historical date inside the 3M window but not today: first of last month.
+    // Relative to "now" so the test is deterministic whenever the suite runs.
+    const histDate = (() => {
+      const d = new Date();
+      d.setUTCDate(1);
+      d.setUTCMonth(d.getUTCMonth() - 1);
+      return d.toISOString().slice(0, 10);
+    })();
+
+    await db.insert(balanceHistory).values({ id: uuid(), accountId: checkingId, date: histDate, balance: 70000 });
+    await db.insert(balanceHistory).values({ id: uuid(), accountId: creditId, date: histDate, balance: 15000 });
 
     const result = await getNetWorthHistory(householdId, "3M", db);
 
     expect(result.length).toBeGreaterThanOrEqual(2);
 
-    const historicalPoint = result.find((r) => r.date === "2026-04-01");
+    const historicalPoint = result.find((r) => r.date === histDate);
     expect(historicalPoint).toBeDefined();
     expect(historicalPoint!.assets).toBe(70000);
     expect(historicalPoint!.liabilities).toBe(15000);
@@ -161,20 +170,30 @@ describe("getCashFlow", () => {
       isIncome: true,
     });
 
+    // Current month and previous month both fall inside the getCashFlow(3)
+    // window no matter when the suite runs.
+    const thisMonth = new Date().toISOString().slice(0, 7);
+    const lastMonth = (() => {
+      const d = new Date();
+      d.setUTCDate(1);
+      d.setUTCMonth(d.getUTCMonth() - 1);
+      return d.toISOString().slice(0, 7);
+    })();
+
     await insertTransaction(db, householdId, accountId, {
-      date: "2026-05-05",
+      date: `${thisMonth}-05`,
       normalizedAmount: -4000,
       amount: 4000,
     });
     await insertTransaction(db, householdId, accountId, {
-      date: "2026-05-15",
+      date: `${thisMonth}-15`,
       normalizedAmount: 150000,
       amount: -150000,
       categoryId: incomeCatId,
     });
 
     await insertTransaction(db, householdId, accountId, {
-      date: "2026-04-10",
+      date: `${lastMonth}-10`,
       normalizedAmount: -2500,
       amount: 2500,
     });
@@ -183,30 +202,32 @@ describe("getCashFlow", () => {
 
     expect(result.length).toBeGreaterThanOrEqual(2);
 
-    const aprilData = result.find((r) => r.month === "2026-04");
-    expect(aprilData).toBeDefined();
-    expect(aprilData!.expenses).toBe(2500);
-    expect(aprilData!.income).toBe(0);
-    expect(aprilData!.net).toBe(-2500);
+    const lastMonthData = result.find((r) => r.month === lastMonth);
+    expect(lastMonthData).toBeDefined();
+    expect(lastMonthData!.expenses).toBe(2500);
+    expect(lastMonthData!.income).toBe(0);
+    expect(lastMonthData!.net).toBe(-2500);
 
-    const mayData = result.find((r) => r.month === "2026-05");
-    expect(mayData).toBeDefined();
-    expect(mayData!.expenses).toBe(4000);
-    expect(mayData!.income).toBe(150000);
-    expect(mayData!.net).toBe(150000 - 4000);
+    const thisMonthData = result.find((r) => r.month === thisMonth);
+    expect(thisMonthData).toBeDefined();
+    expect(thisMonthData!.expenses).toBe(4000);
+    expect(thisMonthData!.income).toBe(150000);
+    expect(thisMonthData!.net).toBe(150000 - 4000);
   });
 
   it("excludes transfer transactions", async () => {
     const { householdId } = await insertHousehold(db);
     const { accountId } = await insertAccount(db, householdId);
 
+    const thisMonth = new Date().toISOString().slice(0, 7);
+
     await insertTransaction(db, householdId, accountId, {
-      date: "2026-05-05",
+      date: `${thisMonth}-05`,
       normalizedAmount: -3000,
       amount: 3000,
     });
     await insertTransaction(db, householdId, accountId, {
-      date: "2026-05-10",
+      date: `${thisMonth}-10`,
       normalizedAmount: -50000,
       amount: 50000,
       isTransfer: true,
@@ -214,9 +235,9 @@ describe("getCashFlow", () => {
 
     const result = await getCashFlow(householdId, 3, db);
 
-    const mayData = result.find((r) => r.month === "2026-05");
-    expect(mayData).toBeDefined();
-    expect(mayData!.expenses).toBe(3000);
+    const thisMonthData = result.find((r) => r.month === thisMonth);
+    expect(thisMonthData).toBeDefined();
+    expect(thisMonthData!.expenses).toBe(3000);
   });
 });
 

--- a/tests/integration/dashboard-queries.test.ts
+++ b/tests/integration/dashboard-queries.test.ts
@@ -15,7 +15,17 @@ import {
   getMonthlySpending,
   getCashFlow,
   getRecentTransactions,
+  getLatestActivityMonth,
 } from "../../src/queries/dashboard";
+
+// Month strings derived relative to "now" so tests stay deterministic as the
+// calendar moves (see repo convention: never hardcode "recent" dates).
+function monthsAgo(n: number): string {
+  const d = new Date();
+  d.setUTCDate(1);
+  d.setUTCMonth(d.getUTCMonth() - n);
+  return d.toISOString().slice(0, 7);
+}
 import type { LedgrDb } from "../../src/db";
 
 let db: LedgrDb;
@@ -108,9 +118,90 @@ describe("getNetWorthHistory", () => {
     expect(todayPoint!.liabilities).toBe(20000);
     expect(todayPoint!.netWorth).toBe(60000);
   });
+
+  it("returns empty array when no account has a balance", async () => {
+    // The CSV-import scenario: accounts exist but carry no balance, so there is
+    // no net worth to plot. The chart must see an empty series to render its
+    // empty state instead of a degenerate zero-axis.
+    const { householdId } = await insertHousehold(db);
+    await insertAccount(db, householdId, { type: "checking", currentBalance: null });
+
+    const result = await getNetWorthHistory(householdId, "6M", db);
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("getLatestActivityMonth", () => {
+  it("returns the YYYY-MM of the most recent non-pending transaction", async () => {
+    const { householdId } = await insertHousehold(db);
+    const { accountId } = await insertAccount(db, householdId);
+
+    await insertTransaction(db, householdId, accountId, { date: "2026-03-15" });
+    await insertTransaction(db, householdId, accountId, { date: "2026-05-20" });
+    // A later, still-pending transaction must not count as activity.
+    await insertTransaction(db, householdId, accountId, { date: "2026-06-01", pending: true });
+
+    const result = await getLatestActivityMonth(householdId, db);
+
+    expect(result).toBe("2026-05");
+  });
+
+  it("returns null when the household has no transactions", async () => {
+    const { householdId } = await insertHousehold(db);
+    expect(await getLatestActivityMonth(householdId, db)).toBeNull();
+  });
+});
+
+describe("getDashboardSummary latest-activity fallback", () => {
+  it("uses the latest month with activity when the current month is empty", async () => {
+    const { householdId } = await insertHousehold(db);
+    const { accountId } = await insertAccount(db, householdId, {
+      type: "checking",
+      currentBalance: 100000,
+    });
+
+    const activityMonth = monthsAgo(2);
+    await insertTransaction(db, householdId, accountId, {
+      date: `${activityMonth}-05`,
+      normalizedAmount: -4000,
+      amount: 4000,
+    });
+    await insertTransaction(db, householdId, accountId, {
+      date: `${activityMonth}-10`,
+      normalizedAmount: 250000,
+      amount: -250000,
+    });
+
+    const result = await getDashboardSummary(householdId, db);
+
+    expect(result.monthlyExpenses).toBe(4000);
+    expect(result.monthlyIncome).toBe(250000);
+    expect(result.monthlyNet).toBe(250000 - 4000);
+  });
 });
 
 describe("getMonthlySpending", () => {
+  it("falls back to the latest month with activity when no month is given", async () => {
+    const { householdId } = await insertHousehold(db);
+    const { accountId } = await insertAccount(db, householdId);
+    const { groupId } = await insertCategoryGroup(db, householdId, { name: "Food" });
+    const { categoryId } = await insertCategory(db, householdId, groupId, { name: "Groceries" });
+
+    const activityMonth = monthsAgo(1);
+    await insertTransaction(db, householdId, accountId, {
+      date: `${activityMonth}-05`,
+      normalizedAmount: -6000,
+      amount: 6000,
+      categoryId,
+    });
+
+    const result = await getMonthlySpending(householdId, undefined, db);
+
+    expect(result.length).toBe(1);
+    expect(result[0].total).toBe(6000);
+  });
+
   it("groups expense transactions by category", async () => {
     const { householdId } = await insertHousehold(db);
     const { accountId } = await insertAccount(db, householdId);

--- a/tests/integration/db-factory.test.ts
+++ b/tests/integration/db-factory.test.ts
@@ -3,10 +3,14 @@ import { createTestDb } from "./setup";
 import { households } from "../../src/db/schema";
 
 describe("createTestDb", () => {
-  let close: () => Promise<void>;
+  let close: (() => Promise<void>) | undefined;
 
   afterEach(async () => {
+    // Null out after closing: the "isolated instances" test manages its own
+    // cleanup and never reassigns `close`, so without this the stale (already
+    // ended) pool from the previous test would be closed a second time.
     await close?.();
+    close = undefined;
   });
 
   it("creates a working database with schema", async () => {

--- a/tests/integration/plaid-exchange.test.ts
+++ b/tests/integration/plaid-exchange.test.ts
@@ -32,7 +32,7 @@ afterAll(() => {
 
 describe("plaid exchange flow", () => {
   let db: LedgrDb;
-  let close: () => Promise<void>;
+  let close: (() => Promise<void>) | undefined;
 
   beforeEach(() => {
     resetPlaidClient();
@@ -40,7 +40,11 @@ describe("plaid exchange flow", () => {
 
   afterEach(async () => {
     server.resetHandlers();
+    // Null out after closing: the pure-unit "maps account types" test never
+    // calls setup(), so without this the stale (already ended) pool from the
+    // previous test would be closed a second time and throw.
     await close?.();
+    close = undefined;
   });
 
   async function setup() {

--- a/tests/integration/recurring-sync.test.ts
+++ b/tests/integration/recurring-sync.test.ts
@@ -14,7 +14,7 @@ import {
   insertAccount,
   insertTransaction,
 } from "./helpers";
-import { recurringTransactions, transactions } from "../../src/db/schema";
+import { recurringTransactions, transactions, merchants } from "../../src/db/schema";
 import { eq } from "drizzle-orm";
 import { resetPlaidClient } from "../../src/lib/plaid/client";
 import type { LedgrDb } from "../../src/db";
@@ -91,6 +91,43 @@ describe("syncRecurringTransactions", () => {
     expect(salary).toBeDefined();
     expect(salary!.isIncome).toBe(true);
     expect(salary!.averageAmount).toBe(-300000);
+  });
+
+  it("creates and links a merchant for named streams; falls back to the description otherwise", async () => {
+    server.use(recurringGetHandler);
+    const { householdId, plaidItemId } = await seedForSync(db);
+
+    const { syncRecurringTransactions } = await import(
+      "../../src/lib/plaid/recurring"
+    );
+    await syncRecurringTransactions(plaidItemId, householdId, "access-sandbox-test-token", db);
+
+    const [merchant] = await db
+      .select()
+      .from(merchants)
+      .where(eq(merchants.householdId, householdId));
+    const netflixMerchant = await db
+      .select()
+      .from(merchants)
+      .where(eq(merchants.name, "Netflix"));
+    expect(netflixMerchant).toHaveLength(1);
+
+    const rows = await db
+      .select()
+      .from(recurringTransactions)
+      .where(eq(recurringTransactions.householdId, householdId));
+
+    // Named stream → merchant row created and linked by id.
+    const netflix = rows.find((r) => r.plaidStreamId === TEST_STREAM_IDS.netflix)!;
+    expect(netflix.merchantId).toBe(netflixMerchant[0].id);
+
+    // Null merchant_name → no merchant link, name derived from titleCase(description).
+    const salary = rows.find((r) => r.plaidStreamId === TEST_STREAM_IDS.salary)!;
+    expect(salary.merchantId).toBeNull();
+    expect(salary.name).toBe("Direct Deposit Employer");
+
+    // Sanity: at least one merchant was persisted.
+    expect(merchant).toBeDefined();
   });
 
   it("updates existing stream when amounts/dates change", async () => {

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -10,14 +10,31 @@ export async function createTestDb() {
     process.env.DATABASE_URL || "postgresql://ledgr:ledgr@localhost:5432/ledgr_test";
 
   const schemaName = `test_${randomUUID().replace(/-/g, "")}`;
-  const pool = new Pool({ connectionString });
 
-  await pool.query(`CREATE SCHEMA "${schemaName}"`);
-  await pool.query(`SET search_path TO "${schemaName}"`);
+  // Create the schema with a throwaway connection first, then open the real
+  // pool with search_path pinned at *connection* time. `SET search_path` only
+  // affects a single connection, but a Pool hands out many connections — so
+  // setting it via a query left migrate/queries resolving to `public` on any
+  // fresh connection, which broke the full concurrent suite (relation-not-found).
+  // The `options` startup param applies to every connection the pool opens.
+  const admin = new Pool({ connectionString });
+  await admin.query(`CREATE SCHEMA "${schemaName}"`);
+  await admin.end();
+
+  const pool = new Pool({
+    connectionString,
+    options: `-c search_path=${schemaName}`,
+  });
 
   const db = drizzle({ client: pool, schema });
+  // Track applied migrations *inside this test schema*, not the shared default
+  // `drizzle` schema. Otherwise the first test file to migrate records the
+  // migrations globally and every later createTestDb() sees them as "already
+  // applied" and creates no tables — the real cause of the full-suite
+  // relation-not-found failures (each file passed only in isolation).
   await migrate(db, {
     migrationsFolder: path.join(process.cwd(), "src/db/migrations"),
+    migrationsSchema: schemaName,
   });
 
   return {

--- a/tests/integration/spending-helpers.test.ts
+++ b/tests/integration/spending-helpers.test.ts
@@ -1,0 +1,170 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb } from "./setup";
+import {
+  insertHousehold,
+  insertAccount,
+  insertTransaction,
+  insertCategoryGroup,
+  insertCategory,
+  insertTransactionSplit,
+} from "./helpers";
+import { aggregateSpending, enrichSpendingMap } from "../../src/lib/spending-helpers";
+import type { ReportFilters } from "../../src/queries/reports";
+import type { LedgrDb } from "../../src/db";
+
+let db: LedgrDb;
+let close: () => Promise<void>;
+let householdId: string;
+let accountId: string;
+let groupId: string;
+let foodCatId: string;
+let rentCatId: string;
+let incomeCatId: string;
+
+// May window; all fixture expenses land on 2026-05-01 by default.
+const filters: ReportFilters = { dateFrom: "2026-05-01", dateTo: "2026-05-31" };
+
+beforeEach(async () => {
+  ({ db, close } = await createTestDb());
+  ({ householdId } = await insertHousehold(db));
+  ({ accountId } = await insertAccount(db, householdId));
+  ({ groupId } = await insertCategoryGroup(db, householdId, { name: "Living" }));
+  ({ categoryId: foodCatId } = await insertCategory(db, householdId, groupId, { name: "Food" }));
+  ({ categoryId: rentCatId } = await insertCategory(db, householdId, groupId, { name: "Rent" }));
+  const incGroup = await insertCategoryGroup(db, householdId, { name: "Income" });
+  ({ categoryId: incomeCatId } = await insertCategory(db, householdId, incGroup.groupId, {
+    name: "Paycheck",
+    isIncome: true,
+  }));
+});
+
+afterEach(async () => {
+  await close();
+});
+
+// An "expense" for these helpers means normalizedAmount < 0.
+async function expense(overrides: Record<string, unknown> = {}) {
+  return insertTransaction(db, householdId, accountId, {
+    normalizedAmount: -1000,
+    ...overrides,
+  });
+}
+
+describe("aggregateSpending", () => {
+  test("sums absolute spend per category", async () => {
+    await expense({ categoryId: foodCatId, normalizedAmount: -1000 });
+    await expense({ categoryId: foodCatId, normalizedAmount: -500 });
+    await expense({ categoryId: rentCatId, normalizedAmount: -2000 });
+
+    const result = await aggregateSpending(householdId, filters, db);
+
+    expect(result.get(foodCatId)).toBe(1500);
+    expect(result.get(rentCatId)).toBe(2000);
+  });
+
+  test("groups null-category spend under 'uncategorized'", async () => {
+    await expense({ categoryId: null, normalizedAmount: -750 });
+
+    const result = await aggregateSpending(householdId, filters, db);
+
+    expect(result.get("uncategorized")).toBe(750);
+  });
+
+  test("excludes income, transfers, pending, deleted, paired, and out-of-range rows", async () => {
+    await expense({ categoryId: foodCatId, normalizedAmount: -1000 }); // the only one that counts
+    await expense({ categoryId: incomeCatId, normalizedAmount: -9999 }); // income category
+    await expense({ categoryId: foodCatId, normalizedAmount: 5000 }); // positive → not spend
+    await expense({ categoryId: foodCatId, normalizedAmount: -9999, isTransfer: true });
+    await expense({ categoryId: foodCatId, normalizedAmount: -9999, pending: true });
+    await expense({ categoryId: foodCatId, normalizedAmount: -9999, deletedAt: new Date() });
+    await expense({ categoryId: foodCatId, normalizedAmount: -9999, transferPairId: "some-pair" });
+    await expense({ categoryId: foodCatId, normalizedAmount: -9999, date: "2026-06-15" }); // out of window
+
+    const result = await aggregateSpending(householdId, filters, db);
+
+    expect(result.get(foodCatId)).toBe(1000);
+    expect(result.has(incomeCatId)).toBe(false);
+    expect([...result.values()].reduce((a, b) => a + b, 0)).toBe(1000);
+  });
+
+  test("attributes split transactions to their split categories, not the parent", async () => {
+    const { transactionId } = await expense({ categoryId: foodCatId, normalizedAmount: -3000 });
+    await insertTransactionSplit(db, transactionId, foodCatId, 1000);
+    await insertTransactionSplit(db, transactionId, rentCatId, 2000);
+
+    const result = await aggregateSpending(householdId, filters, db);
+
+    // Parent's -3000 is NOT counted once; splits supply the breakdown.
+    expect(result.get(foodCatId)).toBe(1000);
+    expect(result.get(rentCatId)).toBe(2000);
+  });
+
+  test("isolates spend by household", async () => {
+    const other = await insertHousehold(db, "Other");
+    const otherAccount = await insertAccount(db, other.householdId);
+    await insertTransaction(db, other.householdId, otherAccount.accountId, {
+      categoryId: null,
+      normalizedAmount: -5000,
+    });
+    await expense({ categoryId: foodCatId, normalizedAmount: -1000 });
+
+    const result = await aggregateSpending(householdId, filters, db);
+
+    expect(result.get(foodCatId)).toBe(1000);
+    expect([...result.values()].reduce((a, b) => a + b, 0)).toBe(1000);
+  });
+
+  test("honors the accountIds filter", async () => {
+    const second = await insertAccount(db, householdId, { name: "Second" });
+    await expense({ categoryId: foodCatId, normalizedAmount: -1000 }); // default account
+    await insertTransaction(db, householdId, second.accountId, {
+      categoryId: foodCatId,
+      normalizedAmount: -4000,
+    });
+
+    const scoped = await aggregateSpending(
+      householdId,
+      { ...filters, accountIds: [second.accountId] },
+      db,
+    );
+
+    expect(scoped.get(foodCatId)).toBe(4000);
+  });
+});
+
+describe("enrichSpendingMap", () => {
+  test("resolves category name + group and labels the uncategorized bucket", async () => {
+    const spending = new Map<string, number>([
+      [foodCatId, 1500],
+      ["uncategorized", 500],
+    ]);
+
+    const result = await enrichSpendingMap(spending, db);
+
+    const food = result.find((r) => r.id === foodCatId);
+    expect(food).toMatchObject({ name: "Food", groupName: "Living", groupId, value: 1500 });
+
+    const uncategorized = result.find((r) => r.id === null);
+    expect(uncategorized).toMatchObject({ name: "Uncategorized", value: 500, groupName: null });
+  });
+
+  test("labels an unknown category id as 'Unknown'", async () => {
+    const spending = new Map<string, number>([["missing-cat-id", 200]]);
+
+    const result = await enrichSpendingMap(spending, db);
+
+    expect(result[0]).toMatchObject({ id: "missing-cat-id", name: "Unknown", groupName: null });
+  });
+
+  test("sorts descending by value", async () => {
+    const spending = new Map<string, number>([
+      [foodCatId, 100],
+      [rentCatId, 900],
+      ["uncategorized", 500],
+    ]);
+
+    const result = await enrichSpendingMap(spending, db);
+
+    expect(result.map((r) => r.value)).toEqual([900, 500, 100]);
+  });
+});

--- a/tests/integration/webhook-handler.test.ts
+++ b/tests/integration/webhook-handler.test.ts
@@ -7,6 +7,7 @@ import { server } from "../mocks/server";
 import { encrypt } from "@/lib/encryption";
 import { resetPlaidClient } from "@/lib/plaid/client";
 import { households, householdMembers, plaidItems, accounts, syncLog } from "@/db/schema";
+import { DEMO_HOUSEHOLD_ID } from "@/lib/demo-mode";
 import type { LedgrDb } from "@/db";
 
 const HOUSEHOLD_ID = "hh-webhook-test";
@@ -165,6 +166,51 @@ describe("dispatchWebhook", () => {
 
     const [item] = await db.select().from(plaidItems).where(eq(plaidItems.id, INTERNAL_ITEM_ID));
     expect(item!.status).toBe("revoked");
+  });
+
+  it("ITEM:ERROR for an unknown plaid_item_id is a no-op", async () => {
+    const { dispatchWebhook } = await import("@/lib/plaid/webhook-handlers");
+    await setup();
+    await seedTestData(db);
+
+    await dispatchWebhook({
+      webhook_type: "ITEM",
+      webhook_code: "ERROR",
+      item_id: "no-such-plaid-item",
+      error: { error_type: "ITEM_ERROR", error_code: "ITEM_LOGIN_REQUIRED", error_message: "login required" },
+    }, db);
+
+    // The seeded item is untouched because nothing matched.
+    const [item] = await db.select().from(plaidItems).where(eq(plaidItems.id, INTERNAL_ITEM_ID));
+    expect(item!.status).toBe("active");
+  });
+
+  it("never mutates a demo-household item on ITEM:ERROR", async () => {
+    const { dispatchWebhook } = await import("@/lib/plaid/webhook-handlers");
+    await setup();
+    const now = new Date();
+    await db.insert(households).values({ id: DEMO_HOUSEHOLD_ID, name: "Demo", createdAt: now, updatedAt: now });
+    await db.insert(plaidItems).values({
+      id: "demo-item",
+      householdId: DEMO_HOUSEHOLD_ID,
+      accessToken: encrypt("access-sandbox-demo"),
+      plaidItemId: "plaid-demo-item",
+      institutionName: "Demo Bank",
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await dispatchWebhook({
+      webhook_type: "ITEM",
+      webhook_code: "ERROR",
+      item_id: "plaid-demo-item",
+      error: { error_type: "ITEM_ERROR", error_code: "ITEM_LOGIN_REQUIRED", error_message: "login required" },
+    }, db);
+
+    const [item] = await db.select().from(plaidItems).where(eq(plaidItems.id, "demo-item"));
+    expect(item!.status).toBe("active");
+    expect(item!.errorCode).toBeNull();
   });
 
   it("unknown webhook type is a no-op", async () => {


### PR DESCRIPTION
Bundles the branch's two themes: hardening the test/CI workflow, and a round of dashboard/transaction UI/UX fixes surfaced while exercising the running app. 16 commits, full suite green (459 tests).

## Testing & CI hardening
- CI runs typecheck → lint → vitest → (PR-only) mutation on push/PR
- Per-test-schema migration isolation + pinned `search_path`
- Deterministic plaid-exchange + dashboard tests (dates derived relative to now)
- Real query bugs surfaced once the suite actually ran
- Pure-logic coverage added across plaid, import, mcp, query helpers, spending-helpers, webhook, recurring
- pre-commit hook scoped to lint (fast); mutation job non-blocking

## UI/UX fixes (all TDD, verified in the running app)
- **Dashboard net worth**: `getNetWorthHistory` no longer emits a synthetic zero point when no account has a balance, so the widget shows its empty state instead of a degenerate zero-axis chart.
- **Dashboard latest-activity fallback**: `getDashboardSummary` / `getMonthlySpending` fall back to the most recent month with activity (new `getLatestActivityMonth`) instead of hard-coding the current month, so a returning user whose data is from an earlier month doesn't land on all-zeros.
- **Merchant name cleanup**: `cleanTransactionName` strips bank boilerplate (ACH/ZELLE/POS prefixes, date/time stamps, reference numbers), extracts Zelle `NAME:` payees, and title-cases ALL-CAPS while preserving short acronyms. Applied at CSV import + Plaid fallback; `originalName` preserves the raw string (still shown in the detail panel). Backfill via `pnpm backfill-clean-names` (never clobbers an edited name).
- **Transfer labels**: uncategorized transfers (CC autopay, inter-account, P2P) now read "Transfer" instead of italic "Uncategorized".

## Notes
- The branch's later UI work builds on the earlier TDD/CI commits; they're bundled here as one branch.
- Known follow-up (not in this PR): CSV import currently runs no categorization; the seed data only makes it look categorized. Wiring the engine into import (+ a starter keyword→category map) is the real next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LD2C6UQoJX2kiekzyeu6bm