### PR TITLE
feat(reports): richer iconography and chart-linked category rows

### DIFF
--- a/src/components/atoms/report-summary-bar.tsx
+++ b/src/components/atoms/report-summary-bar.tsx
@@ -1,4 +1,6 @@
+import type { LucideIcon } from "lucide-react";
 import { centsToDisplay } from "@/lib/money";
+import { cn } from "@/lib/utils";
 
 export interface SummaryItem {
   label: string;
@@ -6,10 +8,7 @@ export interface SummaryItem {
   format?: "currency" | "number" | "percent";
   color?: "default" | "income" | "expense" | "dynamic";
   secondaryLabel?: string;
-}
-
-interface ReportSummaryBarProps {
-  items: SummaryItem[];
+  icon?: LucideIcon;
 }
 
 const GREEN = "text-green-600 dark:text-green-500";
@@ -25,33 +24,80 @@ function formatValue(value: number, format: SummaryItem["format"]): string {
   }
 }
 
-function getValueColor(item: SummaryItem): string {
+type Tone = "default" | "income" | "expense";
+
+function resolveTone(item: SummaryItem): Tone {
   switch (item.color) {
     case "income":
-      return GREEN;
+      return "income";
     case "expense":
-      return "text-destructive";
+      return "expense";
     case "dynamic":
-      return item.value >= 0 ? GREEN : "text-destructive";
+      return item.value >= 0 ? "income" : "expense";
     default:
-      return "";
+      return "default";
   }
+}
+
+const VALUE_TONE: Record<Tone, string> = {
+  income: GREEN,
+  expense: "text-destructive",
+  default: "",
+};
+
+const ICON_TONE: Record<Tone, string> = {
+  income: "bg-green-600/10 text-green-600 dark:text-green-500",
+  expense: "bg-destructive/10 text-destructive",
+  default: "bg-muted text-muted-foreground",
+};
+
+interface ReportSummaryBarProps {
+  items: SummaryItem[];
 }
 
 export function ReportSummaryBar({ items }: ReportSummaryBarProps) {
   return (
-    <div className="grid gap-4" style={{ gridTemplateColumns: `repeat(${Math.min(items.length, 5)}, 1fr)` }}>
-      {items.map((item) => (
-        <div key={item.label} className="rounded-lg border p-3">
-          <div className="text-xs text-muted-foreground">{item.label}</div>
-          <div className={`text-lg font-semibold tabular-nums ${getValueColor(item)}`}>
-            {formatValue(item.value, item.format)}
+    <div
+      className="grid gap-4"
+      style={{ gridTemplateColumns: `repeat(${Math.min(items.length, 5)}, 1fr)` }}
+    >
+      {items.map((item) => {
+        const tone = resolveTone(item);
+        const Icon = item.icon;
+        return (
+          <div
+            key={item.label}
+            className="flex items-center gap-3 rounded-lg border p-3"
+          >
+            {Icon && (
+              <div
+                className={cn(
+                  "flex size-9 shrink-0 items-center justify-center rounded-md",
+                  ICON_TONE[tone]
+                )}
+              >
+                <Icon className="size-[18px]" strokeWidth={2} />
+              </div>
+            )}
+            <div className="min-w-0">
+              <div className="truncate text-xs text-muted-foreground">{item.label}</div>
+              <div
+                className={cn(
+                  "text-lg font-semibold tabular-nums",
+                  VALUE_TONE[tone]
+                )}
+              >
+                {formatValue(item.value, item.format)}
+              </div>
+              {item.secondaryLabel && (
+                <div className="mt-0.5 text-xs text-muted-foreground">
+                  {item.secondaryLabel}
+                </div>
+              )}
+            </div>
           </div>
-          {item.secondaryLabel && (
-            <div className="text-xs text-muted-foreground mt-0.5">{item.secondaryLabel}</div>
-          )}
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/src/components/organisms/report-cash-flow.tsx
+++ b/src/components/organisms/report-cash-flow.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { TrendingUp, Repeat, Receipt, PiggyBank } from "lucide-react";
 import { SankeyChart, type SankeyNode, type SankeyLink } from "@/components/organisms/sankey-chart";
 import { CashFlowBarChart } from "@/components/atoms/cash-flow-bar-chart";
 import { ReportSummaryBar, type SummaryItem } from "@/components/atoms/report-summary-bar";
@@ -35,14 +36,15 @@ export function ReportCashFlow({
   })();
 
   const summaryItems: SummaryItem[] = [
-    { label: "Total Income", value: safeToSpend.monthlyIncome, color: "income" },
-    { label: "Recurring Bills", value: safeToSpend.recurringExpenses, color: "expense" },
-    { label: "Spent So Far", value: safeToSpend.discretionarySpent, color: "expense" },
+    { label: "Total Income", value: safeToSpend.monthlyIncome, color: "income", icon: TrendingUp },
+    { label: "Recurring Bills", value: safeToSpend.recurringExpenses, color: "expense", icon: Repeat },
+    { label: "Spent So Far", value: safeToSpend.discretionarySpent, color: "expense", icon: Receipt },
     {
       label: "Safe to Spend",
       value: safeToSpend.safeToSpend,
       color: safeColor,
       secondaryLabel: isCurrentMonth ? undefined : "(current month)",
+      icon: PiggyBank,
     },
   ];
 

--- a/src/components/organisms/report-filter-bar.tsx
+++ b/src/components/organisms/report-filter-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronsUpDown, X } from "lucide-react";
+import { ChevronsUpDown, X, CalendarDays, Landmark, Tags } from "lucide-react";
 import { DateRangeSelector } from "@/components/molecules/date-range-selector";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -57,6 +57,7 @@ export function ReportFilterBar({ accounts, categories }: ReportFilterBarProps) 
 
   return (
     <div className="flex flex-wrap items-center gap-2">
+      <CalendarDays className="h-4 w-4 text-muted-foreground" aria-hidden />
       <DateRangeSelector value={currentPreset} onChange={handlePresetChange} />
 
       <Input
@@ -78,6 +79,7 @@ export function ReportFilterBar({ accounts, categories }: ReportFilterBarProps) 
         <PopoverTrigger
           render={<Button variant="outline" size="sm" className="h-8 text-xs" />}
         >
+          <Landmark className="mr-1 h-3.5 w-3.5" />
           {selectedAccountIds.length > 0
             ? `${selectedAccountIds.length} account${selectedAccountIds.length > 1 ? "s" : ""}`
             : "All accounts"}
@@ -109,6 +111,7 @@ export function ReportFilterBar({ accounts, categories }: ReportFilterBarProps) 
         <PopoverTrigger
           render={<Button variant="outline" size="sm" className="h-8 text-xs" />}
         >
+          <Tags className="mr-1 h-3.5 w-3.5" />
           {selectedCategoryIds.length > 0
             ? `${selectedCategoryIds.length} categor${selectedCategoryIds.length > 1 ? "ies" : "y"}`
             : "All categories"}

--- a/src/components/organisms/report-income-expense.tsx
+++ b/src/components/organisms/report-income-expense.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { TrendingUp, TrendingDown, Scale } from "lucide-react";
 import { CashFlowBarChart } from "@/components/atoms/cash-flow-bar-chart";
 import { ReportSummaryBar, type SummaryItem } from "@/components/atoms/report-summary-bar";
 import { IncomeExpenseCategoryTable } from "@/components/molecules/income-expense-category-table";
@@ -29,9 +30,9 @@ export function ReportIncomeExpense({ data, categoryData }: ReportIncomeExpenseP
   const totalNet = totalIncome - totalExpenses;
 
   const summaryItems: SummaryItem[] = [
-    { label: "Total Income", value: totalIncome, color: "income" },
-    { label: "Total Expenses", value: totalExpenses, color: "expense" },
-    { label: "Net", value: totalNet, color: "dynamic" },
+    { label: "Total Income", value: totalIncome, color: "income", icon: TrendingUp },
+    { label: "Total Expenses", value: totalExpenses, color: "expense", icon: TrendingDown },
+    { label: "Net", value: totalNet, color: "dynamic", icon: Scale },
   ];
 
   function handleCategoryDrillDown(categoryId: string, isIncome: boolean) {

--- a/src/components/organisms/report-net-worth.tsx
+++ b/src/components/organisms/report-net-worth.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Wallet, TrendingUp } from "lucide-react";
 import { NetWorthAreaChart } from "@/components/atoms/net-worth-area-chart";
 import { ReportSummaryBar, type SummaryItem } from "@/components/atoms/report-summary-bar";
 import type { NetWorthPoint } from "@/queries/dashboard";
@@ -17,12 +18,13 @@ export function ReportNetWorth({ data }: ReportNetWorthProps) {
     : "0.0";
 
   const summaryItems: SummaryItem[] = [
-    { label: "Current Net Worth", value: latest?.netWorth ?? 0, color: "dynamic" },
+    { label: "Current Net Worth", value: latest?.netWorth ?? 0, color: "dynamic", icon: Wallet },
     {
       label: "Change",
       value: change,
       color: "dynamic",
       secondaryLabel: `${change >= 0 ? "+" : ""}${changePct}%`,
+      icon: TrendingUp,
     },
   ];
 

--- a/src/components/organisms/report-spending.tsx
+++ b/src/components/organisms/report-spending.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useState } from "react";
+import { Wallet, Layers, Crown, Tag } from "lucide-react";
+import { DynamicIcon, type IconName } from "lucide-react/dynamic";
 import { ChartViewToggle } from "@/components/atoms/chart-view-toggle";
 import { SpendingChart } from "@/components/atoms/spending-chart";
 import { ReportSummaryBar, type SummaryItem } from "@/components/atoms/report-summary-bar";
 import { ComparisonBadge } from "@/components/molecules/comparison-badge";
 import { DrillDownSheet, type DrillDownFilter } from "@/components/organisms/drill-down-sheet";
 import { centsToDisplay } from "@/lib/money";
+import { CHART_COLORS } from "@/lib/chart-colors";
 import { useSearchParamFilters } from "@/hooks/use-search-param-filters";
 import type { SpendingRow } from "@/queries/reports";
 
@@ -29,10 +32,10 @@ export function ReportSpending({ data, comparisonLabel: compLabel }: ReportSpend
   const totalSpent = data.reduce((s, r) => s + r.total, 0);
   const topCategory = data.length > 0 ? data[0] : null;
   const summaryItems: SummaryItem[] = [
-    { label: "Total Spent", value: totalSpent, color: "expense" },
-    { label: "Categories", value: data.length, format: "number" },
+    { label: "Total Spent", value: totalSpent, color: "expense", icon: Wallet },
+    { label: "Categories", value: data.length, format: "number", icon: Layers },
     ...(topCategory
-      ? [{ label: `Top: ${topCategory.categoryName}`, value: topCategory.total } as SummaryItem]
+      ? [{ label: `Top: ${topCategory.categoryName}`, value: topCategory.total, icon: Crown } as SummaryItem]
       : []),
   ];
 
@@ -67,17 +70,43 @@ export function ReportSpending({ data, comparisonLabel: compLabel }: ReportSpend
             </tr>
           </thead>
           <tbody>
-            {data.map((row) => (
+            {data.map((row, i) => (
               <tr
                 key={row.categoryId ?? "uncategorized"}
                 className="border-b last:border-0 cursor-pointer hover:bg-muted/50"
                 onClick={() => handleDrillDown({ id: row.categoryId, name: row.categoryName })}
               >
                 <td className="px-3 py-2">
-                  <div className="text-sm">{row.categoryName}</div>
-                  {row.groupName && (
-                    <div className="text-xs text-muted-foreground">{row.groupName}</div>
-                  )}
+                  <div className="flex items-center gap-3">
+                    <span
+                      aria-hidden
+                      className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+                      style={
+                        i < 8
+                          ? {
+                              color: CHART_COLORS[i],
+                              backgroundColor: CHART_COLORS[i].replace(")", " / 0.12)"),
+                            }
+                          : undefined
+                      }
+                    >
+                      {row.groupIcon ? (
+                        <DynamicIcon
+                          name={row.groupIcon as IconName}
+                          size={16}
+                          fallback={() => <Tag size={16} />}
+                        />
+                      ) : (
+                        <Tag size={16} />
+                      )}
+                    </span>
+                    <div className="min-w-0">
+                      <div className="text-sm">{row.categoryName}</div>
+                      {row.groupName && (
+                        <div className="text-xs text-muted-foreground">{row.groupName}</div>
+                      )}
+                    </div>
+                  </div>
                 </td>
                 <td className="px-3 py-2 text-right tabular-nums font-medium">
                   {centsToDisplay(row.total)}

--- a/src/components/organisms/report-tabs.tsx
+++ b/src/components/organisms/report-tabs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PieChart, ArrowLeftRight, Waypoints, TrendingUp, LineChart } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useSearchParamFilters } from "@/hooks/use-search-param-filters";
 import { ReportSpending } from "./report-spending";
@@ -47,12 +48,22 @@ export function ReportTabs({
       value={activeTab}
       onValueChange={(tab) => updateFilter("tab", tab === "spending" ? null : tab)}
     >
-      <TabsList>
-        <TabsTrigger value="spending">Spending</TabsTrigger>
-        <TabsTrigger value="income-expense">Income vs Expense</TabsTrigger>
-        <TabsTrigger value="cash-flow">Cash Flow</TabsTrigger>
-        <TabsTrigger value="trends">Trends</TabsTrigger>
-        <TabsTrigger value="net-worth">Net Worth</TabsTrigger>
+      <TabsList className="h-9">
+        <TabsTrigger value="spending">
+          <PieChart /> Spending
+        </TabsTrigger>
+        <TabsTrigger value="income-expense">
+          <ArrowLeftRight /> Income vs Expense
+        </TabsTrigger>
+        <TabsTrigger value="cash-flow">
+          <Waypoints /> Cash Flow
+        </TabsTrigger>
+        <TabsTrigger value="trends">
+          <TrendingUp /> Trends
+        </TabsTrigger>
+        <TabsTrigger value="net-worth">
+          <LineChart /> Net Worth
+        </TabsTrigger>
       </TabsList>
 
       <TabsContent value="spending" className="mt-4">

--- a/src/components/organisms/report-trends.tsx
+++ b/src/components/organisms/report-trends.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { Wallet, CalendarDays } from "lucide-react";
 import { TrendLineChart } from "@/components/atoms/trend-line-chart";
 import { ReportSummaryBar, type SummaryItem } from "@/components/atoms/report-summary-bar";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -49,8 +50,8 @@ export function ReportTrends({ data }: ReportTrendsProps) {
   const monthlyAvg = monthCount > 0 ? Math.round(totalSpent / monthCount) : 0;
 
   const summaryItems: SummaryItem[] = [
-    { label: "Total Spent", value: totalSpent, color: "expense" },
-    { label: "Monthly Average", value: monthlyAvg },
+    { label: "Total Spent", value: totalSpent, color: "expense", icon: Wallet },
+    { label: "Monthly Average", value: monthlyAvg, icon: CalendarDays },
   ];
 
   return (

--- a/src/lib/spending-helpers.ts
+++ b/src/lib/spending-helpers.ts
@@ -17,6 +17,7 @@ export interface SpendingChartItem {
   value: number;
   groupName: string | null;
   groupId: string | null;
+  groupIcon: string | null;
 }
 
 
@@ -109,7 +110,13 @@ export async function enrichSpendingMap(
 ): Promise<SpendingChartItem[]> {
   const categoryIds = [...spending.keys()].filter((k) => k !== "uncategorized");
 
-  type CatRow = { id: string; name: string; groupName: string | null; groupId: string | null };
+  type CatRow = {
+    id: string;
+    name: string;
+    groupName: string | null;
+    groupId: string | null;
+    groupIcon: string | null;
+  };
   let catRows: CatRow[] = [];
   if (categoryIds.length > 0) {
     catRows = await db
@@ -118,6 +125,7 @@ export async function enrichSpendingMap(
         name: categories.name,
         groupName: categoryGroups.name,
         groupId: categoryGroups.id,
+        groupIcon: categoryGroups.icon,
       })
       .from(categories)
       .leftJoin(categoryGroups, eq(categories.groupId, categoryGroups.id))
@@ -129,7 +137,14 @@ export async function enrichSpendingMap(
 
   for (const [key, value] of spending.entries()) {
     if (key === "uncategorized") {
-      result.push({ id: null, name: "Uncategorized", value, groupName: null, groupId: null });
+      result.push({
+        id: null,
+        name: "Uncategorized",
+        value,
+        groupName: null,
+        groupId: null,
+        groupIcon: null,
+      });
     } else {
       const cat = catMap.get(key);
       result.push({
@@ -138,6 +153,7 @@ export async function enrichSpendingMap(
         value,
         groupName: cat?.groupName ?? null,
         groupId: cat?.groupId ?? null,
+        groupIcon: cat?.groupIcon ?? null,
       });
     }
   }

--- a/src/queries/reports.ts
+++ b/src/queries/reports.ts
@@ -31,6 +31,7 @@ export interface SpendingRow {
   categoryName: string;
   groupName: string | null;
   groupId: string | null;
+  groupIcon: string | null;
   total: number;
   prevTotal: number;
 }
@@ -70,6 +71,7 @@ export async function getSpendingByCategory(
     categoryName: row.name,
     groupName: row.groupName,
     groupId: row.groupId,
+    groupIcon: row.groupIcon,
     total: row.value,
     prevTotal: prevMap.get(row.id ?? "uncategorized") ?? 0,
   }));


### PR DESCRIPTION
## What

UI/UX polish for the **Reports** screen, focused on consistent iconography and tying the spending table to its chart.

- **Tab icons** — a glyph per report type (Spending, Income vs Expense, Cash Flow, Trends, Net Worth).
- **Summary cards** — each metric card gets a tinted icon chip, tone-matched to income / expense / neutral.
- **Spending table ↔ chart** — each category row now shows a chart-color-tinted chip with its **group's icon** (via lucide `DynamicIcon`). Top slices match the donut/bar colors; the remainder are muted; Uncategorized falls back to a tag glyph.
- **Filter bar** — calendar affordance on the date-range presets, a bank icon on *All accounts*, a tags icon on *All categories*.

To support the row chips, `categoryGroups.icon` is surfaced through `enrichSpendingMap` → `SpendingRow`.

## Scope

UI-only. No behavior, route, or query-semantics changes. `typecheck` passes; `eslint` reports 0 errors in touched files.

## Screenshots

Verified live across tabs (Spending + Cash Flow) during development — icons, tone-matched chips, and chart-linked row chips all render correctly in the running app.

## Notes

- The pre-commit hook (`lint-staged`) is configured on another branch but not on `main`, so the commit used `--no-verify`; lint + typecheck were run manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEbGCdCZaWWbDvR9ev74Ja