### PR TITLE
fix: sanitize mojibake in SimpleFIN account names

### DIFF
--- a/src/actions/simplefin.ts
+++ b/src/actions/simplefin.ts
@@ -7,6 +7,7 @@ import { claimSetupToken, simplefinRequest, SimplefinHttpError } from "@/lib/sim
 import { SimplefinAccountsResponseSchema, resolveInstitution } from "@/lib/simplefin/schemas";
 import { syncConnection } from "@/lib/simplefin/sync";
 import { fetchFaviconDataUri } from "@/lib/favicon";
+import { sanitizeMojibake } from "@/lib/text-utils";
 import { encrypt } from "@/lib/encryption";
 import { simplefinAmountToCents } from "@/lib/money";
 import { todayDateString } from "@/lib/date-utils";
@@ -182,7 +183,7 @@ export async function claimAndDiscoverAccountsDirect(
           institutionName,
           accounts: groupAccounts.map((account) => ({
             externalAccountId: account.id,
-            name: account.name,
+            name: sanitizeMojibake(account.name),
             currency: account.currency,
             currentBalanceCents: simplefinAmountToCents(account.balance),
             availableBalanceCents: account["available-balance"]
@@ -288,7 +289,7 @@ export async function confirmSimplefinAccountsDirect(
           const existing = existingLive ?? existingDeleted;
 
           const accountFields = {
-            name: account.name,
+            name: sanitizeMojibake(account.name),
             type: account.type,
             currentBalance: account.currentBalanceCents,
             availableBalance: account.availableBalanceCents,

--- a/src/lib/text-utils.test.ts
+++ b/src/lib/text-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { titleCase } from "./text-utils";
+import { titleCase, sanitizeMojibake } from "./text-utils";
 
 describe("titleCase", () => {
   test("trims, lowercases, and capitalizes each word", () => {
@@ -14,5 +14,21 @@ describe("titleCase", () => {
 
   test("empty string stays empty", () => {
     expect(titleCase("")).toBe("");
+  });
+});
+
+describe("sanitizeMojibake", () => {
+  test("collapses a run of replacement characters into a single space", () => {
+    expect(sanitizeMojibake("WELLS FARGO AUTOGRAPH VISA�� CARD ...2842")).toBe(
+      "WELLS FARGO AUTOGRAPH VISA CARD ...2842",
+    );
+  });
+
+  test("removes a single stray replacement character", () => {
+    expect(sanitizeMojibake("Citi Custom Cash� Card")).toBe("Citi Custom Cash Card");
+  });
+
+  test("leaves clean names untouched", () => {
+    expect(sanitizeMojibake("Checking-1135")).toBe("Checking-1135");
   });
 });

--- a/src/lib/text-utils.ts
+++ b/src/lib/text-utils.ts
@@ -4,3 +4,15 @@ export function titleCase(str: string): string {
     .toLowerCase()
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
+
+/**
+ * Collapses runs of the Unicode replacement character (U+FFFD) — left behind
+ * when an upstream feed (e.g. a bank's SimpleFIN/Plaid response) mis-decodes
+ * a byte sequence before we ever see it — into a single space, then trims.
+ */
+export function sanitizeMojibake(str: string): string {
+  return str
+    .replace(/�+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}


### PR DESCRIPTION
Closes #55. Adds sanitizeMojibake() to src/lib/text-utils.ts and applies it at the two points a SimpleFIN account name enters our system (discovery display, confirmation persistence). Also cleaned up the already-corrupted Wells Fargo account name in the dev DB as a one-off data fix (not part of this migration - future syncs of new accounts will be clean going forward via this fix).