### PR TITLE
Perf: batch sync/investment writes + scope income-category query

### DIFF
--- a/src/lib/plaid/investments-apply.ts
+++ b/src/lib/plaid/investments-apply.ts
@@ -35,58 +35,40 @@ export async function applyInvestmentsToDb(
         .where(inArray(investmentHoldings.accountId, itemAccountIds));
     }
 
-    for (const row of holdingRows) {
-      await tx.insert(investmentHoldings)
-        .values({
-          id: row.id,
-          accountId: row.accountId,
-          plaidSecurityId: row.plaidSecurityId,
-          securityName: row.securityName,
-          ticker: row.ticker,
-          quantity: row.quantity,
-          costBasis: row.costBasis,
-          currentValue: row.currentValue,
+    if (holdingRows.length > 0) {
+      await tx.insert(investmentHoldings).values(
+        holdingRows.map((row) => ({
+          id: row.id, accountId: row.accountId, plaidSecurityId: row.plaidSecurityId,
+          securityName: row.securityName, ticker: row.ticker, quantity: row.quantity,
+          costBasis: row.costBasis, currentValue: row.currentValue,
           type: row.type as "stock" | "etf" | "mutual_fund" | "bond" | "crypto" | "cash" | "other",
-          sector: row.sector,
-          currency: row.currency,
-          asOfDate: row.asOfDate,
-        });
-      holdingsUpserted++;
+          sector: row.sector, currency: row.currency, asOfDate: row.asOfDate,
+        })),
+      );
+      holdingsUpserted = holdingRows.length;
     }
 
-    for (const row of txnRows) {
-      const result = await tx
-        .insert(investmentTransactions)
-        .values({
-          id: row.id,
-          accountId: row.accountId,
+    if (txnRows.length > 0) {
+      const result = await tx.insert(investmentTransactions).values(
+        txnRows.map((row) => ({
+          id: row.id, accountId: row.accountId,
           plaidInvestmentTransactionId: row.plaidInvestmentTransactionId,
-          securityName: row.securityName,
-          ticker: row.ticker,
+          securityName: row.securityName, ticker: row.ticker,
           type: row.type as "buy" | "sell" | "dividend" | "transfer" | "fee" | "other",
-          quantity: row.quantity,
-          price: row.price,
-          amount: row.amount,
-          fees: row.fees,
-          date: row.date,
-        })
-        .onConflictDoNothing();
-      if ((result.rowCount ?? 0) > 0) txnsInserted++;
+          quantity: row.quantity, price: row.price, amount: row.amount, fees: row.fees, date: row.date,
+        })),
+      ).onConflictDoNothing();
+      txnsInserted = result.rowCount ?? 0;
     }
 
-    for (const row of holdingRows) {
-      await tx.insert(holdingsHistory)
-        .values({
-          id: uuid(),
-          accountId: row.accountId,
-          plaidSecurityId: row.plaidSecurityId,
-          securityName: row.securityName,
-          ticker: row.ticker,
-          quantity: row.quantity,
-          value: row.currentValue,
-          date: today,
-        })
-        .onConflictDoNothing();
+    if (holdingRows.length > 0) {
+      await tx.insert(holdingsHistory).values(
+        holdingRows.map((row) => ({
+          id: uuid(), accountId: row.accountId, plaidSecurityId: row.plaidSecurityId,
+          securityName: row.securityName, ticker: row.ticker, quantity: row.quantity,
+          value: row.currentValue, date: today,
+        })),
+      ).onConflictDoNothing();
     }
   });
 
@@ -111,19 +93,21 @@ export async function snapshotHoldings(dbInstance: LedgrDb = defaultDb): Promise
     .innerJoin(accounts, eq(investmentHoldings.accountId, accounts.id))
     .where(ne(accounts.householdId, DEMO_HOUSEHOLD_ID));
 
-  for (const h of allHoldings) {
+  if (allHoldings.length > 0) {
     await dbInstance
       .insert(holdingsHistory)
-      .values({
-        id: uuid(),
-        accountId: h.accountId,
-        plaidSecurityId: h.plaidSecurityId,
-        securityName: h.securityName,
-        ticker: h.ticker,
-        quantity: h.quantity,
-        value: h.currentValue,
-        date: today,
-      })
+      .values(
+        allHoldings.map((h) => ({
+          id: uuid(),
+          accountId: h.accountId,
+          plaidSecurityId: h.plaidSecurityId,
+          securityName: h.securityName,
+          ticker: h.ticker,
+          quantity: h.quantity,
+          value: h.currentValue,
+          date: today,
+        })),
+      )
       .onConflictDoNothing();
   }
 }

--- a/src/lib/plaid/sync.ts
+++ b/src/lib/plaid/sync.ts
@@ -487,12 +487,12 @@ async function applyToDb(
 
     // --- Soft-delete removed transactions ---
     let removedCount = 0;
-    for (const removedPlaidId of processed.removedIds) {
+    if (processed.removedIds.length > 0) {
       const result = await tx
         .update(transactions)
         .set({ deletedAt: now, updatedAt: now })
-        .where(eq(transactions.plaidTransactionId, removedPlaidId));
-      if (result.rowCount && result.rowCount > 0) removedCount++;
+        .where(inArray(transactions.plaidTransactionId, processed.removedIds));
+      removedCount = result.rowCount ?? 0;
     }
 
     // --- Update account balances ---

--- a/src/lib/spending-helpers.ts
+++ b/src/lib/spending-helpers.ts
@@ -22,7 +22,7 @@ export interface SpendingChartItem {
 }
 
 
-async function spendingBaseConditions(filters: ReportFilters, db: LedgrDb) {
+async function spendingBaseConditions(householdId: string, filters: ReportFilters, db: LedgrDb) {
   const conditions = [
     notDeleted(transactions),
     lt(transactions.normalizedAmount, 0),
@@ -31,7 +31,7 @@ async function spendingBaseConditions(filters: ReportFilters, db: LedgrDb) {
     isNull(transactions.transferPairId),
     gte(transactions.date, filters.dateFrom),
     lte(transactions.date, filters.dateTo),
-    await notIncome(db),
+    await notIncome(householdId, db),
   ];
   if (filters.accountIds?.length) {
     conditions.push(inArray(transactions.accountId, filters.accountIds));
@@ -61,7 +61,7 @@ export async function aggregateSpending(
   db: LedgrDb = defaultDb,
 ): Promise<Map<string, number>> {
   const scoped = scopedQuery(householdId, db);
-  const conditions = await spendingBaseConditions(filters, db);
+  const conditions = await spendingBaseConditions(householdId, filters, db);
 
   const splitParentIds = await findSplitParentIds(scoped, conditions, db);
 

--- a/src/queries/dashboard.ts
+++ b/src/queries/dashboard.ts
@@ -263,7 +263,7 @@ export async function getCashFlow(
   d.setDate(1);
   const dateFrom = d.toISOString().slice(0, 10);
 
-  const incomeCatIds = [...(await getIncomeCategoryIds(db))];
+  const incomeCatIds = [...(await getIncomeCategoryIds(householdId, db))];
 
   // COALESCE(...,false): a null or non-income category is treated as non-income,
   // matching the prior `txn.categoryId && incomeCatIds.has(...)` check. When

--- a/src/queries/reports.ts
+++ b/src/queries/reports.ts
@@ -101,7 +101,7 @@ export async function getIncomeVsExpense(
     conditions.push(inArray(transactions.categoryId, filters.categoryIds));
   }
 
-  const incomeCatIds = [...(await getIncomeCategoryIds(db))];
+  const incomeCatIds = [...(await getIncomeCategoryIds(householdId, db))];
 
   // Income sums the raw (signed) amount of income-category txns; expenses sum
   // the absolute value of everything else. An uncategorized row (no
@@ -150,7 +150,7 @@ export async function getCategoryTrends(
     isNull(transactions.transferPairId),
     gte(transactions.date, filters.dateFrom),
     lte(transactions.date, filters.dateTo),
-    await notIncome(db),
+    await notIncome(householdId, db),
   ];
   if (filters.accountIds?.length) {
     conditions.push(inArray(transactions.accountId, filters.accountIds));
@@ -258,7 +258,7 @@ export async function getIncomeExpenseByCategory(
   db: LedgrDb = defaultDb,
 ): Promise<IncomeExpenseCategoryRow[]> {
   const scoped = scopedQuery(householdId, db);
-  const incomeCatIds = await getIncomeCategoryIds(db);
+  const incomeCatIds = await getIncomeCategoryIds(householdId, db);
 
   const conditions = [
     notDeleted(transactions),
@@ -402,7 +402,7 @@ export async function getCashFlowSankey(
   db: LedgrDb = defaultDb,
 ): Promise<{ nodes: SankeyNode[]; links: SankeyLink[] }> {
   const scoped = scopedQuery(householdId, db);
-  const incomeCatIds = await getIncomeCategoryIds(db);
+  const incomeCatIds = await getIncomeCategoryIds(householdId, db);
 
   const conditions = [
     notDeleted(transactions),
@@ -520,7 +520,7 @@ export async function getSafeToSpend(
   db: LedgrDb = defaultDb,
 ): Promise<SafeToSpendResult> {
   const scoped = scopedQuery(householdId, db);
-  const incomeCatIds = await getIncomeCategoryIds(db);
+  const incomeCatIds = await getIncomeCategoryIds(householdId, db);
   const { from: dateFrom, to: dateTo } = monthBounds(getCurrentMonth());
 
   // Monthly income (including pending — so paycheck shows immediately)
@@ -595,7 +595,7 @@ export async function getSafeToSpend(
   }
 
   // Discretionary spending: non-recurring expenses this month
-  const notIncomeCondition = await notIncome(db);
+  const notIncomeCondition = await notIncome(householdId, db);
   const discretionaryTxns = await db
     .select({ normalizedAmount: transactions.normalizedAmount })
     .from(transactions)

--- a/src/queries/shared-conditions.ts
+++ b/src/queries/shared-conditions.ts
@@ -1,18 +1,23 @@
+import { cache } from "react";
 import { eq, isNull, or, sql, notInArray } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import type { LedgrDb } from "@/db";
 import { transactions, categories } from "@/db/schema";
+import { scopedQuery } from "@/lib/scoped-query";
 
-export async function getIncomeCategoryIds(db: LedgrDb): Promise<Set<string>> {
-  const rows = await db
-    .select({ id: categories.id })
-    .from(categories)
-    .where(eq(categories.isIncome, true));
-  return new Set(rows.map((r) => r.id));
-}
+export const getIncomeCategoryIds = cache(
+  async (householdId: string, db: LedgrDb): Promise<Set<string>> => {
+    const scoped = scopedQuery(householdId, db);
+    const rows = await db
+      .select({ id: categories.id })
+      .from(categories)
+      .where(scoped.where(categories, eq(categories.isIncome, true)));
+    return new Set(rows.map((r) => r.id));
+  },
+);
 
-export async function notIncome(db: LedgrDb): Promise<SQL> {
-  const ids = [...(await getIncomeCategoryIds(db))];
+export async function notIncome(householdId: string, db: LedgrDb): Promise<SQL> {
+  const ids = [...(await getIncomeCategoryIds(householdId, db))];
   if (ids.length === 0) return sql`1=1`;
   return or(
     isNull(transactions.categoryId),

--- a/tests/integration/dashboard-queries.test.ts
+++ b/tests/integration/dashboard-queries.test.ts
@@ -17,6 +17,7 @@ import {
   getRecentTransactions,
   getLatestActivityMonth,
 } from "../../src/queries/dashboard";
+import { todayDateString } from "../../src/lib/date-utils";
 
 // Month strings derived relative to "now" so tests stay deterministic as the
 // calendar moves (see repo convention: never hardcode "recent" dates).
@@ -111,7 +112,7 @@ describe("getNetWorthHistory", () => {
     expect(historicalPoint!.liabilities).toBe(15000);
     expect(historicalPoint!.netWorth).toBe(55000);
 
-    const today = new Date().toISOString().slice(0, 10);
+    const today = todayDateString();
     const todayPoint = result.find((r) => r.date === today);
     expect(todayPoint).toBeDefined();
     expect(todayPoint!.assets).toBe(80000);
@@ -400,7 +401,7 @@ describe("household isolation", () => {
     expect(summary.monthlyIncome).toBe(0);
 
     const history = await getNetWorthHistory(otherId, "1M", db);
-    const today = new Date().toISOString().slice(0, 10);
+    const today = todayDateString();
     const nonTodayPoints = history.filter((p) => p.date !== today);
     expect(nonTodayPoints.length).toBe(0);
 

--- a/tests/integration/investment-sync.test.ts
+++ b/tests/integration/investment-sync.test.ts
@@ -12,6 +12,7 @@ import type { HoldingRow, InvestmentTxnRow } from "@/lib/plaid/investments";
 import { investmentHoldings, holdingsHistory, investmentTransactions } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import type { LedgrDb } from "@/db";
+import { todayDateString } from "@/lib/date-utils";
 
 function makeHolding(accountId: string, overrides: Partial<HoldingRow> = {}): HoldingRow {
   return {
@@ -130,6 +131,42 @@ describe("applyInvestmentsToDb", () => {
 
     const snapshots = await db.select().from(holdingsHistory);
     expect(snapshots).toHaveLength(1);
+  });
+
+  it("batches multi-row inserts: 3 holdings, 3 txns (1 pre-existing dup), idempotent history", async () => {
+    // Pre-insert one investment transaction so one of the 3 in this call collides.
+    const dupTxn = makeTxn(accountId, { plaidInvestmentTransactionId: "dup-batch-txn" });
+    await applyInvestmentsToDb(db, [], [dupTxn], plaidItemId);
+
+    const holdings = [
+      makeHolding(accountId, { id: crypto.randomUUID(), plaidSecurityId: "sec-a" }),
+      makeHolding(accountId, { id: crypto.randomUUID(), plaidSecurityId: "sec-b" }),
+      makeHolding(accountId, { id: crypto.randomUUID(), plaidSecurityId: "sec-c" }),
+    ];
+    const txns = [
+      makeTxn(accountId, { plaidInvestmentTransactionId: "dup-batch-txn" }), // conflicts with pre-inserted row
+      makeTxn(accountId, { plaidInvestmentTransactionId: "new-batch-txn-1" }),
+      makeTxn(accountId, { plaidInvestmentTransactionId: "new-batch-txn-2" }),
+    ];
+
+    const result = await applyInvestmentsToDb(db, holdings, txns, plaidItemId);
+
+    expect(result.holdingsUpserted).toBe(3);
+    expect(result.txnsInserted).toBe(2); // the dup is skipped via onConflictDoNothing
+
+    const dbHoldings = await db.select().from(investmentHoldings);
+    expect(dbHoldings).toHaveLength(3);
+
+    const today = todayDateString();
+    const history = await db.select().from(holdingsHistory);
+    expect(history).toHaveLength(3);
+    expect(history.every((h) => h.date === today)).toBe(true);
+
+    // Calling again with the same holdings must not duplicate history rows
+    // (onConflictDoNothing on accountId+plaidSecurityId+date).
+    await applyInvestmentsToDb(db, holdings, [], plaidItemId);
+    const historyAfterRepeat = await db.select().from(holdingsHistory);
+    expect(historyAfterRepeat).toHaveLength(3);
   });
 
   it("isolates holdings across households", async () => {

--- a/tests/integration/mcp-net-worth-history.test.ts
+++ b/tests/integration/mcp-net-worth-history.test.ts
@@ -5,6 +5,7 @@ import { insertHousehold, insertAccount } from "./helpers";
 import { balanceHistory } from "../../src/db/schema";
 import { getNetWorthHistory } from "../../src/queries/dashboard";
 import { formatNetWorthHistory } from "../../src/lib/mcp/tools/dashboard";
+import { todayDateString } from "../../src/lib/date-utils";
 import type { LedgrDb } from "../../src/db";
 
 // End-to-end coverage for the get_net_worth_history MCP tool's data path:
@@ -60,7 +61,7 @@ describe("get_net_worth_history tool data path", () => {
       netWorthDisplay: "$550.00",
     });
 
-    const today = new Date().toISOString().slice(0, 10);
+    const today = todayDateString();
     const todayPoint = wire.find((p) => p.date === today);
     expect(todayPoint).toEqual({
       date: today,

--- a/tests/integration/shared-conditions.test.ts
+++ b/tests/integration/shared-conditions.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { createTestDb } from "./setup";
+import {
+  insertHousehold,
+  insertAccount,
+  insertCategoryGroup,
+  insertCategory,
+  insertTransaction,
+} from "./helpers";
+import { getIncomeCategoryIds, notIncome } from "../../src/queries/shared-conditions";
+import type { LedgrDb } from "../../src/db";
+
+let db: LedgrDb;
+let close: () => Promise<void>;
+let householdA: string;
+let householdB: string;
+let aIncomeCatId: string;
+let bIncomeCatId: string;
+
+beforeEach(async () => {
+  ({ db, close } = await createTestDb());
+
+  ({ householdId: householdA } = await insertHousehold(db, "Household A"));
+  ({ householdId: householdB } = await insertHousehold(db, "Household B"));
+
+  const aGroup = await insertCategoryGroup(db, householdA, { name: "Income" });
+  ({ categoryId: aIncomeCatId } = await insertCategory(db, householdA, aGroup.groupId, {
+    name: "Salary",
+    isIncome: true,
+  }));
+
+  const bGroup = await insertCategoryGroup(db, householdB, { name: "Income" });
+  ({ categoryId: bIncomeCatId } = await insertCategory(db, householdB, bGroup.groupId, {
+    name: "Freelance",
+    isIncome: true,
+  }));
+});
+
+afterEach(async () => {
+  await close();
+});
+
+describe("getIncomeCategoryIds", () => {
+  test("returns only the caller household's income category ids", async () => {
+    const ids = await getIncomeCategoryIds(householdA, db);
+    expect(ids.has(aIncomeCatId)).toBe(true);
+    expect(ids.has(bIncomeCatId)).toBe(false);
+  });
+
+  test("scopes correctly for the other household too", async () => {
+    const ids = await getIncomeCategoryIds(householdB, db);
+    expect(ids.has(bIncomeCatId)).toBe(true);
+    expect(ids.has(aIncomeCatId)).toBe(false);
+  });
+});
+
+describe("notIncome", () => {
+  test("excludes only the caller household's income category, not another household's", async () => {
+    const { accountId } = await insertAccount(db, householdA);
+    const { transactionId: incomeTxnId } = await insertTransaction(db, householdA, accountId, {
+      categoryId: aIncomeCatId,
+      normalizedAmount: 500000,
+      amount: -500000,
+    });
+    const { transactionId: expenseTxnId } = await insertTransaction(db, householdA, accountId, {
+      categoryId: null,
+      normalizedAmount: -2000,
+      amount: 2000,
+    });
+
+    const condition = await notIncome(householdA, db);
+    const { transactions } = await import("../../src/db/schema");
+    const { and, eq } = await import("drizzle-orm");
+
+    const rows = await db
+      .select({ id: transactions.id })
+      .from(transactions)
+      .where(and(eq(transactions.householdId, householdA), condition));
+
+    const ids = rows.map((r) => r.id);
+    expect(ids).toContain(expenseTxnId);
+    expect(ids).not.toContain(incomeTxnId);
+  });
+});

--- a/tests/integration/transaction-sync.test.ts
+++ b/tests/integration/transaction-sync.test.ts
@@ -276,6 +276,81 @@ describe("transaction sync integration", () => {
     expect(txn?.deletedAt).not.toBeNull();
   });
 
+  it("batches multiple removed transactions into one soft-delete update", async () => {
+    await setup();
+    await seedTestData(db);
+
+    const now = new Date();
+    await db.insert(transactions).values([
+      {
+        id: uuid(),
+        accountId: "acc-internal-checking",
+        householdId: HOUSEHOLD_ID,
+        plaidTransactionId: TEST_TXN_IDS.removed1,
+        date: "2026-05-01",
+        originalName: "OLD TRANSACTION 1",
+        name: "Old Transaction 1",
+        amount: 1000,
+        normalizedAmount: -1000,
+        currency: "USD",
+        pending: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: uuid(),
+        accountId: "acc-internal-checking",
+        householdId: HOUSEHOLD_ID,
+        plaidTransactionId: TEST_TXN_IDS.removed2,
+        date: "2026-05-02",
+        originalName: "OLD TRANSACTION 2",
+        name: "Old Transaction 2",
+        amount: 2000,
+        normalizedAmount: -2000,
+        currency: "USD",
+        pending: false,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+
+    server.use(
+      http.post("https://sandbox.plaid.com/transactions/sync", () =>
+        HttpResponse.json({
+          added: [],
+          modified: [],
+          removed: [
+            { transaction_id: TEST_TXN_IDS.removed1 },
+            { transaction_id: TEST_TXN_IDS.removed2 },
+          ],
+          has_more: false,
+          next_cursor: "cursor_removed_batch",
+          request_id: "req-sync-removed-batch",
+        }),
+      ),
+    );
+
+    const result = await syncInstitution(PLAID_ITEM_ID, HOUSEHOLD_ID, db);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.removedCount).toBe(2);
+
+    const removedTxns = await db
+      .select()
+      .from(transactions)
+      .where(
+        eq(transactions.plaidTransactionId, TEST_TXN_IDS.removed1),
+      );
+    expect(removedTxns[0]?.deletedAt).not.toBeNull();
+
+    const [txn2] = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.plaidTransactionId, TEST_TXN_IDS.removed2));
+    expect(txn2?.deletedAt).not.toBeNull();
+  });
+
   it("modified transactions upsert without duplicates", async () => {
     await setup();
     await seedTestData(db);

--- a/tests/mocks/handlers.ts
+++ b/tests/mocks/handlers.ts
@@ -128,6 +128,7 @@ export const TEST_TXN_IDS = {
   posted1: "txn-posted-1",
   modified1: "txn-modified-1",
   removed1: "txn-removed-1",
+  removed2: "txn-removed-2",
 } as const;
 
 export const syncPageOneHandler = http.post(


### PR DESCRIPTION
Performance follow-ups from the review. Behavior-preserving refactors; full suite green (524 tests), typecheck + lint clean.

## Changes
- **Batch investment inserts** (`investments-apply.ts`) — the three per-row insert loops in `applyInvestmentsToDb` (holdings, investment transactions, holdings history) and the `snapshotHoldings` loop become single multi-row inserts. Eliminates 100–400 serialized round-trips per investment sync inside one open transaction.
- **Household-scope + memoize `getIncomeCategoryIds` / `notIncome`** (`shared-conditions.ts`) — the query now filters by household (was unscoped, violating the scoping convention and returning every household's income categories) and is wrapped in React `cache()` so a single dashboard/reports render stops re-running it 3–6×. All 8 call sites updated to pass `householdId`.
- **Batch removed-transaction soft-deletes** (`sync.ts`) — the per-row soft-delete loop becomes one `inArray` bulk update. The pending→posted loop (with the recently-added replacement gate) is deliberately left untouched.

## Also included (B4 follow-on)
- **Fix timezone-fragile net-worth tests** — `dashboard-queries` and `mcp-net-worth-history` computed "today" as `toISOString().slice(0,10)` (UTC) while production emits the synthetic net-worth point via `todayDateString()` (local, since the B4 date fix). They flaked on non-UTC runners in the evening. Now aligned with production. (CI runs UTC so this never failed the pipeline, but it broke local dev runs west of UTC.)

Plan: `docs/superpowers/plans/2026-07-21-perf-batching.md`. Deferred: CASE-based bulk update of modified transactions (different values per row) — higher risk, low incremental value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)