### PR TITLE
feat(settings): data + account deletion (Danger Zone)

### DIFF
--- a/src/actions/account-deletion.ts
+++ b/src/actions/account-deletion.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { authorizeAction } from "@/lib/auth/authorize-action";
+import {
+  deleteFinancialData,
+  deleteAccount,
+} from "@/lib/account-deletion";
+
+/**
+ * Erase all connected-account financial data for the current household while
+ * keeping the user's login, categories, and budgets.
+ */
+export async function deleteFinancialDataAction() {
+  const auth = await authorizeAction();
+  if ("error" in auth) return auth;
+
+  await deleteFinancialData(auth.householdId);
+
+  revalidatePath("/");
+  revalidatePath("/accounts");
+  revalidatePath("/transactions");
+  revalidatePath("/investments");
+  revalidatePath("/reports");
+  return { success: true as const };
+}
+
+/**
+ * Permanently delete the current user's account and all associated data. The
+ * caller is responsible for signing out afterward (the session row is erased as
+ * part of this, but the client cookie should be cleared too).
+ */
+export async function deleteAccountAction() {
+  const auth = await authorizeAction();
+  if ("error" in auth) return auth;
+
+  await deleteAccount(auth.householdId, auth.userId);
+  return { success: true as const };
+}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -2,6 +2,7 @@ import { getSession } from "@/lib/auth/session";
 import { getMcpSettings } from "@/queries/mcp-settings";
 import { McpSettingsForm } from "@/components/organisms/mcp-settings-form";
 import { DemoModeToggle } from "@/components/molecules/demo-mode-toggle";
+import { DangerZone } from "@/components/organisms/danger-zone";
 import { isDemoMode } from "@/lib/demo-mode";
 
 export default async function SettingsPage() {
@@ -26,6 +27,7 @@ export default async function SettingsPage() {
         mcpEnabled={mcpSettings.mcpEnabled}
         connectedClients={mcpSettings.connectedClients}
       />
+      <DangerZone />
     </div>
   );
 }

--- a/src/components/organisms/danger-zone.tsx
+++ b/src/components/organisms/danger-zone.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { authClient } from "@/lib/auth/client";
+import {
+  deleteFinancialDataAction,
+  deleteAccountAction,
+} from "@/actions/account-deletion";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+} from "@/components/ui/alert-dialog";
+
+type DangerActionProps = {
+  triggerLabel: string;
+  triggerVariant: "outline" | "destructive";
+  title: string;
+  description: string;
+  consequences: string[];
+  keep?: string;
+  confirmPhrase: string;
+  confirmLabel: string;
+  onConfirm: () => Promise<{ error?: string; success?: true }>;
+  onSuccess: () => void | Promise<void>;
+};
+
+function DangerAction({
+  triggerLabel,
+  triggerVariant,
+  title,
+  description,
+  consequences,
+  keep,
+  confirmPhrase,
+  confirmLabel,
+  onConfirm,
+  onSuccess,
+}: DangerActionProps) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const confirmed = text.trim().toLowerCase() === confirmPhrase.toLowerCase();
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) {
+      setText("");
+      setError(null);
+      setPending(false);
+    }
+  }
+
+  async function handleConfirm() {
+    if (!confirmed || pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await onConfirm();
+      if (res?.error) {
+        setError(res.error);
+        setPending(false);
+        return;
+      }
+      await onSuccess();
+      // Success paths either navigate away or refresh; close defensively.
+      handleOpenChange(false);
+    } catch {
+      setError("Something went wrong. Please try again.");
+      setPending(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant={triggerVariant}
+        onClick={() => setOpen(true)}
+      >
+        {triggerLabel}
+      </Button>
+      <AlertDialog open={open} onOpenChange={handleOpenChange}>
+        <AlertDialogContent className="sm:max-w-md">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{title}</AlertDialogTitle>
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <ul className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-left">
+            {consequences.map((c) => (
+              <li key={c} className="flex gap-2 py-0.5">
+                <span aria-hidden className="text-destructive font-bold">
+                  &ndash;
+                </span>
+                <span>{c}</span>
+              </li>
+            ))}
+          </ul>
+          {keep ? (
+            <p className="-mt-2 text-sm text-muted-foreground text-left">{keep}</p>
+          ) : null}
+
+          <div className="text-left">
+            <Label htmlFor="danger-confirm" className="text-sm">
+              Type{" "}
+              <span className="font-mono font-medium text-foreground">
+                {confirmPhrase}
+              </span>{" "}
+              to confirm
+            </Label>
+            <Input
+              id="danger-confirm"
+              autoComplete="off"
+              value={text}
+              placeholder={confirmPhrase}
+              onChange={(e) => setText(e.target.value)}
+              className="mt-1.5"
+            />
+          </div>
+
+          {error ? (
+            <p className="text-sm text-destructive text-left" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <AlertDialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={pending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleConfirm}
+              disabled={!confirmed || pending}
+            >
+              {pending ? "Working…" : confirmLabel}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+export function DangerZone() {
+  const router = useRouter();
+
+  return (
+    <section
+      className="rounded-lg border border-destructive/30 overflow-hidden"
+      aria-labelledby="danger-zone-title"
+    >
+      <div className="flex items-center gap-2 border-b border-destructive/30 bg-destructive/5 px-5 py-3">
+        <span
+          aria-hidden
+          className="size-2 rounded-full bg-destructive shrink-0"
+        />
+        <h2 id="danger-zone-title" className="text-sm font-semibold">
+          Danger zone
+        </h2>
+      </div>
+
+      <div className="divide-y">
+        <div className="flex items-center justify-between gap-5 px-5 py-4">
+          <div>
+            <h3 className="text-sm font-medium">Delete all financial data</h3>
+            <p className="mt-1 text-sm text-muted-foreground max-w-md">
+              Disconnects every bank and erases all accounts, transactions,
+              balances, and investment records. Your login, categories, and
+              budgets are kept.
+            </p>
+          </div>
+          <DangerAction
+            triggerLabel="Delete data"
+            triggerVariant="outline"
+            title="Delete all financial data?"
+            description="This disconnects your banks at Plaid and erases financial records from your instance."
+            consequences={[
+              "Revokes all Plaid connections (banks stop syncing)",
+              "Deletes every account, transaction, and split",
+              "Deletes investment holdings, history, and balances",
+              "Deletes detected recurring bills",
+            ]}
+            keep="Kept: your login, custom categories, and budgets."
+            confirmPhrase="DELETE"
+            confirmLabel="Delete data"
+            onConfirm={deleteFinancialDataAction}
+            onSuccess={() => router.refresh()}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-5 px-5 py-4">
+          <div>
+            <h3 className="text-sm font-medium">Delete account</h3>
+            <p className="mt-1 text-sm text-muted-foreground max-w-md">
+              Permanently erases everything — your financial data and your Ledgr
+              login. This cannot be undone.
+            </p>
+          </div>
+          <DangerAction
+            triggerLabel="Delete account"
+            triggerVariant="destructive"
+            title="Delete your account?"
+            description="This permanently erases everything and signs you out. It cannot be undone."
+            consequences={[
+              "Revokes all Plaid connections",
+              "Deletes all financial data (accounts, transactions, investments)",
+              "Deletes categories, budgets, and saved reports",
+              "Deletes your login, sessions, and connected AI clients",
+            ]}
+            confirmPhrase="delete my account"
+            confirmLabel="Delete account forever"
+            onConfirm={deleteAccountAction}
+            onSuccess={async () => {
+              await authClient.signOut();
+              router.push("/login");
+            }}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/account-deletion.ts
+++ b/src/lib/account-deletion.ts
@@ -1,0 +1,137 @@
+import { eq } from "drizzle-orm";
+import { db as defaultDb, type LedgrDb } from "@/db";
+import {
+  plaidItems,
+  accounts,
+  transactions,
+  recurringTransactions,
+  budgets,
+  households,
+  user,
+  userSettings,
+  oauthCodes,
+  oauthRefreshTokens,
+  oauthConsents,
+} from "@/db/schema";
+import { decrypt } from "@/lib/encryption";
+import { getPlaidClient } from "@/lib/plaid/client";
+
+/**
+ * Full erasure of a household's financial data and (optionally) the owning user.
+ *
+ * These back the user-facing "Danger zone" actions in Settings and give Ledgr a
+ * true data-deletion capability (as opposed to soft-delete on Plaid disconnect).
+ */
+export type DeletionDeps = {
+  db?: LedgrDb;
+  /**
+   * Revoke a Plaid item at Plaid, given its (encrypted) access token. Injectable
+   * for tests. The default decrypts and calls Plaid's `/item/remove`.
+   */
+  revokePlaidItem?: (encryptedAccessToken: string) => Promise<void>;
+};
+
+// A Drizzle transaction handle. Kept loose so the teardown helper works with both
+// the top-level db and a transaction.
+type Tx = Parameters<Parameters<LedgrDb["transaction"]>[0]>[0];
+
+const defaultRevoke = async (encryptedAccessToken: string): Promise<void> => {
+  await getPlaidClient().itemRemove({
+    access_token: decrypt(encryptedAccessToken),
+  });
+};
+
+/** Revoke every Plaid item for a household. Best-effort — a Plaid failure must not
+ * block local erasure (the user still expects their data gone). */
+async function revokeAllPlaidItems(
+  db: LedgrDb,
+  householdId: string,
+  revoke: (token: string) => Promise<void>,
+): Promise<void> {
+  const items = await db
+    .select({ accessToken: plaidItems.accessToken })
+    .from(plaidItems)
+    .where(eq(plaidItems.householdId, householdId));
+
+  for (const item of items) {
+    try {
+      await revoke(item.accessToken);
+    } catch {
+      // Best-effort: continue local cleanup even if Plaid rejects the call.
+    }
+  }
+}
+
+/**
+ * Delete the connected-account / transaction subtree for a household, in FK-safe
+ * order. These tables carry NO ACTION cross-references (accounts→plaid_items,
+ * transactions→recurring, recurring→accounts) so the order matters:
+ *
+ *   transactions (cascades transaction_splits)
+ *   → recurring_transactions
+ *   → accounts (cascades investment holdings/history/transactions + balance_history)
+ *   → plaid_items (cascades sync logs + institution logos)
+ */
+async function deleteFinancialTables(tx: Tx, householdId: string): Promise<void> {
+  await tx.delete(transactions).where(eq(transactions.householdId, householdId));
+  await tx
+    .delete(recurringTransactions)
+    .where(eq(recurringTransactions.householdId, householdId));
+  await tx.delete(accounts).where(eq(accounts.householdId, householdId));
+  await tx.delete(plaidItems).where(eq(plaidItems.householdId, householdId));
+}
+
+/**
+ * Erase all financial data for a household while keeping the user's login,
+ * custom categories, and budgets.
+ */
+export async function deleteFinancialData(
+  householdId: string,
+  deps: DeletionDeps = {},
+): Promise<void> {
+  const db = deps.db ?? defaultDb;
+  const revoke = deps.revokePlaidItem ?? defaultRevoke;
+
+  await revokeAllPlaidItems(db, householdId, revoke);
+  await db.transaction((tx) => deleteFinancialTables(tx, householdId));
+}
+
+/**
+ * Permanently erase everything: the household and all of its data, plus the user
+ * and their login artifacts.
+ *
+ * The transaction subtree and budgets are torn down first so that nothing still
+ * references `categories`/`merchants` when the `households` row is deleted — those
+ * back-references are NO ACTION and Postgres raises mid-cascade if a referencing
+ * row (e.g. a transaction split or budget category) still exists. Once they're
+ * gone, deleting `households` cleanly cascades categories, category groups/rules,
+ * merchants, saved reports, and household memberships. OAuth grants and user
+ * settings hold IDs without FKs, so they are removed explicitly; deleting the
+ * `user` row cascades to sessions and auth accounts.
+ */
+export async function deleteAccount(
+  householdId: string,
+  userId: string,
+  deps: DeletionDeps = {},
+): Promise<void> {
+  const db = deps.db ?? defaultDb;
+  const revoke = deps.revokePlaidItem ?? defaultRevoke;
+
+  await revokeAllPlaidItems(db, householdId, revoke);
+
+  await db.transaction(async (tx) => {
+    await deleteFinancialTables(tx, householdId);
+    // Removes budget_categories (which back-reference categories) before the
+    // household cascade reaches categories.
+    await tx.delete(budgets).where(eq(budgets.householdId, householdId));
+
+    await tx.delete(households).where(eq(households.id, householdId));
+
+    await tx.delete(oauthCodes).where(eq(oauthCodes.userId, userId));
+    await tx.delete(oauthRefreshTokens).where(eq(oauthRefreshTokens.userId, userId));
+    await tx.delete(oauthConsents).where(eq(oauthConsents.userId, userId));
+    await tx.delete(userSettings).where(eq(userSettings.userId, userId));
+
+    await tx.delete(user).where(eq(user.id, userId));
+  });
+}

--- a/tests/integration/account-deletion.test.ts
+++ b/tests/integration/account-deletion.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./setup";
+import type { LedgrDb } from "@/db";
+import {
+  households,
+  householdMembers,
+  user,
+  session,
+  account as authAccount,
+  userSettings,
+  categoryGroups,
+  categories,
+  plaidItems,
+  syncLog,
+  institutionLogos,
+  accounts,
+  transactions,
+  transactionSplits,
+  investmentHoldings,
+  holdingsHistory,
+  investmentTransactions,
+  balanceHistory,
+  recurringTransactions,
+  budgets,
+  oauthCodes,
+  oauthRefreshTokens,
+  oauthConsents,
+} from "@/db/schema";
+import { deleteFinancialData, deleteAccount } from "@/lib/account-deletion";
+
+/**
+ * Seed one fully-populated household + user so deletions can be verified to touch
+ * exactly the right tables (and nothing belonging to another household).
+ */
+async function seedHousehold(db: LedgrDb, s: string) {
+  const hh = `hh-${s}`;
+  const uid = `u-${s}`;
+
+  await db.insert(user).values({
+    id: uid,
+    name: `User ${s}`,
+    email: `${s}@example.com`,
+    updatedAt: new Date(),
+  });
+  await db.insert(households).values({ id: hh, name: `HH ${s}` });
+  await db.insert(householdMembers).values({
+    id: `hm-${s}`,
+    householdId: hh,
+    userId: uid,
+    role: "owner",
+  });
+  await db.insert(session).values({
+    id: `sess-${s}`,
+    token: `tok-${s}`,
+    userId: uid,
+    expiresAt: new Date(Date.now() + 1_000_000_000),
+    updatedAt: new Date(),
+  });
+  await db.insert(authAccount).values({
+    id: `authacc-${s}`,
+    accountId: `acc-${s}`,
+    providerId: "credential",
+    userId: uid,
+    password: "hashed",
+    updatedAt: new Date(),
+  });
+  await db.insert(userSettings).values({ id: `us-${s}`, userId: uid });
+
+  await db.insert(categoryGroups).values({ id: `cg-${s}`, householdId: hh, name: "Group" });
+  await db.insert(categories).values({
+    id: `cat-${s}`,
+    householdId: hh,
+    groupId: `cg-${s}`,
+    name: "Cat",
+  });
+
+  await db.insert(plaidItems).values({
+    id: `pi-${s}`,
+    householdId: hh,
+    accessToken: `enc-token-${s}`,
+  });
+  await db.insert(syncLog).values({ id: `sl-${s}`, plaidItemId: `pi-${s}` });
+  await db.insert(institutionLogos).values({
+    id: `il-${s}`,
+    plaidItemId: `pi-${s}`,
+    logo: "logo-data",
+  });
+
+  await db.insert(accounts).values({
+    id: `ac-${s}`,
+    householdId: hh,
+    plaidItemId: `pi-${s}`,
+    name: "Checking",
+    type: "checking",
+    currentBalance: 1000,
+  });
+  await db.insert(transactions).values({
+    id: `tx-${s}`,
+    accountId: `ac-${s}`,
+    householdId: hh,
+    date: "2026-01-01",
+    originalName: "Coffee",
+    name: "Coffee",
+    amount: 500,
+    normalizedAmount: 500,
+  });
+  await db.insert(transactionSplits).values({
+    id: `sp-${s}`,
+    transactionId: `tx-${s}`,
+    categoryId: `cat-${s}`,
+    amount: 500,
+  });
+  await db.insert(investmentHoldings).values({
+    id: `ih-${s}`,
+    accountId: `ac-${s}`,
+    securityName: "AAPL",
+    asOfDate: "2026-01-01",
+  });
+  await db.insert(holdingsHistory).values({
+    id: `hist-${s}`,
+    accountId: `ac-${s}`,
+    date: "2026-01-01",
+  });
+  await db.insert(investmentTransactions).values({
+    id: `it-${s}`,
+    accountId: `ac-${s}`,
+    amount: 1000,
+    date: "2026-01-01",
+  });
+  await db.insert(balanceHistory).values({
+    id: `bh-${s}`,
+    accountId: `ac-${s}`,
+    date: "2026-01-01",
+    balance: 1000,
+  });
+  await db.insert(recurringTransactions).values({
+    id: `rt-${s}`,
+    householdId: hh,
+    name: "Netflix",
+  });
+  await db.insert(budgets).values({ id: `bud-${s}`, householdId: hh, month: "2026-01" });
+
+  await db.insert(oauthCodes).values({
+    code: `code-${s}`,
+    clientId: "client",
+    userId: uid,
+    householdId: hh,
+    scope: "read",
+    codeChallenge: "cc",
+    redirectUri: "https://x",
+    expiresAt: "2026-12-31",
+  });
+  await db.insert(oauthRefreshTokens).values({
+    token: `rtok-${s}`,
+    clientId: "client",
+    userId: uid,
+    householdId: hh,
+    scope: "read",
+    expiresAt: "2026-12-31",
+  });
+  await db.insert(oauthConsents).values({
+    id: `consent-${s}`,
+    userId: uid,
+    clientId: "client",
+    scope: "read",
+    grantedAt: "2026-01-01",
+  });
+
+  return { hh, uid };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function count(db: LedgrDb, table: any, where: any): Promise<number> {
+  const rows = await db.select().from(table).where(where);
+  return rows.length;
+}
+
+describe("account deletion (integration)", () => {
+  let db: LedgrDb;
+  let close: () => Promise<void>;
+
+  beforeAll(async () => {
+    ({ db, close } = await createTestDb());
+  });
+  afterAll(async () => {
+    await close();
+  });
+
+  describe("deleteFinancialData", () => {
+    it("erases all financial data but keeps login, categories, and budgets", async () => {
+      const { hh, uid } = await seedHousehold(db, "fin");
+      const revoked: string[] = [];
+
+      await deleteFinancialData(hh, {
+        db,
+        revokePlaidItem: async (token) => {
+          revoked.push(token);
+        },
+      });
+
+      // Plaid items are revoked (best-effort) with their stored token.
+      expect(revoked).toEqual(["enc-token-fin"]);
+
+      // Financial data is gone.
+      expect(await count(db, accounts, eq(accounts.householdId, hh))).toBe(0);
+      expect(await count(db, transactions, eq(transactions.householdId, hh))).toBe(0);
+      expect(await count(db, transactionSplits, eq(transactionSplits.id, "sp-fin"))).toBe(0);
+      expect(await count(db, investmentHoldings, eq(investmentHoldings.accountId, "ac-fin"))).toBe(0);
+      expect(await count(db, holdingsHistory, eq(holdingsHistory.accountId, "ac-fin"))).toBe(0);
+      expect(await count(db, investmentTransactions, eq(investmentTransactions.accountId, "ac-fin"))).toBe(0);
+      expect(await count(db, balanceHistory, eq(balanceHistory.accountId, "ac-fin"))).toBe(0);
+      expect(await count(db, plaidItems, eq(plaidItems.householdId, hh))).toBe(0);
+      expect(await count(db, syncLog, eq(syncLog.id, "sl-fin"))).toBe(0);
+      expect(await count(db, institutionLogos, eq(institutionLogos.id, "il-fin"))).toBe(0);
+      expect(await count(db, recurringTransactions, eq(recurringTransactions.householdId, hh))).toBe(0);
+
+      // Login + configuration are kept.
+      expect(await count(db, user, eq(user.id, uid))).toBe(1);
+      expect(await count(db, households, eq(households.id, hh))).toBe(1);
+      expect(await count(db, categories, eq(categories.householdId, hh))).toBe(1);
+      expect(await count(db, budgets, eq(budgets.householdId, hh))).toBe(1);
+      expect(await count(db, session, eq(session.userId, uid))).toBe(1);
+    });
+
+    it("does not touch another household's data", async () => {
+      const a = await seedHousehold(db, "iso-a");
+      const b = await seedHousehold(db, "iso-b");
+
+      await deleteFinancialData(a.hh, { db, revokePlaidItem: async () => {} });
+
+      expect(await count(db, accounts, eq(accounts.householdId, a.hh))).toBe(0);
+      expect(await count(db, accounts, eq(accounts.householdId, b.hh))).toBe(1);
+      expect(await count(db, transactions, eq(transactions.householdId, b.hh))).toBe(1);
+      expect(await count(db, plaidItems, eq(plaidItems.householdId, b.hh))).toBe(1);
+    });
+  });
+
+  describe("deleteAccount", () => {
+    it("erases everything including login, sessions, and oauth grants", async () => {
+      const { hh, uid } = await seedHousehold(db, "acct");
+      const revoked: string[] = [];
+
+      await deleteAccount(hh, uid, {
+        db,
+        revokePlaidItem: async (token) => {
+          revoked.push(token);
+        },
+      });
+
+      expect(revoked).toEqual(["enc-token-acct"]);
+
+      // Household + all its data (cascade).
+      expect(await count(db, households, eq(households.id, hh))).toBe(0);
+      expect(await count(db, accounts, eq(accounts.householdId, hh))).toBe(0);
+      expect(await count(db, transactions, eq(transactions.householdId, hh))).toBe(0);
+      expect(await count(db, categories, eq(categories.householdId, hh))).toBe(0);
+      expect(await count(db, budgets, eq(budgets.householdId, hh))).toBe(0);
+      expect(await count(db, plaidItems, eq(plaidItems.householdId, hh))).toBe(0);
+
+      // User + login artifacts.
+      expect(await count(db, user, eq(user.id, uid))).toBe(0);
+      expect(await count(db, session, eq(session.userId, uid))).toBe(0);
+      expect(await count(db, authAccount, eq(authAccount.userId, uid))).toBe(0);
+      expect(await count(db, userSettings, eq(userSettings.userId, uid))).toBe(0);
+
+      // OAuth grants (no FK cascade — must be cleaned manually).
+      expect(await count(db, oauthCodes, eq(oauthCodes.userId, uid))).toBe(0);
+      expect(await count(db, oauthRefreshTokens, eq(oauthRefreshTokens.userId, uid))).toBe(0);
+      expect(await count(db, oauthConsents, eq(oauthConsents.userId, uid))).toBe(0);
+    });
+
+    it("does not touch another user's account", async () => {
+      const a = await seedHousehold(db, "del-a");
+      const b = await seedHousehold(db, "del-b");
+
+      await deleteAccount(a.hh, a.uid, { db, revokePlaidItem: async () => {} });
+
+      expect(await count(db, user, eq(user.id, a.uid))).toBe(0);
+      expect(await count(db, user, eq(user.id, b.uid))).toBe(1);
+      expect(await count(db, households, eq(households.id, b.hh))).toBe(1);
+      expect(await count(db, oauthConsents, eq(oauthConsents.userId, b.uid))).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Gives Ledgr a true **data-erasure** capability — closing the last open gap (Q11 data deletion / retention) in the Plaid production security questionnaire. Previously, disconnecting a Plaid item only soft-deleted accounts and left all transactions/holdings in the database.

## What's added
Two destructive actions in **Settings → Danger zone**, each behind a type-to-confirm dialog:

1. **Delete all financial data** — revokes every Plaid item, then erases accounts, transactions, splits, investments, balances, plaid items, and recurring. **Keeps** login, categories, budgets.
2. **Delete account** — the above + erases the household (categories, budgets, merchants, saved reports, memberships), the user, sessions, auth accounts, oauth grants, and user settings. Signs out and redirects.

## Implementation notes
- `lib/account-deletion.ts` deletes the transaction subtree + budgets **before** the `households` cascade. This matters: `transaction_splits`, `budget_categories`, and `recurring` hold `NO ACTION` back-references to `categories`/`merchants`, so a naive `DELETE households` aborts mid-cascade (Postgres 23503). Integration tests caught this and drove the fix.
- Server actions are gated by `authorizeAction()` (blocks demo mode).
- Plaid revocation is best-effort — a Plaid failure never blocks local erasure.

## Tests
Integration tests (real Postgres) prove each action erases exactly the right tables, keeps what it should, and never touches another household/user. **4/4 pass**; typecheck + eslint clean.

## Verification
The risky part — cascade/erasure correctness — is exercised end-to-end against Postgres (it already caught the FK-ordering bug). UI is a standard confirm-dialog pattern; mock previewed and approved before build.

Depends conceptually on #5 (PRIVACY.md already documents this deletion capability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LD2C6UQoJX2kiekzyeu6bm