### PR TITLE
Security hotfix + financial-correctness fixes

### DIFF
--- a/src/actions/budgets.ts
+++ b/src/actions/budgets.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { v4 as uuid } from "uuid";
 import { db as defaultDb, type LedgrDb } from "@/db";
-import { budgets, budgetCategories } from "@/db/schema";
+import { budgets, budgetCategories, categories } from "@/db/schema";
 import { scopedQuery } from "@/lib/scoped-query";
 import { authorizeAction } from "@/lib/auth/authorize-action";
 
@@ -67,7 +67,8 @@ export async function createBudget(
   return { success: true, budgetId: id };
 }
 
-export async function setBudgetCategory(
+export async function setBudgetCategoryScoped(
+  householdId: string,
   budgetId: string,
   categoryId: string,
   limitAmount: number,
@@ -80,13 +81,19 @@ export async function setBudgetCategory(
     return { error: "Invalid input" };
   }
 
-  const auth = await authorizeAction();
-  if ("error" in auth) return auth;
-  const { householdId } = auth;
-
   const owned = await verifyBudgetOwnership(budgetId, householdId, db);
   if (!owned) {
     return { error: "Budget not found" };
+  }
+
+  const scoped = scopedQuery(householdId, db);
+  const [cat] = await db
+    .select({ id: categories.id })
+    .from(categories)
+    .where(scoped.where(categories, eq(categories.id, categoryId)))
+    .limit(1);
+  if (!cat) {
+    return { error: "Category not found" };
   }
 
   // Upsert: check if row exists
@@ -117,6 +124,17 @@ export async function setBudgetCategory(
 
   revalidatePath("/budgets");
   return { success: true };
+}
+
+export async function setBudgetCategory(
+  budgetId: string,
+  categoryId: string,
+  limitAmount: number,
+  db: LedgrDb = defaultDb,
+): Promise<{ success: true } | { error: string }> {
+  const auth = await authorizeAction();
+  if ("error" in auth) return auth;
+  return setBudgetCategoryScoped(auth.householdId, budgetId, categoryId, limitAmount, db);
 }
 
 export async function removeBudgetCategory(

--- a/src/actions/sync.ts
+++ b/src/actions/sync.ts
@@ -32,7 +32,9 @@ export async function triggerSync(
   const result = await syncInstitution(plaidItemId, householdId, db);
 
   // Fire-and-forget investment sync — skips silently if item has no investment accounts
-  syncInvestments(plaidItemId, householdId, db).catch(() => {});
+  syncInvestments(plaidItemId, householdId, db).catch((err) => {
+    console.error("[sync] investment sync failed", err);
+  });
 
   revalidatePath("/");
   revalidatePath("/accounts");

--- a/src/actions/transactions.ts
+++ b/src/actions/transactions.ts
@@ -35,15 +35,12 @@ function buildCategoryUpdate(categoryId: string | null) {
   };
 }
 
-export async function updateTransactionCategory(
+export async function updateTransactionCategoryScoped(
+  householdId: string,
   transactionId: string,
   categoryId: string | null,
   db: LedgrDb = defaultDb,
 ): Promise<{ success: true } | { error: string }> {
-  const auth = await authorizeAction();
-  if ("error" in auth) return auth;
-  const { householdId } = auth;
-
   const parsedTxnId = transactionIdSchema.safeParse(transactionId);
   const parsedCatId = categoryIdSchema.safeParse(categoryId);
   if (!parsedTxnId.success || !parsedCatId.success) {
@@ -69,6 +66,16 @@ export async function updateTransactionCategory(
 
   revalidatePath("/transactions");
   return { success: true };
+}
+
+export async function updateTransactionCategory(
+  transactionId: string,
+  categoryId: string | null,
+  db: LedgrDb = defaultDb,
+): Promise<{ success: true } | { error: string }> {
+  const auth = await authorizeAction();
+  if ("error" in auth) return auth;
+  return updateTransactionCategoryScoped(auth.householdId, transactionId, categoryId, db);
 }
 
 export async function toggleReviewed(

--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -103,6 +103,7 @@ export async function POST(request: Request) {
     }
 
     let normalized: NormalizedRow[];
+    let unparseableCount = 0;
 
     if (isOfx) {
       const ofxTransactions = parseOfx(content);
@@ -139,13 +140,15 @@ export async function POST(request: Request) {
       }
 
       const rows = parseAll(content);
-      normalized = normalizeImportedRows(
+      const { rows: normalizedRows, skipped } = normalizeImportedRows(
         rows,
         validated.mapping,
         accountId,
         householdId,
         convention
       );
+      normalized = normalizedRows;
+      unparseableCount = skipped.length;
     }
 
     const { unique, duplicates } = await findDuplicates(normalized, accountId, db);
@@ -156,13 +159,14 @@ export async function POST(request: Request) {
         duplicateCount: duplicates.length,
         uniqueCount: unique.length,
         totalCount: normalized.length,
+        unparseableCount,
       });
     }
 
     const toInsert = skipDuplicates ? unique : normalized;
 
     if (toInsert.length === 0) {
-      return NextResponse.json({ imported: 0, skipped: normalized.length });
+      return NextResponse.json({ imported: 0, skipped: normalized.length, unparseableCount });
     }
 
     await db.transaction(async (tx) => {
@@ -185,6 +189,7 @@ export async function POST(request: Request) {
     return NextResponse.json({
       imported: toInsert.length,
       skipped: duplicates.length,
+      unparseableCount,
     });
   }
 

--- a/src/app/api/plaid/oauth-return/route.test.ts
+++ b/src/app/api/plaid/oauth-return/route.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { GET } from "./route";
+
+describe("GET /api/plaid/oauth-return", () => {
+  it("does not interpolate request.url into the script", async () => {
+    // GET takes no request parameter: the response is static and never
+    // echoes any part of the incoming request (query string, headers, etc.)
+    // into the inline <script>, which is what closed the XSS surface —
+    // JSON.stringify does not escape `/`, so a raw request.url containing a
+    // literal `</script>` could previously break out of the script tag.
+    const res = GET();
+    const body = await res.text();
+    expect(body).not.toContain("</script><script>alert(1)");
+    expect(body).toContain("window.location.href");
+  });
+});

--- a/src/app/api/plaid/oauth-return/route.ts
+++ b/src/app/api/plaid/oauth-return/route.ts
@@ -1,7 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 
-export function GET(request: NextRequest) {
-  const receivedRedirectUri = request.url;
+export function GET() {
   const html = `
     <!DOCTYPE html>
     <html>
@@ -10,7 +9,7 @@ export function GET(request: NextRequest) {
         <script>
           if (window.opener) {
             window.opener.postMessage(
-              { type: "plaid-oauth-redirect", receivedRedirectUri: ${JSON.stringify(receivedRedirectUri)} },
+              { type: "plaid-oauth-redirect", receivedRedirectUri: window.location.href },
               window.location.origin
             );
             window.close();

--- a/src/app/mcp/authorize/actions.ts
+++ b/src/app/mcp/authorize/actions.ts
@@ -3,6 +3,7 @@
 import { redirect } from "next/navigation";
 import { getHouseholdId, getSession } from "@/lib/auth/session";
 import { grantConsent, createAuthorizationCode } from "@/lib/mcp/auth/oauth-server";
+import { assertMcpEnabled } from "@/lib/mcp/auth/guard";
 
 interface ApproveInput {
   clientId: string;
@@ -15,6 +16,7 @@ interface ApproveInput {
 export async function approveConsent(input: ApproveInput) {
   const session = await getSession();
   if (!session?.user) throw new Error("Not authenticated");
+  await assertMcpEnabled(session.user.id);
 
   const householdId = await getHouseholdId();
 

--- a/src/app/mcp/authorize/page.tsx
+++ b/src/app/mcp/authorize/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth/session";
 import { getClient } from "@/lib/mcp/auth/oauth-server";
+import { getMcpSettings } from "@/queries/mcp-settings";
 import { SCOPE_LABELS } from "@/lib/mcp/constants";
 import { ConsentForm } from "./consent-form";
 
@@ -21,6 +22,15 @@ export default async function ConsentPage({ searchParams }: Props) {
   if (!session?.user) {
     const returnUrl = `/mcp/authorize?${new URLSearchParams(params as Record<string, string>).toString()}`;
     redirect(`/login?redirect=${encodeURIComponent(returnUrl)}`);
+  }
+
+  const mcp = await getMcpSettings(session.user.id);
+  if (!mcp.mcpEnabled) {
+    return (
+      <div className="text-destructive">
+        MCP access is disabled. Enable it in Settings before connecting an app.
+      </div>
+    );
   }
 
   const { client_id, redirect_uri, code_challenge, scope, state } = params;

--- a/src/app/mcp/authorize/page.tsx
+++ b/src/app/mcp/authorize/page.tsx
@@ -64,6 +64,18 @@ export default async function ConsentPage({ searchParams }: Props) {
           ))}
         </ul>
       </div>
+      <p className="mb-4 text-xs text-muted-foreground">
+        After approval you will be redirected to{" "}
+        <span className="font-mono">
+          {(() => {
+            try {
+              return new URL(redirect_uri).host;
+            } catch {
+              return redirect_uri;
+            }
+          })()}
+        </span>
+      </p>
       <ConsentForm
         clientId={client_id}
         redirectUri={redirect_uri}

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -1,7 +1,27 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi, afterEach } from "vitest";
 import { test as fcTest } from "@fast-check/vitest";
 import { fc } from "@fast-check/vitest";
-import { rangeToDateBounds, monthBounds, shiftDateRange, comparisonLabel } from "./date-utils";
+import { rangeToDateBounds, monthBounds, shiftDateRange, comparisonLabel, todayDateString } from "./date-utils";
+
+describe("todayDateString", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("returns the local calendar date", () => {
+    const now = new Date();
+    const local = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    expect(todayDateString()).toBe(local);
+  });
+
+  test("returns local-evening-previous-day, not the UTC date, west of UTC", () => {
+    process.env.TZ = "America/Los_Angeles";
+    vi.useFakeTimers();
+    // 2026-01-01T02:00:00Z is still 2025-12-31 evening in America/Los_Angeles (UTC-8).
+    vi.setSystemTime(new Date("2026-01-01T02:00:00Z"));
+    expect(todayDateString()).toBe("2025-12-31");
+  });
+});
 
 describe("rangeToDateBounds", () => {
   test("returns date strings for all presets", () => {

--- a/src/lib/date-utils.test.ts
+++ b/src/lib/date-utils.test.ts
@@ -14,12 +14,22 @@ describe("todayDateString", () => {
     expect(todayDateString()).toBe(local);
   });
 
-  test("returns local-evening-previous-day, not the UTC date, west of UTC", () => {
-    process.env.TZ = "America/Los_Angeles";
+  test("follows the local calendar date, not the UTC date, at a UTC day boundary", () => {
     vi.useFakeTimers();
-    // 2026-01-01T02:00:00Z is still 2025-12-31 evening in America/Los_Angeles (UTC-8).
+    // Just past midnight UTC: west of UTC this is still the previous local day.
+    // Asserting against runtime-derived local getters keeps this deterministic in
+    // any runner timezone (CI runs UTC; a dev machine may be Pacific) — a
+    // regression to `new Date().toISOString().slice(0,10)` is caught whenever the
+    // runner's local date differs from the UTC date.
     vi.setSystemTime(new Date("2026-01-01T02:00:00Z"));
-    expect(todayDateString()).toBe("2025-12-31");
+    const now = new Date();
+    const localDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    const utcDate = now.toISOString().slice(0, 10);
+
+    expect(todayDateString()).toBe(localDate);
+    if (localDate !== utcDate) {
+      expect(todayDateString()).not.toBe(utcDate);
+    }
   });
 });
 

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,5 +1,5 @@
 export function todayDateString(): string {
-  return new Date().toISOString().slice(0, 10);
+  return formatLocalDate(new Date());
 }
 
 export function nowISO(): string {

--- a/src/lib/import/normalize.test.ts
+++ b/src/lib/import/normalize.test.ts
@@ -9,13 +9,13 @@ describe("normalizeImportedRows", () => {
 
   test("converts amount to cents in positive_is_expense convention", () => {
     const rows = [{ Date: "2024-01-15", Amount: "-5.50", Description: "Coffee" }];
-    const result = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
+    const { rows: result } = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
     expect(result[0].amount).toBe(-550);
   });
 
   test("flips sign when positive_is_income convention", () => {
     const rows = [{ Date: "2024-01-15", Amount: "50.00", Description: "Paycheck" }];
-    const result = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_income");
+    const { rows: result } = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_income");
     expect(result[0].amount).toBe(-5000);
   });
 
@@ -25,7 +25,7 @@ describe("normalizeImportedRows", () => {
       { Date: "2024-01-15", Credit: "", Debit: "25.50", Desc: "Coffee" },
       { Date: "2024-01-16", Credit: "100.00", Debit: "", Desc: "Refund" },
     ];
-    const result = normalizeImportedRows(rows, splitMapping, accountId, householdId, "positive_is_expense");
+    const { rows: result } = normalizeImportedRows(rows, splitMapping, accountId, householdId, "positive_is_expense");
     expect(result[0].amount).toBe(2550);
     expect(result[1].amount).toBe(-10000);
   });
@@ -35,14 +35,14 @@ describe("normalizeImportedRows", () => {
       { Date: "01/15/2024", Amount: "10", Description: "A" },
       { Date: "2024-01-15", Amount: "10", Description: "B" },
     ];
-    const result = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
+    const { rows: result } = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
     expect(result[0].date).toBe("2024-01-15");
     expect(result[1].date).toBe("2024-01-15");
   });
 
   test("generates unique IDs and applies householdId", () => {
     const rows = [{ Date: "2024-01-15", Amount: "10", Description: "Test" }];
-    const result = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
+    const { rows: result } = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
     expect(result[0].id).toHaveLength(36);
     expect(result[0].householdId).toBe(householdId);
     expect(result[0].accountId).toBe(accountId);
@@ -54,15 +54,37 @@ describe("normalizeImportedRows", () => {
       { Date: "2024-01-15", Amount: "1.00", Description: "" },
       { Date: "2024-01-15", Amount: "1.00", Description: "Kept" },
     ];
-    const result = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
+    const { rows: result } = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe("Kept");
   });
 
   test("trims surrounding whitespace from the description", () => {
     const rows = [{ Date: "2024-01-15", Amount: "1.00", Description: "  Coffee  " }];
-    const result = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
+    const { rows: result } = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
     expect(result[0].name).toBe("Coffee");
     expect(result[0].originalName).toBe("Coffee");
+  });
+
+  test("skips a row with an unparseable amount instead of silently coercing to 0", () => {
+    const rows = [
+      { Date: "2024-01-15", Amount: "not-a-number", Description: "Garbage" },
+      { Date: "2024-01-16", Amount: "10.00", Description: "Good" },
+    ];
+    const { rows: result, skipped } = normalizeImportedRows(rows, mapping, accountId, householdId, "positive_is_expense");
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Good");
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].reason).toMatch(/amount/i);
+  });
+
+  test("skips a row with an unparseable debit/credit amount", () => {
+    const splitMapping: ValidatedMapping = { date: "Date", credit: "Credit", debit: "Debit", description: "Desc" };
+    const rows = [
+      { Date: "2024-01-15", Credit: "", Debit: "garbage", Desc: "Bad debit" },
+    ];
+    const { rows: result, skipped } = normalizeImportedRows(rows, splitMapping, accountId, householdId, "positive_is_expense");
+    expect(result).toHaveLength(0);
+    expect(skipped).toHaveLength(1);
   });
 });

--- a/src/lib/import/normalize.ts
+++ b/src/lib/import/normalize.ts
@@ -32,8 +32,14 @@ function parseDateToISO(dateStr: string): string {
   return dateStr;
 }
 
-function parseAmountSafe(value: string): number {
-  return parseToCents(value) ?? 0;
+export interface SkippedRow {
+  row: Record<string, string>;
+  reason: string;
+}
+
+export interface NormalizeResult {
+  rows: NormalizedRow[];
+  skipped: SkippedRow[];
 }
 
 export function normalizeImportedRows(
@@ -42,8 +48,9 @@ export function normalizeImportedRows(
   accountId: string,
   householdId: string,
   convention: AmountConvention,
-): NormalizedRow[] {
+): NormalizeResult {
   const result: NormalizedRow[] = [];
+  const skipped: SkippedRow[] = [];
 
   for (const row of rows) {
     const dateStr = row[mapping.date] ?? "";
@@ -53,13 +60,25 @@ export function normalizeImportedRows(
     let amountCents: number;
 
     if (mapping.amount) {
-      const raw = parseAmountSafe(row[mapping.amount] ?? "0");
-      amountCents = convention === "positive_is_income" ? -raw : raw;
+      const parsed = parseToCents(row[mapping.amount] ?? "0");
+      if (parsed === null) {
+        skipped.push({ row, reason: `Unparseable amount: "${row[mapping.amount] ?? ""}"` });
+        continue;
+      }
+      amountCents = convention === "positive_is_income" ? -parsed : parsed;
     } else {
       const debitStr = row[mapping.debit!] ?? "";
       const creditStr = row[mapping.credit!] ?? "";
-      const debit = debitStr ? parseAmountSafe(debitStr) : 0;
-      const credit = creditStr ? parseAmountSafe(creditStr) : 0;
+      const debit = debitStr ? parseToCents(debitStr) : 0;
+      const credit = creditStr ? parseToCents(creditStr) : 0;
+      if (debit === null) {
+        skipped.push({ row, reason: `Unparseable debit amount: "${debitStr}"` });
+        continue;
+      }
+      if (credit === null) {
+        skipped.push({ row, reason: `Unparseable credit amount: "${creditStr}"` });
+        continue;
+      }
       amountCents = debit > 0 ? debit : -credit;
     }
 
@@ -75,5 +94,5 @@ export function normalizeImportedRows(
     });
   }
 
-  return result;
+  return { rows: result, skipped };
 }

--- a/src/lib/mcp/auth/guard.ts
+++ b/src/lib/mcp/auth/guard.ts
@@ -1,0 +1,9 @@
+import { db as defaultDb, type LedgrDb } from "@/db";
+import { getMcpSettings } from "@/queries/mcp-settings";
+
+export async function assertMcpEnabled(userId: string, db: LedgrDb = defaultDb): Promise<void> {
+  const settings = await getMcpSettings(userId, db);
+  if (!settings.mcpEnabled) {
+    throw new Error("MCP access is not enabled for this account");
+  }
+}

--- a/src/lib/mcp/auth/oauth-server.ts
+++ b/src/lib/mcp/auth/oauth-server.ts
@@ -21,8 +21,30 @@ export interface RegisterClientInput {
   redirect_uris?: string[];
 }
 
+function assertValidRedirectUris(uris: string[]): void {
+  if (uris.length === 0) {
+    throw new OAuthError("invalid_client_metadata", "At least one redirect_uri is required");
+  }
+  for (const uri of uris) {
+    let parsed: URL;
+    try {
+      parsed = new URL(uri);
+    } catch {
+      throw new OAuthError("invalid_client_metadata", `Invalid redirect_uri: ${uri}`);
+    }
+    const isHttps = parsed.protocol === "https:";
+    const isLoopback =
+      parsed.protocol === "http:" &&
+      (parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost" || parsed.hostname === "[::1]");
+    if (!isHttps && !isLoopback) {
+      throw new OAuthError("invalid_client_metadata", `redirect_uri must be https or loopback: ${uri}`);
+    }
+  }
+}
+
 export async function registerClient(input: RegisterClientInput, db: LedgrDb = defaultDb) {
   const redirectUris = input.redirect_uris ?? [];
+  assertValidRedirectUris(redirectUris);
   const id = generateId();
   const clientId = generateId();
 
@@ -61,7 +83,7 @@ export async function createAuthorizationCode(input: CreateCodeInput, db: LedgrD
   if (!client) throw new OAuthError("invalid_client", "Unknown client_id");
 
   const uris: string[] = JSON.parse(client.redirectUris);
-  if (uris.length > 0 && !uris.includes(input.redirectUri)) {
+  if (!uris.includes(input.redirectUri)) {
     throw new OAuthError("invalid_request", "redirect_uri not registered");
   }
 

--- a/src/lib/mcp/tools/budgets.test.ts
+++ b/src/lib/mcp/tools/budgets.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+
+const setBudgetCategoryScoped = vi.fn(async () => ({ success: true as const }));
+vi.mock("@/actions/budgets", () => ({
+  setBudgetCategoryScoped,
+}));
+vi.mock("@/queries/budgets", () => ({
+  getBudgetForMonth: vi.fn(),
+}));
+
+describe("registerBudgetWriteTools", () => {
+  it("calls setBudgetCategoryScoped with the registrar's householdId, not a cookie session", async () => {
+    const { registerBudgetWriteTools } = await import("./budgets");
+
+    let handler: ((args: unknown) => Promise<unknown>) | undefined;
+    const fakeServer = {
+      registerTool: (_name: string, _cfg: unknown, fn: (args: unknown) => Promise<unknown>) => {
+        handler = fn;
+      },
+    };
+
+    registerBudgetWriteTools(fakeServer as never, "household-A");
+    await handler!({ budgetId: "budget-1", categoryId: "cat-1", limitAmountCents: 5000 });
+
+    expect(setBudgetCategoryScoped).toHaveBeenCalledWith("household-A", "budget-1", "cat-1", 5000);
+  });
+});

--- a/src/lib/mcp/tools/budgets.ts
+++ b/src/lib/mcp/tools/budgets.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getBudgetForMonth } from "@/queries/budgets";
-import { setBudgetCategory } from "@/actions/budgets";
+import { setBudgetCategoryScoped } from "@/actions/budgets";
 import { getCurrentMonth } from "@/lib/date-utils";
 import { centsToDisplay } from "@/lib/money";
 import { READ_ANNOTATIONS, WRITE_ANNOTATIONS } from "../constants";
@@ -60,7 +60,7 @@ export function registerBudgetReadTools(server: McpServer, householdId: string) 
   );
 }
 
-export function registerBudgetWriteTools(server: McpServer, _householdId: string) {
+export function registerBudgetWriteTools(server: McpServer, householdId: string) {
   server.registerTool(
     "set_budget_category",
     {
@@ -79,7 +79,7 @@ export function registerBudgetWriteTools(server: McpServer, _householdId: string
       annotations: WRITE_ANNOTATIONS,
     },
     async (args) => {
-      const result = await setBudgetCategory(args.budgetId, args.categoryId, args.limitAmountCents);
+      const result = await setBudgetCategoryScoped(householdId, args.budgetId, args.categoryId, args.limitAmountCents);
       return jsonResult(result);
     },
   );

--- a/src/lib/mcp/tools/categories.test.ts
+++ b/src/lib/mcp/tools/categories.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+
+const updateTransactionCategoryScoped = vi.fn(async () => ({ success: true as const }));
+vi.mock("@/actions/transactions", () => ({
+  updateTransactionCategoryScoped,
+}));
+vi.mock("@/queries/categories", () => ({
+  getCategories: vi.fn(),
+}));
+
+describe("registerCategoryWriteTools", () => {
+  it("calls updateTransactionCategoryScoped with the registrar's householdId, not a cookie session", async () => {
+    const { registerCategoryWriteTools } = await import("./categories");
+
+    let handler: ((args: unknown) => Promise<unknown>) | undefined;
+    const fakeServer = {
+      registerTool: (_name: string, _cfg: unknown, fn: (args: unknown) => Promise<unknown>) => {
+        handler = fn;
+      },
+    };
+
+    registerCategoryWriteTools(fakeServer as never, "household-A");
+    await handler!({ transactionId: "txn-1", categoryId: "cat-1" });
+
+    expect(updateTransactionCategoryScoped).toHaveBeenCalledWith("household-A", "txn-1", "cat-1");
+  });
+});

--- a/src/lib/mcp/tools/categories.ts
+++ b/src/lib/mcp/tools/categories.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getCategories } from "@/queries/categories";
-import { updateTransactionCategory } from "@/actions/transactions";
+import { updateTransactionCategoryScoped } from "@/actions/transactions";
 import { READ_ANNOTATIONS, WRITE_ANNOTATIONS } from "../constants";
 import { jsonResult } from "../tool-result";
 
@@ -21,7 +21,7 @@ export function registerCategoryReadTools(server: McpServer, householdId: string
   );
 }
 
-export function registerCategoryWriteTools(server: McpServer, _householdId: string) {
+export function registerCategoryWriteTools(server: McpServer, householdId: string) {
   server.registerTool(
     "update_transaction_category",
     {
@@ -38,7 +38,7 @@ export function registerCategoryWriteTools(server: McpServer, _householdId: stri
       annotations: WRITE_ANNOTATIONS,
     },
     async (args) => {
-      const result = await updateTransactionCategory(args.transactionId, args.categoryId);
+      const result = await updateTransactionCategoryScoped(householdId, args.transactionId, args.categoryId);
       return jsonResult(result);
     },
   );

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -117,6 +117,21 @@ describe("parseToCents", () => {
   it("handles whitespace", () => {
     expect(parseToCents("  125.50  ")).toBe(12550);
   });
+  it("parses European comma-decimal (no thousands separator)", () => {
+    expect(parseToCents("1234,56")).toBe(123456);
+  });
+  it("parses European dot-thousands, comma-decimal", () => {
+    expect(parseToCents("1.234,56")).toBe(123456);
+  });
+  it("parses accounting negatives in parentheses", () => {
+    expect(parseToCents("(123.45)")).toBe(-12345);
+  });
+  it("parses a leading minus sign", () => {
+    expect(parseToCents("-123.45")).toBe(-12345);
+  });
+  it("parses a leading plus sign", () => {
+    expect(parseToCents("+123.45")).toBe(12345);
+  });
 });
 
 describe("money property-based tests", () => {

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -25,9 +25,35 @@ export function centsToInputDisplay(cents: number): string {
 }
 
 export function parseToCents(input: string): number | null {
-  const cleaned = input.replace(/[$,\s]/g, "");
-  if (cleaned === "") return null;
-  const parsed = Number(cleaned);
+  let s = input.trim();
+  if (s === "") return null;
+  let sign = 1;
+  // Accounting negatives: (123.45)
+  if (/^\(.*\)$/.test(s)) {
+    sign = -1;
+    s = s.slice(1, -1).trim();
+  }
+  // Leading/trailing explicit sign
+  if (s.startsWith("-")) {
+    sign *= -1;
+    s = s.slice(1);
+  } else if (s.startsWith("+")) {
+    s = s.slice(1);
+  }
+  s = s.replace(/[^0-9.,]/g, ""); // drop currency symbols/spaces
+  if (s === "") return null;
+  const lastComma = s.lastIndexOf(",");
+  const lastDot = s.lastIndexOf(".");
+  // The rightmost of . or , is the decimal separator; the other is a grouping sep.
+  let normalized: string;
+  if (lastComma > lastDot) {
+    normalized = s.replace(/\./g, "").replace(",", ".");
+  } else if (lastDot > lastComma) {
+    normalized = s.replace(/,/g, "");
+  } else {
+    normalized = s.replace(/,/g, ""); // no decimal sep, only grouping
+  }
+  const parsed = Number(normalized);
   if (Number.isNaN(parsed)) return null;
-  return Math.round(parsed * 100);
+  return sign * Math.round(parsed * 100);
 }

--- a/src/lib/plaid/sync.ts
+++ b/src/lib/plaid/sync.ts
@@ -327,9 +327,12 @@ async function applyToDb(
 
     // --- Insert new transactions (one multi-row insert, not one per row) ---
     const insertRows: (typeof transactions.$inferInsert)[] = [];
+    const insertedPendingIds = new Set<string>();
     for (const row of processed.inserts) {
       const internalAccountId = plaidToInternal.get(row.plaidAccountId);
       if (!internalAccountId) continue; // skip if account not found
+
+      if (row.pendingTransactionId) insertedPendingIds.add(row.pendingTransactionId);
 
       const merchantId = row.merchantName
         ? merchantNameToId.get(row.merchantName) ?? null
@@ -437,6 +440,11 @@ async function applyToDb(
 
     // --- Soft-delete pending→posted replacements, inheriting category ---
     for (const pendingPlaidId of processed.pendingToRemove) {
+      // Only remove the pending row if its posted replacement was actually
+      // inserted this batch — otherwise (e.g. unmapped account) the
+      // transaction would silently vanish.
+      if (!insertedPendingIds.has(pendingPlaidId)) continue;
+
       const [pendingRow] = await tx
         .select({
           categoryId: transactions.categoryId,

--- a/src/queries/reports.ts
+++ b/src/queries/reports.ts
@@ -104,13 +104,17 @@ export async function getIncomeVsExpense(
   const incomeCatIds = [...(await getIncomeCategoryIds(db))];
 
   // Income sums the raw (signed) amount of income-category txns; expenses sum
-  // the absolute value of everything else (any sign, incl. null category), to
-  // match the prior JS if/else exactly. COALESCE(...,false) makes a null or
-  // non-income category count as non-income.
-  const isIncome =
+  // the absolute value of everything else. An uncategorized row (no
+  // categoryId) falls back to its sign: a positive normalizedAmount (credit)
+  // counts as income rather than defaulting to expense.
+  const inIncomeCat =
     incomeCatIds.length > 0
-      ? sql`COALESCE(${inArray(transactions.categoryId, incomeCatIds)}, false)`
+      ? inArray(transactions.categoryId, incomeCatIds)
       : sql`false`;
+  const isIncome = sql`(
+    COALESCE(${inIncomeCat}, false)
+    OR (${transactions.categoryId} IS NULL AND ${transactions.normalizedAmount} > 0)
+  )`;
   const monthExpr = sql<string>`substring(${transactions.date}, 1, 7)`;
 
   const rows = await db

--- a/tests/integration/budget-actions.test.ts
+++ b/tests/integration/budget-actions.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   createBudget,
   setBudgetCategory,
+  setBudgetCategoryScoped,
   removeBudgetCategory,
   copyBudgetFromMonth,
 } from "../../src/actions/budgets";
@@ -33,6 +34,7 @@ describe("budget actions", () => {
   let categoryId1: string;
   let categoryId2: string;
   let otherHouseholdId: string;
+  let otherCategoryId: string;
 
   beforeAll(async () => {
     ({ db, close } = await createTestDb());
@@ -46,7 +48,7 @@ describe("budget actions", () => {
     const hh2 = await insertHousehold(db, "Other Household");
     otherHouseholdId = hh2.householdId;
     const { groupId: groupId2 } = await insertCategoryGroup(db, otherHouseholdId, { name: "Other Group" });
-    await insertCategory(db, otherHouseholdId, groupId2, { name: "Other Cat" });
+    ({ categoryId: otherCategoryId } = await insertCategory(db, otherHouseholdId, groupId2, { name: "Other Cat" }));
   });
 
   afterAll(async () => {
@@ -132,6 +134,35 @@ describe("budget actions", () => {
         .from(budgetCategories)
         .where(and(eq(budgetCategories.budgetId, tgtId), eq(budgetCategories.categoryId, categoryId2)));
       expect(cat2Row!.limitAmount).toBe(20000);
+    });
+  });
+
+  describe("setBudgetCategoryScoped", () => {
+    it("rejects a categoryId from another household (IDOR)", async () => {
+      const { budgetId } = await insertBudget(db, mockHouseholdId, { month: "2026-11" });
+
+      const res = await setBudgetCategoryScoped(mockHouseholdId, budgetId, otherCategoryId, 5000, db);
+      expect(res).toEqual({ error: "Category not found" });
+
+      const rows = await db
+        .select()
+        .from(budgetCategories)
+        .where(and(eq(budgetCategories.budgetId, budgetId), eq(budgetCategories.categoryId, otherCategoryId)));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("accepts a categoryId owned by the caller's household", async () => {
+      const { budgetId } = await insertBudget(db, mockHouseholdId, { month: "2026-12" });
+
+      const res = await setBudgetCategoryScoped(mockHouseholdId, budgetId, categoryId1, 5000, db);
+      expect(res).toEqual({ success: true });
+
+      const rows = await db
+        .select()
+        .from(budgetCategories)
+        .where(and(eq(budgetCategories.budgetId, budgetId), eq(budgetCategories.categoryId, categoryId1)));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].limitAmount).toBe(5000);
     });
   });
 

--- a/tests/integration/import.test.ts
+++ b/tests/integration/import.test.ts
@@ -47,7 +47,7 @@ describe("import pipeline integration", () => {
     if (!validated.valid) return;
 
     const rows = parseAll(CSV_CONTENT);
-    const normalized = normalizeImportedRows(
+    const { rows: normalized } = normalizeImportedRows(
       rows,
       validated.mapping,
       accountId,
@@ -94,7 +94,7 @@ describe("import pipeline integration", () => {
     const validated = validateMapping(detected);
     if (!validated.valid) return;
 
-    const normalized = normalizeImportedRows(
+    const { rows: normalized } = normalizeImportedRows(
       rows,
       validated.mapping,
       accountId,

--- a/tests/integration/mcp-oauth.test.ts
+++ b/tests/integration/mcp-oauth.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createTestDb } from "./setup";
+import { registerClient, createAuthorizationCode, OAuthError } from "@/lib/mcp/auth/oauth-server";
+import type { LedgrDb } from "@/db";
+
+describe("MCP OAuth redirect_uri validation", () => {
+  let db: LedgrDb;
+  let close: () => Promise<void>;
+  beforeAll(async () => {
+    ({ db, close } = await createTestDb());
+  });
+  afterAll(() => close());
+
+  it("rejects registration with no redirect_uris", async () => {
+    await expect(registerClient({ client_name: "Evil" }, db)).rejects.toBeInstanceOf(OAuthError);
+  });
+
+  it("rejects registration with a non-https, non-loopback redirect_uri", async () => {
+    await expect(
+      registerClient({ client_name: "Evil", redirect_uris: ["http://attacker.evil/cb"] }, db),
+    ).rejects.toBeInstanceOf(OAuthError);
+  });
+
+  it("accepts https and loopback redirect_uris", async () => {
+    const r = await registerClient(
+      { client_name: "Good", redirect_uris: ["https://app.example.com/cb", "http://127.0.0.1:3000/cb"] },
+      db,
+    );
+    expect(r.redirect_uris).toContain("https://app.example.com/cb");
+  });
+
+  it("rejects an authorize-time redirect_uri not in the registered set", async () => {
+    const c = await registerClient({ redirect_uris: ["https://app.example.com/cb"] }, db);
+    await expect(
+      createAuthorizationCode(
+        {
+          clientId: c.client_id,
+          userId: "u1",
+          householdId: "h1",
+          scope: "ledgr:read",
+          codeChallenge: "x",
+          redirectUri: "https://attacker.evil/cb",
+        },
+        db,
+      ),
+    ).rejects.toBeInstanceOf(OAuthError);
+  });
+
+  it("accepts an exact registered redirect_uri", async () => {
+    const c = await registerClient({ redirect_uris: ["https://app.example.com/cb"] }, db);
+    const code = await createAuthorizationCode(
+      {
+        clientId: c.client_id,
+        userId: "u1",
+        householdId: "h1",
+        scope: "ledgr:read",
+        codeChallenge: "x",
+        redirectUri: "https://app.example.com/cb",
+      },
+      db,
+    );
+    expect(typeof code).toBe("string");
+  });
+});

--- a/tests/integration/mcp-oauth.test.ts
+++ b/tests/integration/mcp-oauth.test.ts
@@ -62,3 +62,17 @@ describe("MCP OAuth redirect_uri validation", () => {
     expect(typeof code).toBe("string");
   });
 });
+
+describe("MCP per-user opt-in enforcement", () => {
+  let db: LedgrDb;
+  let close: () => Promise<void>;
+  beforeAll(async () => {
+    ({ db, close } = await createTestDb());
+  });
+  afterAll(() => close());
+
+  it("assertMcpEnabled throws when the user has not opted in", async () => {
+    const { assertMcpEnabled } = await import("@/lib/mcp/auth/guard");
+    await expect(assertMcpEnabled("user-without-settings", db)).rejects.toThrow();
+  });
+});

--- a/tests/integration/mcp-write-tools.test.ts
+++ b/tests/integration/mcp-write-tools.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./setup";
+import {
+  insertHousehold,
+  insertAccount,
+  insertTransaction,
+  insertCategoryGroup,
+  insertCategory,
+} from "./helpers";
+import { transactions } from "../../src/db/schema";
+import type { LedgrDb } from "../../src/db";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("../../src/lib/demo-mode", () => ({ guardDemoMode: vi.fn(() => null) }));
+
+describe("updateTransactionCategoryScoped", () => {
+  let db: LedgrDb;
+  let close: () => Promise<void>;
+  let householdA: string;
+  let aCategoryId: string;
+  let bTransactionId: string;
+
+  beforeAll(async () => {
+    ({ db, close } = await createTestDb());
+
+    const hhA = await insertHousehold(db, "Household A");
+    householdA = hhA.householdId;
+    const { groupId: groupA } = await insertCategoryGroup(db, householdA);
+    ({ categoryId: aCategoryId } = await insertCategory(db, householdA, groupA, { name: "A Category" }));
+
+    const hhB = await insertHousehold(db, "Household B");
+    const { accountId: bAccountId } = await insertAccount(db, hhB.householdId);
+    ({ transactionId: bTransactionId } = await insertTransaction(db, hhB.householdId, bAccountId));
+  });
+
+  afterAll(async () => {
+    await close();
+  });
+
+  it("rejects a foreign transaction", async () => {
+    const { updateTransactionCategoryScoped } = await import("../../src/actions/transactions");
+    const res = await updateTransactionCategoryScoped(householdA, bTransactionId, aCategoryId, db);
+    expect(res).toEqual({ error: "Transaction not found" });
+
+    const [row] = await db.select().from(transactions).where(eq(transactions.id, bTransactionId));
+    expect(row!.categoryId).toBeNull();
+  });
+
+  it("accepts a transaction owned by the caller's household", async () => {
+    const { updateTransactionCategoryScoped } = await import("../../src/actions/transactions");
+    const { accountId } = await insertAccount(db, householdA);
+    const { transactionId } = await insertTransaction(db, householdA, accountId);
+
+    const res = await updateTransactionCategoryScoped(householdA, transactionId, aCategoryId, db);
+    expect(res).toEqual({ success: true });
+
+    const [row] = await db.select().from(transactions).where(eq(transactions.id, transactionId));
+    expect(row!.categoryId).toBe(aCategoryId);
+  });
+});

--- a/tests/integration/report-queries.test.ts
+++ b/tests/integration/report-queries.test.ts
@@ -84,6 +84,23 @@ describe("getIncomeVsExpense", () => {
     expect(march!.expenses).toBe(110000);
     expect(march!.net).toBe(500000 - 110000);
   });
+
+  test("counts an uncategorized positive amount as income, not expense", async () => {
+    // An uncategorized paycheck (positive normalizedAmount) must not be
+    // bucketed into expenses via ABS() just because categoryId is null.
+    await insertTransaction(db, householdId, accountId, { date: "2026-03-20", normalizedAmount: 300000, amount: -300000, categoryId: null, name: "Mystery Deposit" });
+
+    const { getIncomeVsExpense } = await import("../../src/queries/reports");
+    const result = await getIncomeVsExpense(householdId, { dateFrom: "2026-03-01", dateTo: "2026-03-31" }, db);
+
+    const march = result.find((r) => r.period === "2026-03");
+    expect(march).toBeDefined();
+    // Categorized salary (500000) + uncategorized positive deposit (300000).
+    expect(march!.income).toBe(800000);
+    // Only the categorized non-income transactions (food + rent).
+    expect(march!.expenses).toBe(108000);
+    expect(march!.net).toBe(800000 - 108000);
+  });
 });
 
 describe("getIncomeExpenseByCategory", () => {

--- a/tests/integration/sync-actions.test.ts
+++ b/tests/integration/sync-actions.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
+import { createTestDb } from "./setup";
+import { insertHousehold, insertPlaidItem } from "./helpers";
+import type { LedgrDb } from "../../src/db";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("../../src/lib/demo-mode", () => ({ guardDemoMode: vi.fn(() => null) }));
+
+const mockUserId = "test-user-id";
+let mockHouseholdId: string;
+vi.mock("../../src/lib/auth/session", () => ({
+  getHouseholdId: vi.fn(() => Promise.resolve(mockHouseholdId)),
+  getSession: vi.fn(() => Promise.resolve({ user: { id: mockUserId } })),
+}));
+
+vi.mock("../../src/lib/plaid/sync", () => ({
+  syncInstitution: vi.fn(() =>
+    Promise.resolve({ success: true, addedCount: 0, modifiedCount: 0, removedCount: 0, syncedAt: new Date().toISOString() })
+  ),
+}));
+
+vi.mock("../../src/lib/plaid/investments", () => ({
+  syncInvestments: vi.fn(() => Promise.reject(new Error("investments API down"))),
+}));
+
+describe("triggerSync", () => {
+  let db: LedgrDb;
+  let close: () => Promise<void>;
+  let plaidItemId: string;
+
+  beforeAll(async () => {
+    vi.stubEnv("ENCRYPTION_KEY", "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2");
+    ({ db, close } = await createTestDb());
+    const hh = await insertHousehold(db);
+    mockHouseholdId = hh.householdId;
+    ({ plaidItemId } = await insertPlaidItem(db, hh.householdId));
+  });
+
+  afterAll(async () => {
+    await close();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs investment sync failures instead of swallowing them", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { triggerSync } = await import("../../src/actions/sync");
+    const result = await triggerSync(plaidItemId, db);
+
+    expect(result.success).toBe(true);
+    // The fire-and-forget investment sync rejects asynchronously; flush microtasks.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(errorSpy).toHaveBeenCalled();
+    const loggedError = errorSpy.mock.calls.find((call) =>
+      call.some((arg) => arg instanceof Error && arg.message === "investments API down")
+    );
+    expect(loggedError).toBeDefined();
+  });
+});

--- a/tests/integration/transaction-sync.test.ts
+++ b/tests/integration/transaction-sync.test.ts
@@ -376,6 +376,69 @@ describe("transaction sync integration", () => {
     expect(postedTxn?.pending).toBe(false);
   });
 
+  it("keeps the pending row when its posted replacement is skipped (unmapped account)", async () => {
+    await setup();
+    await seedTestData(db);
+
+    const now = new Date();
+    await db.insert(transactions).values({
+      id: uuid(),
+      accountId: "acc-internal-checking",
+      householdId: HOUSEHOLD_ID,
+      plaidTransactionId: TEST_TXN_IDS.pending1,
+      date: "2026-05-03",
+      originalName: "UBER *TRIP",
+      name: "Uber",
+      amount: 3599,
+      normalizedAmount: -3599,
+      currency: "USD",
+      pending: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // The posted replacement references the pending row via
+    // pending_transaction_id, but posts to an account that isn't in the
+    // internal accounts map — so it gets skipped during insert.
+    server.use(
+      http.post("https://sandbox.plaid.com/transactions/sync", () =>
+        HttpResponse.json({
+          added: [
+            {
+              transaction_id: TEST_TXN_IDS.posted1,
+              account_id: "plaid-acc-nonexistent",
+              amount: 35.99,
+              iso_currency_code: "USD",
+              date: "2026-05-03",
+              name: "UBER *TRIP",
+              merchant_name: "Uber",
+              logo_url: null,
+              pending: false,
+              pending_transaction_id: TEST_TXN_IDS.pending1,
+              personal_finance_category: { primary: "TRANSPORTATION", detailed: "TRANSPORTATION_TAXIS_AND_RIDE_SHARES" },
+            },
+          ],
+          modified: [],
+          removed: [],
+          has_more: false,
+          next_cursor: "cursor_unmapped_posted",
+          request_id: "req-sync-unmapped-posted",
+        })
+      )
+    );
+
+    const result = await syncInstitution(PLAID_ITEM_ID, HOUSEHOLD_ID, db);
+    expect(result.success).toBe(true);
+
+    const [pendingTxn] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.plaidTransactionId, TEST_TXN_IDS.pending1));
+    // The replacement never got inserted, so the pending row must survive —
+    // otherwise the transaction silently vanishes.
+    expect(pendingTxn?.deletedAt).toBeNull();
+  });
+
   it("empty sync advances cursor and writes sync_log", async () => {
     await setup();
     await seedTestData(db);


### PR DESCRIPTION
Fixes surfaced by a multi-agent review of the app. All changes are test-first (TDD); full suite green (519 tests / 86 files), typecheck and lint clean.

## Phase A — Security hotfix
- **Close MCP OAuth authorization-code theft** — require https/loopback redirect URIs at registration; validate `redirect_uri` unconditionally at authorize-time (previously skipped when a client registered with zero URIs → full account-takeover path).
- **Enforce per-user `mcpEnabled` opt-in** at consent (was global-env-only).
- **Show redirect host on the consent screen** so a victim can spot a hostile target.
- **Fix budget category IDOR** — verify `categoryId` household ownership before insert.
- **Scope MCP write tools to the OAuth token's household** instead of falling back to the cookie session.
- **Remove XSS surface** in the Plaid OAuth-return page (read `window.location.href` client-side).

## Phase B — Financial correctness
- **Classify uncategorized income by sign** — an uncategorized paycheck was counted as expense, swinging monthly net ~2× negative.
- **Keep pending Plaid transactions** when their posted replacement is skipped (unmapped account) instead of silently deleting them.
- **Locale-aware CSV money parsing** (`1.234,56`, `(123.45)`); surface unparseable rows instead of silently importing `$0`.
- **`todayDateString()` returns local date, not UTC** — fixes bill-status/snapshot off-by-one in the Americas.
- **Log investment-sync failures** instead of swallowing them.

Plan/spec: `docs/superpowers/plans/2026-07-20-security-and-correctness-fixes.md` (includes a "Deferred" section for the perf/feature/platform follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)