### PR TITLE
ci(mutation): diff-scope Stryker to changed files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,14 @@ jobs:
       - run: pnpm test
 
   mutation:
-    name: mutation (incremental)
+    name: mutation (diff)
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    # Non-blocking for now. Stryker is verified working against the
-    # testcontainers suite locally (score 67% >= 60 break threshold), but a
-    # full cold-cache run over lib+actions+queries has not been timed in CI.
-    # It runs and reports; it does not gate merges. Flip to blocking (remove
-    # this) once a full run is observed green and acceptably fast in CI.
+    # Diff-scoped: only the source files changed in the PR are mutated, so runs
+    # take minutes instead of a full sweep. Non-blocking (reports only): Stryker
+    # currently runs just the unit suite, so files covered mainly by integration
+    # tests score artificially low — a blocking gate would fail legitimate PRs.
+    # Flip to blocking once the mutation harness also runs the integration suite.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
@@ -61,13 +61,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Restore the incremental baseline so unchanged files are not re-mutated.
-      - uses: actions/cache@v4
-        with:
-          path: reports/mutation/.stryker-incremental.json
-          key: stryker-${{ github.head_ref }}-${{ github.sha }}
-          restore-keys: |
-            stryker-${{ github.head_ref }}-
-            stryker-
-
-      - run: pnpm test:mutate:incremental
+      - name: Mutation test changed files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/mutate-diff.sh "$BASE_SHA" "$HEAD_SHA"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:mutate": "stryker run",
     "test:mutate:incremental": "stryker run --incremental",
+    "test:mutate:diff": "bash scripts/mutate-diff.sh",
     "test:changed": "vitest related --run $(git diff --name-only HEAD)",
     "prepare": "simple-git-hooks",
     "build:mcp-widgets": "tsx src/lib/mcp/apps/build.ts",

--- a/scripts/mutate-diff.sh
+++ b/scripts/mutate-diff.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run Stryker mutation testing over only the source files changed between BASE
+# and HEAD (defaults: origin/main .. working tree). Keeps PR runs to minutes
+# instead of a full cold sweep. Exits 0 when no mutatable source changed.
+#
+# Uses a two-dot diff of explicit commits so CI can pass the PR's exact base and
+# head SHAs — a three-dot/merge-base diff against a moving branch tip pulls in
+# files the PR never touched.
+set -euo pipefail
+
+BASE="${1:-origin/main}"
+HEAD="${2:-HEAD}"
+
+FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" "$HEAD" -- \
+  src/lib src/actions src/queries \
+  | grep -E '\.ts$' | grep -vE '\.test\.ts$' || true)
+
+if [ -z "$FILES" ]; then
+  echo "No mutatable source changed between ${BASE} and ${HEAD} — skipping mutation testing."
+  exit 0
+fi
+
+echo "Mutation-testing changed files:"
+echo "$FILES" | sed 's/^/  /'
+
+MUTATE=$(echo "$FILES" | paste -sd, -)
+exec pnpm exec stryker run --mutate "$MUTATE"

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -24,7 +24,5 @@
   "reporters": ["html", "clear-text", "progress"],
   "htmlReporter": {
     "fileName": "reports/mutation/mutation.html"
-  },
-  "incremental": true,
-  "incrementalFile": "reports/mutation/.stryker-incremental.json"
+  }
 }


### PR DESCRIPTION
Replaces #22 (which was accidentally cut from a contaminated base and carried commits from #23). This branch contains **only** the mutation-CI change, cleanly on `main`.

## What
The `mutation` job ran a full cold sweep on every PR (~108 min) and always timed out (incremental cache never populated on a fresh runner). Now **diff-scoped**: `scripts/mutate-diff.sh` diffs the PR's exact base..head SHAs for changed source under `lib/actions/queries` and passes them to `stryker --mutate` → minutes, or an instant skip when nothing mutatable changed. Dropped `incremental` from `stryker.config.json` (it reloaded a stale report and pulled in unrelated files).

**Non-blocking** (reports only): Stryker currently runs only the unit suite, so integration-covered files score artificially low — a gate would fail legit PRs. Flip to blocking once the harness runs integration tests too.

This PR changes no mutatable source, so the mutation job **skips and passes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LD2C6UQoJX2kiekzyeu6bm