### PR TITLE
refactor(passkeys): optimistic list update on passkey removal

### DIFF
--- a/src/components/organisms/passkeys-manager.tsx
+++ b/src/components/organisms/passkeys-manager.tsx
@@ -87,7 +87,8 @@ export function PasskeysManager() {
         setError("Couldn't remove that passkey. Please try again.");
         return;
       }
-      await refresh();
+      // The removed id is known — update locally instead of re-fetching the list.
+      setPasskeys((prev) => prev.filter((p) => p.id !== id));
     } catch {
       setError("Couldn't remove that passkey. Please try again.");
     } finally {


### PR DESCRIPTION
From /simplify. Removes a redundant `listUserPasskeys()` network round-trip after a successful passkey deletion — the removed id is known, so the list is updated in state directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LD2C6UQoJX2kiekzyeu6bm