### PR TITLE
fix: exclude transfers from dashboard income/expense totals

### DIFF
--- a/src/queries/dashboard.ts
+++ b/src/queries/dashboard.ts
@@ -98,7 +98,9 @@ export async function getDashboardSummary(
         notDeleted(transactions),
         gte(transactions.date, dateFrom),
         lte(transactions.date, dateTo),
-        eq(transactions.pending, false)
+        eq(transactions.pending, false),
+        eq(transactions.isTransfer, false),
+        isNull(transactions.transferPairId)
       )
     );
 

--- a/tests/integration/dashboard-queries.test.ts
+++ b/tests/integration/dashboard-queries.test.ts
@@ -76,6 +76,42 @@ describe("getDashboardSummary", () => {
     expect(result.monthlyIncome).toBe(200000);
     expect(result.monthlyNet).toBe(200000 - 3000);
   });
+
+  it("excludes transfer transactions from income and expenses", async () => {
+    const { householdId } = await insertHousehold(db);
+    const { accountId } = await insertAccount(db, householdId, {
+      type: "checking",
+      currentBalance: 100000,
+    });
+
+    const thisMonth = new Date().toISOString().slice(0, 7);
+
+    // A real expense and a real income transaction.
+    await insertTransaction(db, householdId, accountId, {
+      date: `${thisMonth}-05`,
+      normalizedAmount: -3000,
+      amount: 3000,
+    });
+    await insertTransaction(db, householdId, accountId, {
+      date: `${thisMonth}-06`,
+      normalizedAmount: 20000,
+      amount: -20000,
+    });
+
+    // A self-transfer between the household's own accounts must not count as
+    // either income or spending, even though its amount is a large positive.
+    await insertTransaction(db, householdId, accountId, {
+      date: `${thisMonth}-10`,
+      normalizedAmount: 500000,
+      amount: -500000,
+      isTransfer: true,
+    });
+
+    const result = await getDashboardSummary(householdId, undefined, db);
+
+    expect(result.monthlyExpenses).toBe(3000);
+    expect(result.monthlyIncome).toBe(20000);
+  });
 });
 
 describe("getNetWorthHistory", () => {


### PR DESCRIPTION
Closes #52. getDashboardSummary summed normalizedAmount by sign with no transfer exclusion, unlike getCashFlow in the same file which correctly excludes isTransfer/transferPairId rows. This is why the Income tile disagreed with the Cash Flow chart directly below it. Added a regression test mirroring getCashFlow's existing transfer-exclusion test.