### PR TITLE
feat: auto-backfill balance_history on startup after a gap

### DIFF
--- a/src/lib/jobs/snapshot-balances.ts
+++ b/src/lib/jobs/snapshot-balances.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNotNull, isNull, ne } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, ne, sql } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 import { db as defaultDb, type LedgrDb } from "@/db";
 import { accounts, balanceHistory } from "@/db/schema";
@@ -27,4 +27,12 @@ export async function snapshotBalances(dbInstance: LedgrDb = defaultDb): Promise
       .values({ id: uuid(), accountId: account.id, date, balance: account.currentBalance })
       .onConflictDoNothing({ target: [balanceHistory.accountId, balanceHistory.date] });
   }
+}
+
+/** Most recent balance_history date across every household, or null if there are no snapshots yet. */
+export async function getLastSnapshotDate(dbInstance: LedgrDb = defaultDb): Promise<string | null> {
+  const [row] = await dbInstance
+    .select({ maxDate: sql<string | null>`MAX(${balanceHistory.date})` })
+    .from(balanceHistory);
+  return row?.maxDate ?? null;
 }

--- a/src/lib/scheduler/index.ts
+++ b/src/lib/scheduler/index.ts
@@ -4,6 +4,7 @@ import { runTask } from "./runner";
 import { runNightlySnapshot } from "./tasks/nightly-snapshot";
 import { runDailySafetySync } from "./tasks/daily-safety-sync";
 import { runDailySimplefinSync } from "./tasks/daily-simplefin-sync";
+import { checkBalanceHistoryGap } from "./tasks/startup-backfill-check";
 
 let started = false;
 let jobs: Array<ReturnType<typeof cron.schedule>> = [];
@@ -28,6 +29,10 @@ export function startScheduler(): void {
     started = true;
     return;
   }
+
+  // One-shot, not scheduled: catches up on any gap left by downtime through
+  // the nightly snapshot window before the first cron tick ever fires.
+  void runTask("startup-backfill-check", () => checkBalanceHistoryGap());
 
   jobs.push(
     cron.schedule(config.snapshotCron, () =>

--- a/src/lib/scheduler/tasks/startup-backfill-check.test.ts
+++ b/src/lib/scheduler/tasks/startup-backfill-check.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { checkBalanceHistoryGap } from "./startup-backfill-check";
+import type { LedgrDb } from "@/db";
+
+describe("checkBalanceHistoryGap", () => {
+  const fakeDb = {} as LedgrDb;
+
+  it("does nothing when the last snapshot is recent", async () => {
+    const backfill = vi.fn();
+    const today = new Date().toISOString().slice(0, 10);
+
+    await checkBalanceHistoryGap({
+      db: fakeDb,
+      getLastSnapshotDate: vi.fn().mockResolvedValue(today),
+      backfill,
+    });
+
+    expect(backfill).not.toHaveBeenCalled();
+  });
+
+  it("triggers a backfill and warns when the gap exceeds the threshold", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const backfill = vi.fn().mockResolvedValue(undefined);
+
+    const staleDate = (() => {
+      const d = new Date();
+      d.setDate(d.getDate() - 10);
+      return d.toISOString().slice(0, 10);
+    })();
+
+    await checkBalanceHistoryGap({
+      db: fakeDb,
+      getLastSnapshotDate: vi.fn().mockResolvedValue(staleDate),
+      backfill,
+    });
+
+    expect(backfill).toHaveBeenCalledWith(fakeDb);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("balance_history gap detected"));
+  });
+
+  it("triggers a backfill when there are no snapshots at all", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const backfill = vi.fn().mockResolvedValue(undefined);
+
+    await checkBalanceHistoryGap({
+      db: fakeDb,
+      getLastSnapshotDate: vi.fn().mockResolvedValue(null),
+      backfill,
+    });
+
+    expect(backfill).toHaveBeenCalledWith(fakeDb);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("no balance_history snapshots found"));
+  });
+
+  it("logs an error but does not throw when the backfill itself fails", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const backfill = vi.fn().mockRejectedValue(new Error("db unreachable"));
+
+    await expect(
+      checkBalanceHistoryGap({
+        db: fakeDb,
+        getLastSnapshotDate: vi.fn().mockResolvedValue(null),
+        backfill,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(err).toHaveBeenCalledWith(
+      expect.stringContaining("startup backfill failed"),
+      expect.any(Error),
+    );
+  });
+});

--- a/src/lib/scheduler/tasks/startup-backfill-check.ts
+++ b/src/lib/scheduler/tasks/startup-backfill-check.ts
@@ -1,0 +1,45 @@
+import { db as defaultDb, type LedgrDb } from "@/db";
+import { getLastSnapshotDate as defaultGetLastSnapshotDate } from "@/lib/jobs/snapshot-balances";
+import { backfillAccountBalances as defaultBackfillAccountBalances } from "@/lib/jobs/backfill-balances";
+import { todayDateString } from "@/lib/date-utils";
+
+/** Beyond this many days without a snapshot, assume the server was down through one or more nightly windows. */
+const GAP_WARNING_DAYS = 2;
+
+type Deps = {
+  db?: LedgrDb;
+  getLastSnapshotDate?: (db: LedgrDb) => Promise<string | null>;
+  backfill?: (db: LedgrDb) => Promise<void>;
+};
+
+/**
+ * Runs once at server startup. Self-hosted containers aren't guaranteed to run
+ * 24/7, and balance_history is otherwise only ever written by the nightly
+ * cron — so any downtime through that window leaves a permanent,
+ * unrecoverable gap in net-worth history unless something notices and
+ * backfills it. This is that something.
+ */
+export async function checkBalanceHistoryGap(deps: Deps = {}): Promise<void> {
+  const db = deps.db ?? defaultDb;
+  const getLastSnapshotDate = deps.getLastSnapshotDate ?? defaultGetLastSnapshotDate;
+  const backfill = deps.backfill ?? defaultBackfillAccountBalances;
+
+  const lastDate = await getLastSnapshotDate(db);
+  const gapDays = lastDate
+    ? Math.floor((Date.parse(todayDateString()) - Date.parse(lastDate)) / 86_400_000)
+    : Infinity;
+
+  if (gapDays <= GAP_WARNING_DAYS) return;
+
+  console.warn(
+    lastDate
+      ? `[scheduler] balance_history gap detected: last snapshot was ${lastDate} (${gapDays} days ago) — running backfill`
+      : "[scheduler] no balance_history snapshots found — running backfill",
+  );
+
+  try {
+    await backfill(db);
+  } catch (err) {
+    console.error("[scheduler] startup backfill failed", err);
+  }
+}

--- a/tests/integration/balance-snapshot.test.ts
+++ b/tests/integration/balance-snapshot.test.ts
@@ -1,7 +1,8 @@
+import { v4 as uuid } from "uuid";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createTestDb } from "./setup";
 import { insertHousehold, insertAccount } from "./helpers";
-import { snapshotBalances } from "@/lib/jobs/snapshot-balances";
+import { snapshotBalances, getLastSnapshotDate } from "@/lib/jobs/snapshot-balances";
 import { balanceHistory } from "@/db/schema";
 import type { LedgrDb } from "@/db";
 
@@ -66,5 +67,35 @@ describe("snapshotBalances", () => {
     } finally {
       await close3();
     }
+  });
+});
+
+describe("getLastSnapshotDate", () => {
+  let db: LedgrDb;
+  let close: () => Promise<void>;
+
+  beforeAll(async () => {
+    ({ db, close } = await createTestDb());
+  });
+
+  afterAll(async () => {
+    await close();
+  });
+
+  it("returns null when there are no snapshots at all", async () => {
+    expect(await getLastSnapshotDate(db)).toBeNull();
+  });
+
+  it("returns the most recent date across all households", async () => {
+    const { householdId } = await insertHousehold(db);
+    const { accountId } = await insertAccount(db, householdId, { currentBalance: 1000 });
+
+    await db.insert(balanceHistory).values([
+      { id: uuid(), accountId, date: "2026-01-01", balance: 900 },
+      { id: uuid(), accountId, date: "2026-03-15", balance: 1000 },
+      { id: uuid(), accountId, date: "2026-02-10", balance: 950 },
+    ]);
+
+    expect(await getLastSnapshotDate(db)).toBe("2026-03-15");
   });
 });


### PR DESCRIPTION
Closes #56. Balance snapshots only happen via a nightly in-process cron; any container downtime through that window leaves a permanent gap in net-worth history, since backfill-balances.ts was CLI-only and never auto-invoked. Adds checkBalanceHistoryGap(), run once at server startup as a one-shot task alongside the existing cron jobs: if the last snapshot is more than 2 days old (or there is none), logs a warning and runs the existing cross-household backfill job.