### PR TITLE
fix(scheduler): refresh investments in daily safety-sync

### DIFF
--- a/src/lib/scheduler/tasks/daily-safety-sync.test.ts
+++ b/src/lib/scheduler/tasks/daily-safety-sync.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi } from "vitest";
 import { runDailySafetySync } from "./daily-safety-sync";
 import type { SyncResult } from "@/lib/plaid/sync";
+import type { InvestmentSyncResult } from "@/lib/plaid/investments-process";
 import type { LedgrDb } from "@/db";
 
 describe("runDailySafetySync", () => {
   const fakeDb = {} as LedgrDb;
+  const okInvest = () =>
+    vi.fn().mockResolvedValue({ success: true } as InvestmentSyncResult);
 
   it("calls syncInstitution for each active item and logs a summary", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
@@ -15,7 +18,12 @@ describe("runDailySafetySync", () => {
     ]);
     const sync = vi.fn().mockResolvedValue({ success: true } as SyncResult);
 
-    await runDailySafetySync({ db: fakeDb, listItems: list, syncOne: sync });
+    await runDailySafetySync({
+      db: fakeDb,
+      listItems: list,
+      syncOne: sync,
+      syncInvestmentsOne: okInvest(),
+    });
 
     expect(sync).toHaveBeenCalledTimes(2);
     expect(sync).toHaveBeenNthCalledWith(1, "it-1", "hh-1", fakeDb);
@@ -40,7 +48,12 @@ describe("runDailySafetySync", () => {
       .mockRejectedValueOnce(new Error("plaid 500"))
       .mockResolvedValueOnce({ success: false, error: "rate limited" } as SyncResult);
 
-    await runDailySafetySync({ db: fakeDb, listItems: list, syncOne: sync });
+    await runDailySafetySync({
+      db: fakeDb,
+      listItems: list,
+      syncOne: sync,
+      syncInvestmentsOne: okInvest(),
+    });
 
     expect(sync).toHaveBeenCalledTimes(3);
     expect(log).toHaveBeenCalledWith(
@@ -59,16 +72,87 @@ describe("runDailySafetySync", () => {
   it("logs and returns cleanly when there are no items", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const sync = vi.fn();
+    const invest = okInvest();
 
     await runDailySafetySync({
       db: fakeDb,
       listItems: vi.fn().mockResolvedValue([]),
       syncOne: sync,
+      syncInvestmentsOne: invest,
     });
 
     expect(sync).not.toHaveBeenCalled();
+    expect(invest).not.toHaveBeenCalled();
     expect(log).toHaveBeenCalledWith(
       expect.stringContaining("safety-sync: 0 items"),
+    );
+  });
+
+  it("also syncs investments for each active item as a backstop", async () => {
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const list = vi.fn().mockResolvedValue([
+      { itemId: "it-1", householdId: "hh-1" },
+      { itemId: "it-2", householdId: "hh-2" },
+    ]);
+    const sync = vi.fn().mockResolvedValue({ success: true } as SyncResult);
+    const invest = vi
+      .fn()
+      .mockResolvedValue({ success: true } as InvestmentSyncResult);
+
+    await runDailySafetySync({
+      db: fakeDb,
+      listItems: list,
+      syncOne: sync,
+      syncInvestmentsOne: invest,
+    });
+
+    expect(invest).toHaveBeenCalledTimes(2);
+    expect(invest).toHaveBeenNthCalledWith(1, "it-1", "hh-1", fakeDb);
+    expect(invest).toHaveBeenNthCalledWith(2, "it-2", "hh-2", fakeDb);
+  });
+
+  it("isolates investment-sync failures from the transaction-sync result", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const list = vi.fn().mockResolvedValue([
+      { itemId: "it-1", householdId: "hh-1" },
+      { itemId: "it-2", householdId: "hh-2" },
+    ]);
+    // Transactions succeed for both items.
+    const sync = vi.fn().mockResolvedValue({ success: true } as SyncResult);
+    // Investments: one throws, one returns a soft error.
+    const invest = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("holdings 500"))
+      .mockResolvedValueOnce({
+        success: false,
+        error: "transient",
+      } as InvestmentSyncResult);
+
+    await runDailySafetySync({
+      db: fakeDb,
+      listItems: list,
+      syncOne: sync,
+      syncInvestmentsOne: invest,
+    });
+
+    // Transaction sync results are unaffected by investment failures.
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("safety-sync: 2 items, 2 success, 0 error"),
+    );
+    // Investment failures are surfaced separately.
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining("investments 0 success, 2 error"),
+    );
+    expect(err).toHaveBeenCalledWith(
+      expect.stringContaining("[scheduler] safety-sync investments item it-1"),
+      expect.any(Error),
+    );
+    expect(err).toHaveBeenCalledWith(
+      expect.stringContaining("[scheduler] safety-sync investments item it-2"),
+      "transient",
     );
   });
 });

--- a/src/lib/scheduler/tasks/daily-safety-sync.ts
+++ b/src/lib/scheduler/tasks/daily-safety-sync.ts
@@ -4,6 +4,8 @@ import {
   type ActivePlaidItemRef,
 } from "@/lib/plaid/queries";
 import { syncInstitution, type SyncResult } from "@/lib/plaid/sync";
+import { syncInvestments } from "@/lib/plaid/investments-sync";
+import type { InvestmentSyncResult } from "@/lib/plaid/investments-process";
 
 type Deps = {
   db?: LedgrDb;
@@ -13,25 +15,41 @@ type Deps = {
     householdId: string,
     db: LedgrDb,
   ) => Promise<SyncResult>;
+  syncInvestmentsOne?: (
+    itemId: string,
+    householdId: string,
+    db: LedgrDb,
+  ) => Promise<InvestmentSyncResult>;
 };
 
 /**
  * Daily safety-sync: iterates every active Plaid item and calls syncInstitution.
  * Acts as a backstop for missed webhooks.
  *
- * Per-item errors are isolated so one bad item can't poison the whole run.
- * Items are processed sequentially — Plaid has tight rate limits and self-hosters
- * typically have a handful of items, so concurrency isn't worth the complexity.
+ * Investments are refreshed in the same pass. Unlike transactions, Plaid does not
+ * drive investment updates through the SYNC_UPDATES_AVAILABLE webhook we handle, so
+ * without this backstop holdings only refresh on manual sync or at link time and go
+ * stale in between. Items without investment accounts skip cleanly inside
+ * syncInvestments (SKIP_ERROR_CODES), and investments is a per-item subscription
+ * product, so the daily refresh adds no per-call billing.
+ *
+ * Per-item errors are isolated so one bad item can't poison the whole run, and an
+ * investment-sync failure never affects the transaction-sync result. Items are
+ * processed sequentially — Plaid has tight rate limits and self-hosters typically
+ * have a handful of items, so concurrency isn't worth the complexity.
  */
 export async function runDailySafetySync(deps: Deps = {}): Promise<void> {
   const db = deps.db ?? defaultDb;
   const listItems = deps.listItems ?? listActivePlaidItems;
   const syncOne = deps.syncOne ?? syncInstitution;
+  const syncInvestmentsOne = deps.syncInvestmentsOne ?? syncInvestments;
 
   const items = await listItems(db);
 
   let successes = 0;
   let errors = 0;
+  let invSuccesses = 0;
+  let invErrors = 0;
 
   for (const { itemId, householdId } of items) {
     try {
@@ -49,9 +67,29 @@ export async function runDailySafetySync(deps: Deps = {}): Promise<void> {
       errors++;
       console.error(`[scheduler] safety-sync item ${itemId} threw:`, err);
     }
+
+    try {
+      const invResult = await syncInvestmentsOne(itemId, householdId, db);
+      if (invResult.success) {
+        invSuccesses++;
+      } else {
+        invErrors++;
+        console.error(
+          `[scheduler] safety-sync investments item ${itemId} returned error:`,
+          invResult.error,
+        );
+      }
+    } catch (err) {
+      invErrors++;
+      console.error(
+        `[scheduler] safety-sync investments item ${itemId} threw:`,
+        err,
+      );
+    }
   }
 
   console.log(
-    `[scheduler] safety-sync: ${items.length} items, ${successes} success, ${errors} error`,
+    `[scheduler] safety-sync: ${items.length} items, ${successes} success, ${errors} error; ` +
+      `investments ${invSuccesses} success, ${invErrors} error`,
   );
 }


### PR DESCRIPTION
## Problem

Investment holdings only synced on **manual sync** or **at link time**. Plaid does not drive investment updates through the `TRANSACTIONS:SYNC_UPDATES_AVAILABLE` webhook that Ledgr handles, and the daily safety-sync only called `syncInstitution` (transactions). Result: holdings went **stale** between manual refreshes.

## Fix

The daily 4:30 AM safety-sync now refreshes investments alongside transactions, mirroring the *webhook + daily-backstop* pattern already used for transactions.

- Added an injectable `syncInvestmentsOne` dep (defaults to real `syncInvestments`).
- Each item's investment sync runs in its **own** try/catch, so a holdings failure never corrupts the transaction-sync result or poisons the run.
- Summary log extended: `…N items, X success, Y error; investments A success, B error`.

## Why this is safe / cheap

- Non-investment items (checking/savings) skip cleanly via `PRODUCTS_NOT_SUPPORTED` (in `SKIP_ERROR_CODES`) — no nightly error spam.
- Investments is a per-item **subscription** product, so the nightly refresh adds **zero** per-call billing.
- Holdings refresh **at least daily**, matching how often Plaid itself refreshes holdings.

## Tests (TDD — watched RED, then GREEN)

- 2 new regression tests: investments synced per item; investment failures isolated from transaction results.
- Threaded the new dep through the existing 3 tests.
- `daily-safety-sync` unit: 5/5 · scheduler suite: 14/14 · scheduler integration (Postgres testcontainer): 2/2 · typecheck + eslint clean.

## Not included (deliberate)

No real-time `HOLDINGS:DEFAULT_UPDATE` webhook handler — holdings don't change intraday from Plaid's side, so the daily backstop is well-matched. Easy follow-up if near-real-time is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LD2C6UQoJX2kiekzyeu6bm