### PR TITLE
Fix dev:setup polling wrong Postgres port

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "simple-git-hooks",
     "build:mcp-widgets": "tsx src/lib/mcp/apps/build.ts",
     "dev:db": "docker compose up db -d",
-    "dev:setup": "pnpm dev:db && until pg_isready -h localhost -p 5432 2>/dev/null; do sleep 1; done && pnpm db:migrate && pnpm dev"
+    "dev:setup": "pnpm dev:db && until pg_isready -h localhost -p ${DB_PORT:-5433} 2>/dev/null; do sleep 1; done && pnpm db:migrate && pnpm dev"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm exec lint-staged"


### PR DESCRIPTION
## Summary
- `pnpm dev:setup` (the setup command documented in CONTRIBUTING.md) waits on `pg_isready -h localhost -p 5432`, but `docker-compose.yml` maps Postgres to the host on `DB_PORT`, which defaults to `5433`.
- On a fresh clone with default `.env`, nothing listens on 5432, so the readiness loop spins forever and the command never reaches `db:migrate`/`dev`.
- Fix: read the port from `DB_PORT` (falling back to `5433`, matching `docker-compose.yml`'s own default) instead of hardcoding `5432`.

## Test plan
- [x] Ran `pnpm dev:db`, confirmed Postgres healthy on host port 5433
- [x] Confirmed the old command (`pg_isready -h localhost -p 5432`) hangs indefinitely against that setup
- [x] Confirmed `pg_isready -h localhost -p ${DB_PORT:-5433}` succeeds immediately once the container is healthy