### PR TITLE
fix: stop auth middleware from redirecting manifest.json to login

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy } from "@/proxy";
+
+function requestFor(pathname: string): NextRequest {
+  return new NextRequest(new URL(pathname, "http://localhost:4200"));
+}
+
+describe("proxy", () => {
+  it("does not redirect unauthenticated requests for the web app manifest", () => {
+    const response = proxy(requestFor("/manifest.json"));
+    expect(response.status).not.toBe(307);
+  });
+
+  it("redirects unauthenticated requests for protected pages to /login", () => {
+    const response = proxy(requestFor("/dashboard"));
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("/login");
+  });
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSessionCookie } from "better-auth/cookies";
 
-const publicPaths = ["/login", "/signup", "/api/auth", "/api/health", "/api/plaid/oauth-return", "/api/plaid/webhook", "/.well-known", "/api/mcp"];
+const publicPaths = ["/login", "/signup", "/api/auth", "/api/health", "/api/plaid/oauth-return", "/api/plaid/webhook", "/.well-known", "/api/mcp", "/manifest.json", "/robots.txt"];
 
 export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -23,5 +23,8 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|public).*)"],
+  // `public/` files are served at the URL root (not under a `/public` prefix), so
+  // excluding the literal segment "public" here matches nothing — exclude by
+  // static file extension instead.
+  matcher: ["/((?!_next/static|_next/image|.*\\.(?:ico|png|jpg|jpeg|svg|json|txt|xml|webmanifest)$).*)"],
 };


### PR DESCRIPTION
Closes #58. The proxy middleware matcher tried to exclude public/ static assets via a literal 'public' path segment, but public/ files are served at the URL root with no /public prefix, so that exclusion matched nothing. Chrome fetches the web app manifest without credentials, so it hit the auth redirect and got the login page HTML back instead of JSON, logging a console syntax error on every page load. Fixed by explicitly allowlisting manifest.json/robots.txt and correcting the matcher to exclude by static file extension. Verified live: /manifest.json now returns 200 instead of a 307 to /login.