### PR TITLE
Fix MCP spec compliance gaps (2025-11-25) in OAuth discovery and transport

### DIFF
--- a/src/app/.well-known/oauth-authorization-server/route.ts
+++ b/src/app/.well-known/oauth-authorization-server/route.ts
@@ -5,7 +5,7 @@ export function GET() {
   const ledgrUrl = getLedgrUrl();
 
   return NextResponse.json({
-    issuer: "ledgr",
+    issuer: ledgrUrl,
     authorization_endpoint: `${ledgrUrl}/api/mcp/oauth/authorize`,
     token_endpoint: `${ledgrUrl}/api/mcp/oauth/token`,
     registration_endpoint: `${ledgrUrl}/api/mcp/oauth/register`,

--- a/src/app/.well-known/oauth-protected-resource/api/mcp/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/api/mcp/route.ts
@@ -1,0 +1,3 @@
+// RFC 9728 §3.1: clients derive the well-known URI by inserting the resource
+// path (/api/mcp), so the same metadata must be served here as at the root.
+export { GET } from "../../route";

--- a/src/app/.well-known/oauth-protected-resource/route.ts
+++ b/src/app/.well-known/oauth-protected-resource/route.ts
@@ -1,12 +1,10 @@
 import { NextResponse } from "next/server";
-import { MCP_SCOPES, getLedgrUrl } from "@/lib/mcp/constants";
+import { MCP_SCOPES, getLedgrUrl, getMcpResourceUrl } from "@/lib/mcp/constants";
 
 export function GET() {
-  const ledgrUrl = getLedgrUrl();
-
   return NextResponse.json({
-    resource: ledgrUrl,
-    authorization_servers: [ledgrUrl],
+    resource: getMcpResourceUrl(),
+    authorization_servers: [getLedgrUrl()],
     scopes_supported: MCP_SCOPES,
     bearer_methods_supported: ["header"],
   });

--- a/src/app/api/mcp/oauth/authorize/route.ts
+++ b/src/app/api/mcp/oauth/authorize/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getClient } from "@/lib/mcp/auth/oauth-server";
-import { DEFAULT_SCOPE } from "@/lib/mcp/constants";
+import { DEFAULT_SCOPE, getMcpResourceUrl } from "@/lib/mcp/constants";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -10,12 +10,16 @@ export async function GET(request: Request) {
   const codeChallengeMethod = url.searchParams.get("code_challenge_method");
   const scope = url.searchParams.get("scope") ?? DEFAULT_SCOPE;
   const state = url.searchParams.get("state");
+  const resource = url.searchParams.get("resource");
 
   if (!clientId || !redirectUri || !codeChallenge) {
     return NextResponse.json({ error: "invalid_request", error_description: "Missing required parameters" }, { status: 400 });
   }
   if (codeChallengeMethod !== "S256") {
     return NextResponse.json({ error: "invalid_request", error_description: "Only S256 code_challenge_method supported" }, { status: 400 });
+  }
+  if (resource !== null && resource !== getMcpResourceUrl()) {
+    return NextResponse.json({ error: "invalid_target", error_description: `Unknown resource: ${resource}` }, { status: 400 });
   }
   const client = await getClient(clientId);
   if (!client) {

--- a/src/app/api/mcp/oauth/token/route.ts
+++ b/src/app/api/mcp/oauth/token/route.ts
@@ -11,6 +11,7 @@ export async function POST(request: Request) {
       const result = await exchangeCode({
         code: params.code, clientId: params.client_id,
         codeVerifier: params.code_verifier, redirectUri: params.redirect_uri,
+        resource: params.resource,
       });
       return NextResponse.json(result);
     }
@@ -18,6 +19,7 @@ export async function POST(request: Request) {
     if (grantType === "refresh_token") {
       const result = await refreshAccessToken({
         refreshToken: params.refresh_token, clientId: params.client_id,
+        resource: params.resource,
       });
       return NextResponse.json(result);
     }

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -3,17 +3,27 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { createMcpServer } from "@/lib/mcp/server";
 import { authenticateRequest } from "@/lib/mcp/auth/oauth-server";
 import { registerAllTools } from "@/lib/mcp/tools/index";
+import { getLedgrUrl } from "@/lib/mcp/constants";
 
 export async function POST(request: Request) {
   if (process.env.MCP_ENABLED !== "true") {
     return NextResponse.json({ error: "MCP is disabled" }, { status: 403 });
   }
 
+  // DNS-rebinding defense: browser-originated requests must come from our own
+  // origin. Non-browser MCP clients send no Origin header and skip this check.
+  const origin = request.headers.get("Origin");
+  if (origin !== null && origin !== new URL(getLedgrUrl()).origin) {
+    return NextResponse.json({ error: "Invalid Origin" }, { status: 403 });
+  }
+
   const claims = await authenticateRequest(request);
   if (!claims) {
     return new NextResponse(null, {
       status: 401,
-      headers: { "WWW-Authenticate": 'Bearer realm="ledgr"' },
+      headers: {
+        "WWW-Authenticate": `Bearer realm="ledgr", resource_metadata="${getLedgrUrl()}/.well-known/oauth-protected-resource/api/mcp"`,
+      },
     });
   }
 

--- a/src/lib/mcp/auth/oauth-server.ts
+++ b/src/lib/mcp/auth/oauth-server.ts
@@ -6,6 +6,15 @@ import { randomBytes, createHash } from "crypto";
 import { nowISO } from "@/lib/date-utils";
 import { signAccessToken, generateRefreshToken, verifyAccessToken } from "./token";
 import type { AccessTokenClaims } from "./token";
+import { getMcpResourceUrl } from "@/lib/mcp/constants";
+
+// RFC 8707: the resource parameter is optional, but when present it must name
+// this server's MCP endpoint — we only ever issue tokens for our own resource.
+export function assertValidResource(resource: string | undefined): void {
+  if (resource !== undefined && resource !== getMcpResourceUrl()) {
+    throw new OAuthError("invalid_target", `Unknown resource: ${resource}`);
+  }
+}
 
 function generateId(): string {
   return randomBytes(16).toString("base64url");
@@ -114,9 +123,11 @@ export interface ExchangeCodeInput {
   clientId: string;
   codeVerifier: string;
   redirectUri: string;
+  resource?: string;
 }
 
 export async function exchangeCode(input: ExchangeCodeInput, db: LedgrDb = defaultDb) {
+  assertValidResource(input.resource);
   const [row] = await db.select().from(oauthCodes).where(eq(oauthCodes.code, input.code)).limit(1);
   if (!row) throw new OAuthError("invalid_grant", "Unknown code");
   if (row.used) throw new OAuthError("invalid_grant", "Code already used");
@@ -165,9 +176,11 @@ export async function exchangeCode(input: ExchangeCodeInput, db: LedgrDb = defau
 export interface RefreshInput {
   refreshToken: string;
   clientId: string;
+  resource?: string;
 }
 
 export async function refreshAccessToken(input: RefreshInput, db: LedgrDb = defaultDb) {
+  assertValidResource(input.resource);
   const [row] = await db
     .select()
     .from(oauthRefreshTokens)

--- a/src/lib/mcp/auth/token.ts
+++ b/src/lib/mcp/auth/token.ts
@@ -1,6 +1,6 @@
 import { SignJWT, jwtVerify } from "jose";
 import { randomBytes } from "crypto";
-import { getLedgrUrl } from "@/lib/mcp/constants";
+import { getMcpResourceUrl } from "@/lib/mcp/constants";
 
 function getSigningKey(): Uint8Array {
   const key = process.env.ENCRYPTION_KEY;
@@ -25,7 +25,6 @@ const ISSUER = "ledgr";
 
 export async function signAccessToken(payload: TokenPayload): Promise<string> {
   const expiresIn = payload.expiresInSeconds ?? 3600;
-  const ledgrUrl = getLedgrUrl();
 
   return new SignJWT({
     household_id: payload.householdId,
@@ -34,18 +33,16 @@ export async function signAccessToken(payload: TokenPayload): Promise<string> {
     .setProtectedHeader({ alg: "HS256" })
     .setSubject(payload.userId)
     .setIssuer(ISSUER)
-    .setAudience(ledgrUrl)
+    .setAudience(getMcpResourceUrl())
     .setIssuedAt()
     .setExpirationTime(Math.floor(Date.now() / 1000) + expiresIn)
     .sign(getSigningKey());
 }
 
 export async function verifyAccessToken(token: string): Promise<AccessTokenClaims> {
-  const ledgrUrl = getLedgrUrl();
-
   const { payload } = await jwtVerify(token, getSigningKey(), {
     issuer: ISSUER,
-    audience: ledgrUrl,
+    audience: getMcpResourceUrl(),
   });
 
   return {

--- a/src/lib/mcp/constants.ts
+++ b/src/lib/mcp/constants.ts
@@ -2,6 +2,12 @@ export function getLedgrUrl(): string {
   return process.env.LEDGR_URL ?? "http://localhost:4200";
 }
 
+// Canonical resource identifier (RFC 8707): PRM `resource`, token `aud`, and
+// `resource` parameter validation must all agree on this exact URL.
+export function getMcpResourceUrl(): string {
+  return `${getLedgrUrl()}/api/mcp`;
+}
+
 export const MCP_SCOPES = ["ledgr:read", "ledgr:write", "ledgr:sync"] as const;
 export const DEFAULT_SCOPE = "ledgr:read ledgr:write ledgr:sync";
 

--- a/tests/integration/mcp-spec-compliance.test.ts
+++ b/tests/integration/mcp-spec-compliance.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createTestDb } from "./setup";
+import type { LedgrDb } from "@/db";
+import { registerClient, createAuthorizationCode, exchangeCode, refreshAccessToken } from "@/lib/mcp/auth/oauth-server";
+import { getLedgrUrl, getMcpResourceUrl } from "@/lib/mcp/constants";
+import { createHash } from "crypto";
+
+const LEDGR_URL = getLedgrUrl();
+const MCP_RESOURCE = `${LEDGR_URL}/api/mcp`;
+
+describe("OAuth discovery metadata (RFC 8414 / RFC 9728)", () => {
+  it("authorization server metadata uses the server URL as issuer", async () => {
+    const { GET } = await import("@/app/.well-known/oauth-authorization-server/route");
+    const body = await GET().json();
+    expect(body.issuer).toBe(LEDGR_URL);
+  });
+
+  it("protected resource metadata identifies the MCP endpoint as the resource", async () => {
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/route");
+    const body = await GET().json();
+    expect(body.resource).toBe(MCP_RESOURCE);
+    expect(body.authorization_servers).toEqual([LEDGR_URL]);
+  });
+
+  it("serves protected resource metadata at the RFC 9728 path-suffixed well-known URI", async () => {
+    const { GET } = await import("@/app/.well-known/oauth-protected-resource/api/mcp/route");
+    const body = await GET().json();
+    expect(body.resource).toBe(MCP_RESOURCE);
+  });
+
+  it("getMcpResourceUrl returns the canonical MCP endpoint URL", () => {
+    expect(getMcpResourceUrl()).toBe(MCP_RESOURCE);
+  });
+});
+
+describe("MCP endpoint transport security", () => {
+  let previousMcpEnabled: string | undefined;
+
+  beforeAll(() => {
+    previousMcpEnabled = process.env.MCP_ENABLED;
+    process.env.MCP_ENABLED = "true";
+  });
+
+  afterAll(() => {
+    if (previousMcpEnabled === undefined) delete process.env.MCP_ENABLED;
+    else process.env.MCP_ENABLED = previousMcpEnabled;
+  });
+
+  it("401 response advertises the resource metadata URL in WWW-Authenticate", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(new Request(`${LEDGR_URL}/api/mcp`, { method: "POST" }));
+    expect(res.status).toBe(401);
+    const header = res.headers.get("WWW-Authenticate");
+    expect(header).toContain(
+      `resource_metadata="${LEDGR_URL}/.well-known/oauth-protected-resource/api/mcp"`,
+    );
+  });
+
+  it("rejects requests with a mismatched Origin header with 403", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(
+      new Request(`${LEDGR_URL}/api/mcp`, {
+        method: "POST",
+        headers: { Origin: "https://attacker.evil" },
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("allows requests whose Origin matches the server origin", async () => {
+    const { POST } = await import("@/app/api/mcp/route");
+    const res = await POST(
+      new Request(`${LEDGR_URL}/api/mcp`, {
+        method: "POST",
+        headers: { Origin: new URL(LEDGR_URL).origin },
+      }),
+    );
+    // Passes the Origin check and proceeds to token auth, which fails with 401 (not 403)
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("Resource indicators (RFC 8707)", () => {
+  let db: LedgrDb;
+  let close: () => Promise<void>;
+
+  beforeAll(async () => {
+    process.env.ENCRYPTION_KEY ??= "test-key-for-jwt-signing-32chars!!";
+    ({ db, close } = await createTestDb());
+  });
+
+  afterAll(async () => {
+    await close();
+  });
+
+  async function issueCode() {
+    const client = await registerClient({ redirect_uris: ["http://localhost:8080/cb"] }, db);
+    const codeVerifier = "resource-indicator-test-verifier-string";
+    const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
+    const code = await createAuthorizationCode(
+      {
+        clientId: client.client_id, userId: "u-rfc8707", householdId: "hh-rfc8707",
+        scope: "ledgr:read", codeChallenge, redirectUri: "http://localhost:8080/cb",
+      },
+      db,
+    );
+    return { client, code, codeVerifier };
+  }
+
+  it("rejects a code exchange whose resource parameter is not the MCP endpoint", async () => {
+    const { client, code, codeVerifier } = await issueCode();
+    await expect(
+      exchangeCode(
+        {
+          code, clientId: client.client_id, codeVerifier,
+          redirectUri: "http://localhost:8080/cb", resource: "https://other-server.example/mcp",
+        },
+        db,
+      ),
+    ).rejects.toMatchObject({ code: "invalid_target" });
+  });
+
+  it("accepts a code exchange with the canonical resource and binds the token audience to it", async () => {
+    const { client, code, codeVerifier } = await issueCode();
+    const tokens = await exchangeCode(
+      {
+        code, clientId: client.client_id, codeVerifier,
+        redirectUri: "http://localhost:8080/cb", resource: MCP_RESOURCE,
+      },
+      db,
+    );
+    const payload = JSON.parse(Buffer.from(tokens.access_token.split(".")[1], "base64url").toString());
+    expect(payload.aud).toBe(MCP_RESOURCE);
+  });
+
+  it("rejects a refresh whose resource parameter is not the MCP endpoint", async () => {
+    const { client, code, codeVerifier } = await issueCode();
+    const tokens = await exchangeCode(
+      { code, clientId: client.client_id, codeVerifier, redirectUri: "http://localhost:8080/cb" },
+      db,
+    );
+    await expect(
+      refreshAccessToken(
+        {
+          refreshToken: tokens.refresh_token, clientId: client.client_id,
+          resource: "https://other-server.example/mcp",
+        },
+        db,
+      ),
+    ).rejects.toMatchObject({ code: "invalid_target" });
+  });
+
+  it("authorize endpoint rejects a mismatched resource parameter with invalid_target", async () => {
+    const { GET } = await import("@/app/api/mcp/oauth/authorize/route");
+    const url = new URL(`${LEDGR_URL}/api/mcp/oauth/authorize`);
+    url.searchParams.set("client_id", "any-client");
+    url.searchParams.set("redirect_uri", "http://localhost:8080/cb");
+    url.searchParams.set("code_challenge", "x");
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("resource", "https://other-server.example/mcp");
+    const res = await GET(new Request(url));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_target");
+  });
+});


### PR DESCRIPTION
## Summary

Audited the MCP server against the current MCP specification (2025-11-25) and fixed the four compliance gaps found. The SDK (1.29.0) already negotiates protocol version 2025-11-25; the gaps were all in the OAuth discovery layer and transport hardening.

- **Protected resource metadata discovery (RFC 9728):** the 401 from `POST /api/mcp` now advertises `resource_metadata` in `WWW-Authenticate`, the metadata is additionally served at the path-suffixed well-known URI (`/.well-known/oauth-protected-resource/api/mcp`) that spec-following clients derive, and its `resource` field now names the MCP endpoint instead of the site root.
- **Issuer (RFC 8414):** authorization server metadata returns the server URL as `issuer` instead of the literal string `"ledgr"`, which strict clients reject.
- **Origin validation:** `POST /api/mcp` returns 403 on a mismatched `Origin` header (DNS-rebinding defense, made explicit in the 2025-11-25 revision). Requests without an Origin header (normal MCP clients) are unaffected.
- **Resource indicators (RFC 8707):** a single canonical resource identifier (`getMcpResourceUrl()`, i.e. `${LEDGR_URL}/api/mcp`) is now used consistently for the PRM `resource` field, the JWT `aud` claim, and validation of the `resource` parameter at the authorize/token endpoints (`invalid_target` on mismatch).

## Deployment note

Access tokens issued before this change have the old audience and will fail verification once deployed. Connected clients see a single 401 and recover automatically via their refresh token — no re-consent needed.

## Test plan

- [x] 10 new tests in `tests/integration/mcp-spec-compliance.test.ts` (written test-first, watched fail, then implemented)
- [x] Full Vitest suite: 547 tests / 89 files pass
- [x] `pnpm typecheck` and `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaHozaZHtpaEHgrKTnFhWC