### PR TITLE
Fix budget spending semantics and dark-mode scrollbars

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,6 +54,7 @@
 }
 
 :root {
+  color-scheme: light;
   --background: oklch(0.985 0.002 75);
   --foreground: oklch(0.145 0.005 75);
   --card: oklch(1 0 0);
@@ -98,6 +99,7 @@
 
 @media (prefers-color-scheme: dark) {
 :root {
+  color-scheme: dark;
   --background: oklch(0.1 0.005 75);
   --foreground: oklch(0.94 0.005 75);
   --card: oklch(0.13 0.005 75);

--- a/src/components/atoms/budget-summary-bar.tsx
+++ b/src/components/atoms/budget-summary-bar.tsx
@@ -1,4 +1,5 @@
-import { BalanceDisplay } from "@/components/atoms/balance-display";
+import { centsToDisplay } from "@/lib/money";
+import { StatStrip } from "@/components/molecules/stat-strip";
 
 interface BudgetSummaryBarProps {
   totalBudgeted: number;
@@ -24,21 +25,22 @@ export function BudgetSummaryBar({
   totalRemaining,
   lastSyncedAt,
 }: BudgetSummaryBarProps) {
-  const labels = ["Total Budgeted", "Total Spent", "Remaining"];
-  const values = [totalBudgeted, totalSpent, totalRemaining];
-
   return (
-    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between rounded-lg border bg-card p-4 gap-3 sm:gap-0">
-      <div className="flex gap-4 sm:gap-8 overflow-x-auto">
-        {labels.map((label, i) => (
-          <div key={label}>
-            <p className="text-xs text-muted-foreground">{label}</p>
-            <BalanceDisplay amount={values[i]} size="lg" />
-          </div>
-        ))}
-      </div>
+    <div>
+      <StatStrip
+        ariaLabel="Budget summary"
+        items={[
+          { label: "Total Budgeted", value: centsToDisplay(totalBudgeted) },
+          { label: "Total Spent", value: centsToDisplay(totalSpent) },
+          {
+            label: "Remaining",
+            value: centsToDisplay(totalRemaining),
+            valueClassName: totalRemaining < 0 ? "text-destructive" : undefined,
+          },
+        ]}
+      />
       {lastSyncedAt && (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-xs text-muted-foreground text-right mt-1.5">
           Last synced {timeAgo(lastSyncedAt)}
         </p>
       )}

--- a/src/components/molecules/budget-category-row.tsx
+++ b/src/components/molecules/budget-category-row.tsx
@@ -128,7 +128,7 @@ export function BudgetCategoryRow({
         </div>
       </TableCell>
       <TableCell className="py-2 px-3">
-        <AmountDisplay amount={spent} className="text-xs" />
+        <AmountDisplay amount={spent} absolute className="text-xs" />
       </TableCell>
       <TableCell className="py-2 px-3">
         {error ? (

--- a/src/components/organisms/budget-table.tsx
+++ b/src/components/organisms/budget-table.tsx
@@ -78,7 +78,7 @@ export function BudgetTable({ data }: BudgetTableProps) {
           <div className="flex items-center justify-between px-3 py-2 text-sm font-medium bg-muted/20 rounded-t-lg">
             <span className="text-muted-foreground">Everything Else</span>
             <span className="text-xs text-muted-foreground tabular-nums">
-              <AmountDisplay amount={data.unbudgeted.spent} className="text-xs" />
+              <AmountDisplay amount={data.unbudgeted.spent} absolute className="text-xs" />
             </span>
           </div>
           <Table>
@@ -92,7 +92,7 @@ export function BudgetTable({ data }: BudgetTableProps) {
                     )}
                   </TableCell>
                   <TableCell className="py-2 px-3 text-right">
-                    <AmountDisplay amount={cat.spent} className="text-xs" />
+                    <AmountDisplay amount={cat.spent} absolute className="text-xs" />
                   </TableCell>
                 </TableRow>
               ))}


### PR DESCRIPTION
## Summary

Two issues found while walking the live app after #37:

- **Budgets rendered spending as green income** — the spent column showed "+\$445.12" and the "Everything Else" list showed "Rent/Mortgage +\$2,162.04" in green, the same semantics bug fixed for Bills in #37. All budget spent amounts now render neutral (`AmountDisplay absolute`). The summary header also moves from a card to the shared StatStrip, with Remaining tinted destructive when negative.
- **Light scrollbars on dark surfaces** — the app never declared `color-scheme`, so scrollbars/form controls rendered light in dark mode (visible under the Reports legend). Added `color-scheme: light` / `dark` alongside the existing token blocks.

## Test plan

- [x] `pnpm test` — 536 passed
- [x] `pnpm typecheck` / `pnpm lint` — clean
- [x] Verified live in-browser (dark mode): budgets May 2026 shows neutral spent amounts + StatStrip header; Reports scrollbar now themed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ub4EaXQf3P5zxvHXdxUDQX