### PR TITLE
feat(mcp): add get_net_worth_history tool (+ fix passkey migration)

### DIFF
--- a/src/db/migrations/0003_mysterious_exiles.sql
+++ b/src/db/migrations/0003_mysterious_exiles.sql
@@ -12,6 +12,6 @@ CREATE TABLE "passkey" (
 	"aaguid" text
 );
 --> statement-breakpoint
-ALTER TABLE "passkey" ADD CONSTRAINT "passkey_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "passkey" ADD CONSTRAINT "passkey_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "passkey_userId_idx" ON "passkey" USING btree ("user_id");--> statement-breakpoint
 CREATE INDEX "passkey_credentialID_idx" ON "passkey" USING btree ("credential_id");

--- a/src/lib/mcp/tools/dashboard.test.ts
+++ b/src/lib/mcp/tools/dashboard.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "vitest";
+import { formatNetWorthHistory } from "./dashboard";
+import type { NetWorthPoint } from "@/queries/dashboard";
+
+describe("formatNetWorthHistory", () => {
+  test("maps each point to cents plus display values for assets, liabilities, and net worth", () => {
+    const points: NetWorthPoint[] = [
+      { date: "2026-06-01", assets: 1_000_00, liabilities: 250_00, netWorth: 750_00 },
+    ];
+
+    expect(formatNetWorthHistory(points)).toEqual([
+      {
+        date: "2026-06-01",
+        assetsCents: 100_000,
+        assetsDisplay: "$1,000.00",
+        liabilitiesCents: 25_000,
+        liabilitiesDisplay: "$250.00",
+        netWorthCents: 75_000,
+        netWorthDisplay: "$750.00",
+      },
+    ]);
+  });
+
+  test("preserves order and handles negative net worth", () => {
+    const points: NetWorthPoint[] = [
+      { date: "2026-05-01", assets: 100_00, liabilities: 400_00, netWorth: -300_00 },
+      { date: "2026-06-01", assets: 500_00, liabilities: 100_00, netWorth: 400_00 },
+    ];
+
+    const result = formatNetWorthHistory(points);
+
+    expect(result.map((p) => p.date)).toEqual(["2026-05-01", "2026-06-01"]);
+    expect(result[0].netWorthCents).toBe(-30_000);
+    expect(result[0].netWorthDisplay).toBe("-$300.00");
+  });
+
+  test("returns an empty array for no points", () => {
+    expect(formatNetWorthHistory([])).toEqual([]);
+  });
+});

--- a/src/lib/mcp/tools/dashboard.ts
+++ b/src/lib/mcp/tools/dashboard.ts
@@ -1,8 +1,36 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getDashboardSummary } from "@/queries/dashboard";
+import { z } from "zod";
+import type { NetWorthPoint } from "@/queries/dashboard";
+import { getDashboardSummary, getNetWorthHistory } from "@/queries/dashboard";
 import { centsToDisplay } from "@/lib/money";
 import { READ_ANNOTATIONS } from "../constants";
 import { jsonResult } from "../tool-result";
+
+export interface NetWorthHistoryEntry {
+  date: string;
+  assetsCents: number;
+  assetsDisplay: string;
+  liabilitiesCents: number;
+  liabilitiesDisplay: string;
+  netWorthCents: number;
+  netWorthDisplay: string;
+}
+
+/**
+ * Map a net-worth series onto the MCP wire shape: every figure carries both the
+ * raw cents (for agents doing math) and a formatted display string.
+ */
+export function formatNetWorthHistory(points: NetWorthPoint[]): NetWorthHistoryEntry[] {
+  return points.map((p) => ({
+    date: p.date,
+    assetsCents: p.assets,
+    assetsDisplay: centsToDisplay(p.assets),
+    liabilitiesCents: p.liabilities,
+    liabilitiesDisplay: centsToDisplay(p.liabilities),
+    netWorthCents: p.netWorth,
+    netWorthDisplay: centsToDisplay(p.netWorth),
+  }));
+}
 
 export function registerDashboardTools(server: McpServer, householdId: string) {
   server.registerTool(
@@ -26,6 +54,26 @@ export function registerDashboardTools(server: McpServer, householdId: string) {
         monthlyNetCents: s.monthlyNet,
         monthlyNetDisplay: centsToDisplay(s.monthlyNet),
       });
+    },
+  );
+
+  server.registerTool(
+    "get_net_worth_history",
+    {
+      title: "Get Net Worth History",
+      description:
+        "Get the household net-worth trend over time as a dated series of assets, liabilities, and net worth. The final point reflects today's live balances.",
+      inputSchema: {
+        range: z
+          .enum(["1M", "3M", "6M", "1Y", "all"])
+          .optional()
+          .describe("Time window for the series. Defaults to '6M'."),
+      },
+      annotations: READ_ANNOTATIONS,
+    },
+    async ({ range }) => {
+      const points = await getNetWorthHistory(householdId, range ?? "6M");
+      return jsonResult(formatNetWorthHistory(points));
     },
   );
 }

--- a/tests/integration/mcp-net-worth-history.test.ts
+++ b/tests/integration/mcp-net-worth-history.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { v4 as uuid } from "uuid";
+import { createTestDb } from "./setup";
+import { insertHousehold, insertAccount } from "./helpers";
+import { balanceHistory } from "../../src/db/schema";
+import { getNetWorthHistory } from "../../src/queries/dashboard";
+import { formatNetWorthHistory } from "../../src/lib/mcp/tools/dashboard";
+import type { LedgrDb } from "../../src/db";
+
+// End-to-end coverage for the get_net_worth_history MCP tool's data path:
+// real balance_history SQL → formatNetWorthHistory → agent-facing wire shape.
+// The only thing not exercised here is the SDK JSON-RPC transport, which is
+// shared, unchanged plumbing identical to every other read tool.
+
+let db: LedgrDb;
+let close: () => Promise<void>;
+
+beforeEach(async () => {
+  ({ db, close } = await createTestDb());
+});
+
+afterEach(async () => {
+  await close();
+});
+
+function firstOfLastMonth(): string {
+  const d = new Date();
+  d.setUTCDate(1);
+  d.setUTCMonth(d.getUTCMonth() - 1);
+  return d.toISOString().slice(0, 10);
+}
+
+describe("get_net_worth_history tool data path", () => {
+  it("returns a dated series with cents and display for real balance history", async () => {
+    const { householdId } = await insertHousehold(db);
+    const { accountId: checkingId } = await insertAccount(db, householdId, {
+      type: "checking",
+      currentBalance: 80000,
+    });
+    const { accountId: creditId } = await insertAccount(db, householdId, {
+      type: "credit",
+      currentBalance: 20000,
+    });
+
+    const histDate = firstOfLastMonth();
+    await db.insert(balanceHistory).values({ id: uuid(), accountId: checkingId, date: histDate, balance: 70000 });
+    await db.insert(balanceHistory).values({ id: uuid(), accountId: creditId, date: histDate, balance: 15000 });
+
+    const points = await getNetWorthHistory(householdId, "3M", db);
+    const wire = formatNetWorthHistory(points);
+
+    const historical = wire.find((p) => p.date === histDate);
+    expect(historical).toEqual({
+      date: histDate,
+      assetsCents: 70000,
+      assetsDisplay: "$700.00",
+      liabilitiesCents: 15000,
+      liabilitiesDisplay: "$150.00",
+      netWorthCents: 55000,
+      netWorthDisplay: "$550.00",
+    });
+
+    const today = new Date().toISOString().slice(0, 10);
+    const todayPoint = wire.find((p) => p.date === today);
+    expect(todayPoint).toEqual({
+      date: today,
+      assetsCents: 80000,
+      assetsDisplay: "$800.00",
+      liabilitiesCents: 20000,
+      liabilitiesDisplay: "$200.00",
+      netWorthCents: 60000,
+      netWorthDisplay: "$600.00",
+    });
+  });
+
+  it("returns an empty series when no account carries a balance", async () => {
+    const { householdId } = await insertHousehold(db);
+    await insertAccount(db, householdId, { type: "checking", currentBalance: null });
+
+    const wire = formatNetWorthHistory(await getNetWorthHistory(householdId, "6M", db));
+
+    expect(wire).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new read-scope MCP tool **`get_net_worth_history`** — exposes the household net-worth trend so agents can answer "how's my net worth tracking?", the single most-asked PFM question and the top gap vs Copilot Money's official MCP server.

Also fixes a pre-existing migration bug (found while verifying) that was silently breaking the **entire integration test suite + CI integration stage**.

## Changes

**`feat(mcp): add get_net_worth_history tool`**
- New tool in `registerDashboardTools`, reusing the existing `getNetWorthHistory` SQL aggregation.
- `range` param: `1M | 3M | 6M | 1Y | all` (default `6M`).
- Returns a dated series; each point carries both raw cents and formatted display for assets, liabilities, and net worth. Final point reflects today's live balances.
- Display mapping factored into a pure `formatNetWorthHistory()` (unit-tested).

**`fix(db): drop stray public. qualifier on passkey→user FK`**
- Migration `0003` was the only schema-qualified FK in the migration set (`REFERENCES "public"."user"`), while all 34 FKs in `0000` are unqualified and match the `pgTable` source. Under the integration test factory's per-schema isolation (search_path pinned to a throwaway `test_<uuid>` schema), `public.user` doesn't exist → `migrate` threw → every integration test failed. Dropping the qualifier lets the FK resolve via `search_path`.

## Testing

- `formatNetWorthHistory` unit tests — 3/3 ✅
- `get_net_worth_history` integration test against real Postgres (seeded `balance_history` → real SQL → formatter → asserted wire shape incl. synthetic today point + empty-series case) — 2/2 ✅
- Previously-broken `dashboard-queries` integration suite — 13/13 ✅ (was 0)
- `pnpm typecheck` + `eslint` — clean

## Notes for reviewers

- The migration fix is a separate commit so it's bisectable on its own; it's worth landing regardless of the feature since it re-enables CI's integration stage.
- Any persistent DB that already applied the old `0003` will see a changed migration hash and should be re-synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166uNkZpgHhjtx4qW1oBaVn