### PR TITLE
Propagate manual category corrections to the merchant's default category

### DIFF
--- a/src/actions/merchants.ts
+++ b/src/actions/merchants.ts
@@ -1,0 +1,48 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { db as defaultDb, type LedgrDb } from "@/db";
+import { merchants } from "@/db/schema";
+import { scopedQuery } from "@/lib/scoped-query";
+import { authorizeAction } from "@/lib/auth/authorize-action";
+
+const merchantIdSchema = z.string().min(1);
+const categoryIdSchema = z.string().min(1);
+
+export async function updateMerchantDefaultCategoryScoped(
+  householdId: string,
+  merchantId: string,
+  categoryId: string,
+  db: LedgrDb = defaultDb,
+): Promise<{ success: true } | { error: string }> {
+  const parsedMerchantId = merchantIdSchema.safeParse(merchantId);
+  const parsedCategoryId = categoryIdSchema.safeParse(categoryId);
+  if (!parsedMerchantId.success || !parsedCategoryId.success) {
+    return { error: "Invalid input" };
+  }
+
+  const scoped = scopedQuery(householdId, db);
+  const updated = await db.update(merchants)
+    .set({ categoryId: parsedCategoryId.data, updatedAt: new Date() })
+    .where(scoped.where(merchants, eq(merchants.id, parsedMerchantId.data)))
+    .returning({ id: merchants.id });
+
+  if (updated.length === 0) {
+    return { error: "Merchant not found" };
+  }
+
+  revalidatePath("/transactions");
+  return { success: true };
+}
+
+export async function updateMerchantDefaultCategory(
+  merchantId: string,
+  categoryId: string,
+  db: LedgrDb = defaultDb,
+): Promise<{ success: true } | { error: string }> {
+  const auth = await authorizeAction();
+  if ("error" in auth) return auth;
+  return updateMerchantDefaultCategoryScoped(auth.householdId, merchantId, categoryId, db);
+}

--- a/src/actions/transactions.ts
+++ b/src/actions/transactions.ts
@@ -35,12 +35,16 @@ function buildCategoryUpdate(categoryId: string | null) {
   };
 }
 
+export type UpdateTransactionCategoryResult =
+  | { success: true; merchantCategoryConflict?: { merchantId: string; currentCategoryId: string } }
+  | { error: string };
+
 export async function updateTransactionCategoryScoped(
   householdId: string,
   transactionId: string,
   categoryId: string | null,
   db: LedgrDb = defaultDb,
-): Promise<{ success: true } | { error: string }> {
+): Promise<UpdateTransactionCategoryResult> {
   const parsedTxnId = transactionIdSchema.safeParse(transactionId);
   const parsedCatId = categoryIdSchema.safeParse(categoryId);
   if (!parsedTxnId.success || !parsedCatId.success) {
@@ -60,30 +64,47 @@ export async function updateTransactionCategoryScoped(
 
   const updates = buildCategoryUpdate(parsedCatId.data);
 
+  let merchantCategoryConflict: { merchantId: string; currentCategoryId: string } | undefined;
+
   await db.transaction(async (tx) => {
     await tx.update(transactions)
       .set(updates)
       .where(eq(transactions.id, existing.id));
 
-    // Propagate the correction to the merchant's default category (tier 2 of the
-    // categorization pipeline) so future synced transactions from this merchant
-    // categorize correctly instead of needing the same manual fix every time.
-    if (parsedCatId.data !== null && existing.merchantId) {
+    if (parsedCatId.data === null || !existing.merchantId) {
+      return;
+    }
+
+    const [merchant] = await tx
+      .select({ categoryId: merchants.categoryId })
+      .from(merchants)
+      .where(scoped.where(merchants, eq(merchants.id, existing.merchantId)))
+      .limit(1);
+
+    if (!merchant || merchant.categoryId === null) {
+      // No existing default to conflict with — safe to set it automatically. This is
+      // the common case: the first time we've seen this merchant get manually categorized.
       await tx.update(merchants)
         .set({ categoryId: parsedCatId.data, updatedAt: new Date() })
         .where(scoped.where(merchants, eq(merchants.id, existing.merchantId)));
+    } else if (merchant.categoryId !== parsedCatId.data) {
+      // Merchant already defaults to a different category. Since a merchant can
+      // legitimately span multiple categories (e.g. Amazon), don't silently overwrite
+      // that default for every other transaction from this merchant — surface the
+      // conflict so the caller can ask the user whether to apply it more broadly.
+      merchantCategoryConflict = { merchantId: existing.merchantId, currentCategoryId: merchant.categoryId };
     }
   });
 
   revalidatePath("/transactions");
-  return { success: true };
+  return merchantCategoryConflict ? { success: true, merchantCategoryConflict } : { success: true };
 }
 
 export async function updateTransactionCategory(
   transactionId: string,
   categoryId: string | null,
   db: LedgrDb = defaultDb,
-): Promise<{ success: true } | { error: string }> {
+): Promise<UpdateTransactionCategoryResult> {
   const auth = await authorizeAction();
   if ("error" in auth) return auth;
   return updateTransactionCategoryScoped(auth.householdId, transactionId, categoryId, db);

--- a/src/actions/transactions.ts
+++ b/src/actions/transactions.ts
@@ -4,7 +4,7 @@ import { eq, inArray } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { db as defaultDb, type LedgrDb } from "@/db";
-import { transactions } from "@/db/schema";
+import { transactions, merchants } from "@/db/schema";
 import { scopedQuery } from "@/lib/scoped-query";
 import { notDeleted } from "@/lib/query-helpers";
 import { authorizeAction } from "@/lib/auth/authorize-action";
@@ -49,7 +49,7 @@ export async function updateTransactionCategoryScoped(
 
   const scoped = scopedQuery(householdId, db);
   const [existing] = await db
-    .select({ id: transactions.id })
+    .select({ id: transactions.id, merchantId: transactions.merchantId })
     .from(transactions)
     .where(scoped.where(transactions, eq(transactions.id, transactionId), notDeleted(transactions)))
     .limit(1);
@@ -60,9 +60,20 @@ export async function updateTransactionCategoryScoped(
 
   const updates = buildCategoryUpdate(parsedCatId.data);
 
-  await db.update(transactions)
-    .set(updates)
-    .where(eq(transactions.id, existing.id));
+  await db.transaction(async (tx) => {
+    await tx.update(transactions)
+      .set(updates)
+      .where(eq(transactions.id, existing.id));
+
+    // Propagate the correction to the merchant's default category (tier 2 of the
+    // categorization pipeline) so future synced transactions from this merchant
+    // categorize correctly instead of needing the same manual fix every time.
+    if (parsedCatId.data !== null && existing.merchantId) {
+      await tx.update(merchants)
+        .set({ categoryId: parsedCatId.data, updatedAt: new Date() })
+        .where(scoped.where(merchants, eq(merchants.id, existing.merchantId)));
+    }
+  });
 
   revalidatePath("/transactions");
   return { success: true };

--- a/src/components/molecules/category-pill.tsx
+++ b/src/components/molecules/category-pill.tsx
@@ -3,11 +3,22 @@
 import { useState } from "react";
 import { useActionTransition } from "@/hooks/use-action-transition";
 import { updateTransactionCategory } from "@/actions/transactions";
+import { updateMerchantDefaultCategory } from "@/actions/merchants";
 import { Badge } from "@/components/ui/badge";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Command, CommandInput, CommandList, CommandEmpty } from "@/components/ui/command";
 import { CategoryCommandItems } from "@/components/molecules/category-command-items";
 import { categoryPillLabel } from "@/components/molecules/category-pill-label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import type { CategoryGroup } from "@/queries/categories";
 import { cn } from "@/lib/utils";
 
@@ -18,9 +29,18 @@ interface CategoryPillProps {
   categories: CategoryGroup[];
   disabled?: boolean;
   isTransfer?: boolean;
+  merchantId?: string | null;
+  merchantName?: string | null;
   onCategoryChange?: (categoryId: string | null, categoryName: string | null) => void;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+}
+
+interface MerchantConflict {
+  merchantId: string;
+  newCategoryId: string;
+  newCategoryName: string | null;
+  currentCategoryName: string | null;
 }
 
 export function CategoryPill({
@@ -29,13 +49,17 @@ export function CategoryPill({
   categories,
   disabled = false,
   isTransfer = false,
+  merchantId,
+  merchantName,
   onCategoryChange,
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
 }: CategoryPillProps) {
   const [internalOpen, setInternalOpen] = useState(false);
   const [categoryName, setCategoryName] = useState(currentCategoryName);
+  const [conflict, setConflict] = useState<MerchantConflict | null>(null);
   const { isPending, execute } = useActionTransition();
+  const { isPending: isApplyingToMerchant, execute: executeMerchantUpdate } = useActionTransition();
 
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
@@ -63,47 +87,89 @@ export function CategoryPill({
       const result = await updateTransactionCategory(transactionId, categoryId);
       if ("error" in result) {
         setCategoryName(prevName);
+        return result;
       }
+
+      if (result.merchantCategoryConflict && merchantId && categoryId) {
+        const currentCategoryName = categories
+          .flatMap((g) => g.categories)
+          .find((c) => c.id === result.merchantCategoryConflict!.currentCategoryId)?.name ?? null;
+        setConflict({ merchantId, newCategoryId: categoryId, newCategoryName: newName, currentCategoryName });
+      }
+
+      return result;
+    });
+  }
+
+  function handleApplyToMerchant() {
+    if (!conflict) return;
+    executeMerchantUpdate(async () => {
+      const result = await updateMerchantDefaultCategory(conflict.merchantId, conflict.newCategoryId);
+      setConflict(null);
       return result;
     });
   }
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        render={
-          <button
-            disabled={disabled || isPending}
-            className={cn(
-              "max-w-[140px] cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
-              isPending && "opacity-50",
+    <>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <button
+              disabled={disabled || isPending}
+              className={cn(
+                "max-w-[140px] cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
+                isPending && "opacity-50",
+              )}
+            />
+          }
+        >
+          <Badge variant="outline" className="text-xs truncate">
+            {(() => {
+              const { text, variant } = categoryPillLabel(categoryName, isTransfer);
+              if (variant === "category") return text;
+              return (
+                <span className={cn("text-muted-foreground", variant === "uncategorized" && "italic")}>
+                  {text}
+                </span>
+              );
+            })()}
+          </Badge>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-[220px] p-0">
+          <Command>
+            {totalCategoryCount > 20 && (
+              <CommandInput placeholder="Search categories..." />
             )}
-          />
-        }
-      >
-        <Badge variant="outline" className="text-xs truncate">
-          {(() => {
-            const { text, variant } = categoryPillLabel(categoryName, isTransfer);
-            if (variant === "category") return text;
-            return (
-              <span className={cn("text-muted-foreground", variant === "uncategorized" && "italic")}>
-                {text}
-              </span>
-            );
-          })()}
-        </Badge>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-[220px] p-0">
-        <Command>
-          {totalCategoryCount > 20 && (
-            <CommandInput placeholder="Search categories..." />
-          )}
-          <CommandList>
-            <CommandEmpty>No category found.</CommandEmpty>
-            <CategoryCommandItems categories={categories} onSelect={handleSelect} />
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
+            <CommandList>
+              <CommandEmpty>No category found.</CommandEmpty>
+              <CategoryCommandItems categories={categories} onSelect={handleSelect} />
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      <AlertDialog open={conflict !== null} onOpenChange={(open) => { if (!open) setConflict(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Update {merchantName ?? "this merchant"}&apos;s default category too?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {merchantName ?? "This merchant"}&apos;s transactions currently default to{" "}
+              {conflict?.currentCategoryName ?? "no category"}. You just categorized this transaction
+              as {conflict?.newCategoryName ?? "uncategorized"}. Apply that to future transactions
+              from this merchant too, or just keep it for this one?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isApplyingToMerchant}>Just this transaction</AlertDialogCancel>
+            <AlertDialogAction onClick={handleApplyToMerchant} disabled={isApplyingToMerchant}>
+              {isApplyingToMerchant ? "Updating..." : "Update default too"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/src/components/molecules/transaction-row.tsx
+++ b/src/components/molecules/transaction-row.tsx
@@ -110,6 +110,8 @@ export const TransactionRow = memo(function TransactionRow({
           categories={categories}
           disabled={txn.hasSplits}
           isTransfer={txn.isTransfer}
+          merchantId={txn.merchantId}
+          merchantName={txn.merchantName}
         />
       </div>
 

--- a/src/components/organisms/transaction-detail-panel.tsx
+++ b/src/components/organisms/transaction-detail-panel.tsx
@@ -127,6 +127,8 @@ export function TransactionDetailPanel({
               currentCategoryName={txn.categoryName}
               categories={categories}
               isTransfer={txn.isTransfer}
+              merchantId={txn.merchantId}
+              merchantName={txn.merchantName}
             />
           </div>
         )}

--- a/tests/integration/merchant-actions.test.ts
+++ b/tests/integration/merchant-actions.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { createTestDb } from "./setup";
+import { insertHousehold, insertMerchant, insertCategoryGroup, insertCategory } from "./helpers";
+import { updateMerchantDefaultCategory } from "../../src/actions/merchants";
+import { merchants } from "../../src/db/schema";
+import { eq } from "drizzle-orm";
+import type { LedgrDb } from "../../src/db";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("../../src/lib/demo-mode", () => ({ guardDemoMode: vi.fn(() => null) }));
+
+const mockUserId = "test-user-id";
+let mockHouseholdId: string;
+vi.mock("../../src/lib/auth/session", () => ({
+  getHouseholdId: vi.fn(() => Promise.resolve(mockHouseholdId)),
+  getSession: vi.fn(() => Promise.resolve({ user: { id: mockUserId } })),
+}));
+
+describe("updateMerchantDefaultCategory", () => {
+  let db: LedgrDb;
+  let close: () => Promise<void>;
+  let categoryId: string;
+
+  beforeAll(async () => {
+    ({ db, close } = await createTestDb());
+
+    const hh = await insertHousehold(db);
+    mockHouseholdId = hh.householdId;
+    const { groupId } = await insertCategoryGroup(db, hh.householdId);
+    ({ categoryId } = await insertCategory(db, hh.householdId, groupId, { name: "Travel" }));
+  });
+
+  afterAll(async () => {
+    await close();
+  });
+
+  it("sets the merchant's default category", async () => {
+    const { merchantId } = await insertMerchant(db, mockHouseholdId);
+
+    const result = await updateMerchantDefaultCategory(merchantId, categoryId, db);
+    expect(result).toEqual({ success: true });
+
+    const [row] = await db.select().from(merchants).where(eq(merchants.id, merchantId));
+    expect(row!.categoryId).toBe(categoryId);
+  });
+
+  it("only updates merchants belonging to the session household", async () => {
+    const { householdId: otherHouseholdId } = await insertHousehold(db, "Other");
+    const { merchantId: otherMerchantId } = await insertMerchant(db, otherHouseholdId);
+
+    const result = await updateMerchantDefaultCategory(otherMerchantId, categoryId, db);
+    expect(result).toEqual({ error: "Merchant not found" });
+
+    const [row] = await db.select().from(merchants).where(eq(merchants.id, otherMerchantId));
+    expect(row!.categoryId).toBeNull();
+  });
+
+  it("returns an error for a nonexistent merchant", async () => {
+    const result = await updateMerchantDefaultCategory("no-such-merchant", categoryId, db);
+    expect(result).toEqual({ error: "Merchant not found" });
+  });
+});

--- a/tests/integration/transaction-actions.test.ts
+++ b/tests/integration/transaction-actions.test.ts
@@ -6,6 +6,7 @@ import {
   insertTransaction,
   insertCategoryGroup,
   insertCategory,
+  insertMerchant,
 } from "./helpers";
 import {
   updateTransactionCategory,
@@ -13,7 +14,7 @@ import {
   bulkUpdateCategory,
   bulkMarkReviewed,
 } from "../../src/actions/transactions";
-import { transactions } from "../../src/db/schema";
+import { transactions, merchants } from "../../src/db/schema";
 import { eq } from "drizzle-orm";
 import type { LedgrDb } from "../../src/db";
 
@@ -68,6 +69,41 @@ describe("transaction actions", () => {
       const [row] = await db.select().from(transactions).where(eq(transactions.id, txnId));
       expect(row!.categoryId).toBeNull();
       expect(row!.reviewed).toBe(false);
+    });
+
+    it("also sets the merchant's default category so future syncs pick it up (ISSUE-004)", async () => {
+      const { merchantId } = await insertMerchant(db, mockHouseholdId);
+      const { transactionId } = await insertTransaction(db, mockHouseholdId, accountId, { merchantId });
+
+      const result = await updateTransactionCategory(transactionId, categoryId, db);
+      expect(result).toEqual({ success: true });
+
+      const [merchantRow] = await db.select().from(merchants).where(eq(merchants.id, merchantId));
+      expect(merchantRow!.categoryId).toBe(categoryId);
+    });
+
+    it("does not clear the merchant's default category when clearing a transaction's category", async () => {
+      const { merchantId } = await insertMerchant(db, mockHouseholdId, { categoryId });
+      const { transactionId } = await insertTransaction(db, mockHouseholdId, accountId, {
+        merchantId,
+        categoryId,
+      });
+
+      const result = await updateTransactionCategory(transactionId, null, db);
+      expect(result).toEqual({ success: true });
+
+      const [merchantRow] = await db.select().from(merchants).where(eq(merchants.id, merchantId));
+      expect(merchantRow!.categoryId).toBe(categoryId);
+    });
+
+    it("leaves merchants untouched when the transaction has no merchant", async () => {
+      const { transactionId } = await insertTransaction(db, mockHouseholdId, accountId);
+
+      const result = await updateTransactionCategory(transactionId, categoryId, db);
+      expect(result).toEqual({ success: true });
+
+      const [row] = await db.select().from(transactions).where(eq(transactions.id, transactionId));
+      expect(row!.categoryId).toBe(categoryId);
     });
   });
 

--- a/tests/integration/transaction-actions.test.ts
+++ b/tests/integration/transaction-actions.test.ts
@@ -33,6 +33,7 @@ describe("transaction actions", () => {
   let close: () => Promise<void>;
   let accountId: string;
   let categoryId: string;
+  let secondCategoryId: string;
   let txnId: string;
 
   beforeAll(async () => {
@@ -43,6 +44,7 @@ describe("transaction actions", () => {
     ({ accountId } = await insertAccount(db, hh.householdId));
     const { groupId } = await insertCategoryGroup(db, hh.householdId);
     ({ categoryId } = await insertCategory(db, hh.householdId, groupId, { name: "Groceries" }));
+    ({ categoryId: secondCategoryId } = await insertCategory(db, hh.householdId, groupId, { name: "Restaurants" }));
   });
 
   afterAll(async () => {
@@ -104,6 +106,31 @@ describe("transaction actions", () => {
 
       const [row] = await db.select().from(transactions).where(eq(transactions.id, transactionId));
       expect(row!.categoryId).toBe(categoryId);
+    });
+
+    it("flags a conflict instead of overwriting the merchant's existing different default", async () => {
+      const { merchantId } = await insertMerchant(db, mockHouseholdId, { categoryId });
+      const { transactionId } = await insertTransaction(db, mockHouseholdId, accountId, { merchantId });
+
+      const result = await updateTransactionCategory(transactionId, secondCategoryId, db);
+      expect(result).toEqual({
+        success: true,
+        merchantCategoryConflict: { merchantId, currentCategoryId: categoryId },
+      });
+
+      const [row] = await db.select().from(transactions).where(eq(transactions.id, transactionId));
+      expect(row!.categoryId).toBe(secondCategoryId);
+
+      const [merchantRow] = await db.select().from(merchants).where(eq(merchants.id, merchantId));
+      expect(merchantRow!.categoryId).toBe(categoryId);
+    });
+
+    it("does not report a conflict when the new category matches the merchant's existing default", async () => {
+      const { merchantId } = await insertMerchant(db, mockHouseholdId, { categoryId });
+      const { transactionId } = await insertTransaction(db, mockHouseholdId, accountId, { merchantId });
+
+      const result = await updateTransactionCategory(transactionId, categoryId, db);
+      expect(result).toEqual({ success: true });
     });
   });
 


### PR DESCRIPTION
## Problem

Correcting a transaction's category only updates that single `transactions` row (`updateTransactionCategoryScoped`, `src/actions/transactions.ts`). It never touches `merchants.categoryId` (tier 2 of the categorization pipeline, `merchant_default`), so a recurring merchant has to be manually re-categorized on every future sync — the correction never generalizes.

## Fix

When a category is set (not cleared) on a transaction that has a `merchantId`:

- If the merchant has **no default category yet**, set it automatically — this is the common case (first time this merchant has been manually categorized), and there's nothing to conflict with.
- If the merchant **already defaults to the same category**, nothing more to do.
- If the merchant **already defaults to a different category**, the action does *not* silently overwrite it. A merchant can legitimately span multiple categories (Amazon, Costco, Venmo, etc.), so blindly propagating every edit would risk corrupting a default that's correct for the merchant's other transactions. Instead, `updateTransactionCategoryScoped` reports a `merchantCategoryConflict` in its result, and `CategoryPill` surfaces it as a confirmation dialog — *"Comcast currently defaults to Utilities. Update just this transaction, or update the default too?"* — backed by a new, explicit action (`updateMerchantDefaultCategory`) the user opts into.

Clearing a transaction's category (setting it to `null`) never touches the merchant default, regardless.

Both the server action (`updateTransactionCategory`) and the MCP tool (`update_transaction_category`) go through the same function, so both get the fix; the MCP tool's JSON result also now carries the conflict info if present, which an AI client could act on.

## Testing

- Integration tests in `tests/integration/transaction-actions.test.ts`:
  - setting a category on a merchant-linked transaction with no existing default auto-sets it
  - clearing a transaction's category never touches the merchant default
  - a transaction with no merchant still updates without error
  - setting a category that conflicts with the merchant's existing default reports `merchantCategoryConflict` and leaves the merchant untouched
  - setting a category that matches the merchant's existing default reports no conflict
- New `tests/integration/merchant-actions.test.ts` covers `updateMerchantDefaultCategory`, including household-scoping.
- Manually verified the original (no-conflict) path end-to-end against a running app.