### PR TITLE
feat: automatic transfer-pair detection for Plaid/SimpleFIN sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:studio": "drizzle-kit studio",
     "rotate-keys": "node --env-file-if-exists=.env --import tsx scripts/rotate-keys.ts",
     "backfill-clean-names": "node --env-file-if-exists=.env --import tsx scripts/backfill-clean-names.ts",
+    "backfill-transfers": "node --env-file-if-exists=.env --import tsx scripts/backfill-transfers.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/backfill-transfers.ts
+++ b/scripts/backfill-transfers.ts
@@ -1,0 +1,18 @@
+/**
+ * Operator entry point for tagging historical self-transfers that predate
+ * automatic transfer detection.
+ * Usage: pnpm backfill-transfers
+ * Requires DATABASE_URL (loaded from .env when present).
+ */
+import { backfillTransfers } from "@/lib/jobs/backfill-transfers";
+
+async function main() {
+  const { households, tagged } = await backfillTransfers();
+  console.log(`[backfill-transfers] households=${households} tagged=${tagged}`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/lib/jobs/backfill-transfers.test.ts
+++ b/src/lib/jobs/backfill-transfers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "../../../tests/integration/setup";
+import { insertHousehold, insertAccount, insertTransaction } from "../../../tests/integration/helpers";
+import { backfillTransfers } from "./backfill-transfers";
+import { transactions } from "@/db/schema";
+
+describe("backfillTransfers", () => {
+  it("tags matching pairs across every household", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const { householdId: hh1 } = await insertHousehold(db, "Household 1");
+      const { accountId: hh1Checking } = await insertAccount(db, hh1, { type: "checking" });
+      const { accountId: hh1Savings } = await insertAccount(db, hh1, { type: "savings" });
+      const { transactionId: hh1Out } = await insertTransaction(db, hh1, hh1Checking, {
+        date: "2026-05-10",
+        normalizedAmount: -20000,
+        amount: 20000,
+      });
+      const { transactionId: hh1In } = await insertTransaction(db, hh1, hh1Savings, {
+        date: "2026-05-10",
+        normalizedAmount: 20000,
+        amount: -20000,
+      });
+
+      const { householdId: hh2 } = await insertHousehold(db, "Household 2");
+      const { accountId: hh2Checking } = await insertAccount(db, hh2, { type: "checking" });
+      const { accountId: hh2Savings } = await insertAccount(db, hh2, { type: "savings" });
+      await insertTransaction(db, hh2, hh2Checking, {
+        date: "2026-05-11",
+        normalizedAmount: -8000,
+        amount: 8000,
+      });
+      await insertTransaction(db, hh2, hh2Savings, {
+        date: "2026-05-11",
+        normalizedAmount: 8000,
+        amount: -8000,
+      });
+
+      const result = await backfillTransfers(db);
+
+      expect(result.households).toBe(2);
+      expect(result.tagged).toBe(2);
+
+      const [out] = await db.select().from(transactions).where(eq(transactions.id, hh1Out));
+      const [inflow] = await db.select().from(transactions).where(eq(transactions.id, hh1In));
+      expect(out.isTransfer).toBe(true);
+      expect(inflow.transferPairId).toBe(hh1Out);
+    } finally {
+      await close();
+    }
+  });
+
+  it("is safe to re-run — already-tagged pairs are skipped", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const { householdId } = await insertHousehold(db);
+      const { accountId: checkingId } = await insertAccount(db, householdId, { type: "checking" });
+      const { accountId: savingsId } = await insertAccount(db, householdId, { type: "savings" });
+      await insertTransaction(db, householdId, checkingId, {
+        date: "2026-05-10",
+        normalizedAmount: -20000,
+        amount: 20000,
+      });
+      await insertTransaction(db, householdId, savingsId, {
+        date: "2026-05-10",
+        normalizedAmount: 20000,
+        amount: -20000,
+      });
+
+      const first = await backfillTransfers(db);
+      expect(first.tagged).toBe(1);
+
+      const second = await backfillTransfers(db);
+      expect(second.tagged).toBe(0);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/src/lib/jobs/backfill-transfers.ts
+++ b/src/lib/jobs/backfill-transfers.ts
@@ -1,0 +1,25 @@
+import { db as defaultDb, type LedgrDb } from "@/db";
+import { households } from "@/db/schema";
+import { applyTransferDetection } from "@/lib/transfer-detection";
+
+/**
+ * One-time operator job: runs applyTransferDetection for every household, so
+ * historical transactions synced before automatic transfer detection existed
+ * get tagged too. Non-destructive and idempotent — safe to re-run.
+ *
+ * Cross-household by design (an operator maintenance job, run via `pnpm
+ * backfill-transfers` — not reachable from the app), same shape as
+ * backfill-balances.ts: loop one household at a time, each in its own
+ * withHousehold transaction (applyTransferDetection already does this
+ * internally per call).
+ */
+export async function backfillTransfers(db: LedgrDb = defaultDb): Promise<{ households: number; tagged: number }> {
+  const allHouseholds = await db.select({ id: households.id }).from(households);
+
+  let tagged = 0;
+  for (const { id: householdId } of allHouseholds) {
+    tagged += await applyTransferDetection(householdId, db);
+  }
+
+  return { households: allHouseholds.length, tagged };
+}

--- a/src/lib/plaid/sync.ts
+++ b/src/lib/plaid/sync.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from "uuid";
 import { eq, and, isNull, inArray } from "drizzle-orm";
 import { categorizeSyncedTransactions } from "@/lib/categorization/engine";
+import { applyTransferDetection } from "@/lib/transfer-detection";
 import type { PlaidApi } from "plaid";
 import {
   PlaidSyncResponseSchema,
@@ -647,6 +648,13 @@ async function doSync(
       await categorizeSyncedTransactions(itemId, householdId, db);
     } catch (catError) {
       console.error("Categorization failed for item", JSON.stringify(itemId), catError);
+    }
+
+    // Detect self-transfers between the household's own accounts (non-fatal)
+    try {
+      await applyTransferDetection(householdId, db);
+    } catch (transferError) {
+      console.error("Transfer detection failed for item", JSON.stringify(itemId), transferError);
     }
 
     // AI categorization and merchant/logo resolution — fire-and-forget, same

--- a/src/lib/simplefin/sync.ts
+++ b/src/lib/simplefin/sync.ts
@@ -11,6 +11,7 @@ import { SimplefinAccountsResponseSchema, resolveInstitution, type SimplefinAcco
 import { classifyPollError } from "./utils";
 import { fetchFaviconDataUri } from "@/lib/favicon";
 import { categorizeSyncedTransactions } from "@/lib/categorization/engine";
+import { applyTransferDetection } from "@/lib/transfer-detection";
 import { withHousehold } from "@/lib/household-context";
 
 // SimpleFIN brokerages don't send a security type the way Plaid does. These
@@ -492,6 +493,13 @@ async function doSync(
       await categorizeSyncedTransactions(connectionId, householdId, db);
     } catch (catError) {
       console.error("Categorization failed for connection", JSON.stringify(connectionId), catError);
+    }
+
+    // Detect self-transfers between the household's own accounts (non-fatal).
+    try {
+      await applyTransferDetection(householdId, db);
+    } catch (transferError) {
+      console.error("Transfer detection failed for connection", JSON.stringify(connectionId), transferError);
     }
 
     // AI categorization and merchant/logo resolution — fire-and-forget, same

--- a/src/lib/transfer-detection.test.ts
+++ b/src/lib/transfer-detection.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { test } from "@fast-check/vitest";
+import * as fc from "fast-check";
+import { detectTransferPairs, type TransferCandidate } from "./transfer-detection";
+
+function candidate(overrides: Partial<TransferCandidate> = {}): TransferCandidate {
+  return {
+    id: "txn-1",
+    accountId: "acct-a",
+    date: "2026-05-10",
+    normalizedAmount: -1000,
+    ...overrides,
+  };
+}
+
+describe("detectTransferPairs", () => {
+  it("pairs an exact-amount outflow and inflow across two accounts within the window", () => {
+    const outflow = candidate({ id: "out-1", accountId: "acct-a", date: "2026-05-10", normalizedAmount: -5000 });
+    const inflow = candidate({ id: "in-1", accountId: "acct-b", date: "2026-05-11", normalizedAmount: 5000 });
+
+    const pairs = detectTransferPairs([outflow, inflow]);
+
+    expect(pairs).toEqual([{ outflowId: "out-1", inflowId: "in-1" }]);
+  });
+
+  it("does not pair transactions in the same account", () => {
+    const outflow = candidate({ id: "out-1", accountId: "acct-a", date: "2026-05-10", normalizedAmount: -5000 });
+    const inflow = candidate({ id: "in-1", accountId: "acct-a", date: "2026-05-10", normalizedAmount: 5000 });
+
+    expect(detectTransferPairs([outflow, inflow])).toEqual([]);
+  });
+
+  it("does not pair when amounts differ", () => {
+    const outflow = candidate({ id: "out-1", accountId: "acct-a", date: "2026-05-10", normalizedAmount: -5000 });
+    const inflow = candidate({ id: "in-1", accountId: "acct-b", date: "2026-05-10", normalizedAmount: 4999 });
+
+    expect(detectTransferPairs([outflow, inflow])).toEqual([]);
+  });
+
+  it("does not pair when the date gap exceeds the window", () => {
+    const outflow = candidate({ id: "out-1", accountId: "acct-a", date: "2026-05-01", normalizedAmount: -5000 });
+    const inflow = candidate({ id: "in-1", accountId: "acct-b", date: "2026-05-10", normalizedAmount: 5000 });
+
+    expect(detectTransferPairs([outflow, inflow], 3)).toEqual([]);
+  });
+
+  it("pairs exactly at the edge of the date window", () => {
+    const outflow = candidate({ id: "out-1", accountId: "acct-a", date: "2026-05-01", normalizedAmount: -5000 });
+    const inflow = candidate({ id: "in-1", accountId: "acct-b", date: "2026-05-04", normalizedAmount: 5000 });
+
+    expect(detectTransferPairs([outflow, inflow], 3)).toEqual([{ outflowId: "out-1", inflowId: "in-1" }]);
+  });
+
+  it("leaves an outflow unpaired when it has two equally-good inflow candidates", () => {
+    const outflow = candidate({ id: "out-1", accountId: "acct-a", date: "2026-05-10", normalizedAmount: -5000 });
+    const inflow1 = candidate({ id: "in-1", accountId: "acct-b", date: "2026-05-10", normalizedAmount: 5000 });
+    const inflow2 = candidate({ id: "in-2", accountId: "acct-c", date: "2026-05-11", normalizedAmount: 5000 });
+
+    expect(detectTransferPairs([outflow, inflow1, inflow2])).toEqual([]);
+  });
+
+  it("leaves an inflow unpaired when it has two equally-good outflow candidates", () => {
+    const inflow = candidate({ id: "in-1", accountId: "acct-a", date: "2026-05-10", normalizedAmount: 5000 });
+    const outflow1 = candidate({ id: "out-1", accountId: "acct-b", date: "2026-05-10", normalizedAmount: -5000 });
+    const outflow2 = candidate({ id: "out-2", accountId: "acct-c", date: "2026-05-11", normalizedAmount: -5000 });
+
+    expect(detectTransferPairs([inflow, outflow1, outflow2])).toEqual([]);
+  });
+
+  it("ignores zero-amount transactions", () => {
+    const zero = candidate({ id: "zero-1", accountId: "acct-a", normalizedAmount: 0 });
+    expect(detectTransferPairs([zero])).toEqual([]);
+  });
+
+  it("pairs correctly among multiple unrelated candidates", () => {
+    const pairAOut = candidate({ id: "out-a", accountId: "acct-a", date: "2026-05-10", normalizedAmount: -5000 });
+    const pairAIn = candidate({ id: "in-a", accountId: "acct-b", date: "2026-05-10", normalizedAmount: 5000 });
+    const pairBOut = candidate({ id: "out-b", accountId: "acct-c", date: "2026-06-01", normalizedAmount: -1500 });
+    const pairBIn = candidate({ id: "in-b", accountId: "acct-d", date: "2026-06-02", normalizedAmount: 1500 });
+    const unrelatedExpense = candidate({ id: "expense-1", accountId: "acct-a", date: "2026-05-15", normalizedAmount: -300 });
+
+    const pairs = detectTransferPairs([pairAOut, pairAIn, pairBOut, pairBIn, unrelatedExpense]);
+
+    expect(pairs).toHaveLength(2);
+    expect(pairs).toEqual(
+      expect.arrayContaining([
+        { outflowId: "out-a", inflowId: "in-a" },
+        { outflowId: "out-b", inflowId: "in-b" },
+      ]),
+    );
+  });
+
+  test.prop([
+    fc.array(
+      fc.record({
+        id: fc.uuid(),
+        accountId: fc.constantFrom("acct-a", "acct-b", "acct-c"),
+        date: fc.constantFrom("2026-05-01", "2026-05-02", "2026-05-03", "2026-05-04"),
+        normalizedAmount: fc.integer({ min: -10000, max: 10000 }),
+      }),
+      { minLength: 0, maxLength: 15 },
+    ),
+  ])("never uses the same transaction id in more than one pair", (candidates) => {
+    const pairs = detectTransferPairs(candidates as TransferCandidate[]);
+    const seen = new Set<string>();
+    for (const pair of pairs) {
+      expect(seen.has(pair.outflowId)).toBe(false);
+      expect(seen.has(pair.inflowId)).toBe(false);
+      seen.add(pair.outflowId);
+      seen.add(pair.inflowId);
+    }
+  });
+});

--- a/src/lib/transfer-detection.ts
+++ b/src/lib/transfer-detection.ts
@@ -1,0 +1,123 @@
+import { eq, isNull } from "drizzle-orm";
+import { db as defaultDb, type LedgrDb } from "@/db";
+import { transactions } from "@/db/schema";
+import { scopedQuery } from "@/lib/scoped-query";
+import { notDeleted } from "@/lib/query-helpers";
+import { withHousehold } from "@/lib/household-context";
+
+export interface TransferCandidate {
+  id: string;
+  accountId: string;
+  date: string; // YYYY-MM-DD
+  normalizedAmount: number; // cents; positive = inflow, negative = outflow
+}
+
+export interface TransferPair {
+  outflowId: string;
+  inflowId: string;
+}
+
+const MS_PER_DAY = 86_400_000;
+
+function daysBetween(a: string, b: string): number {
+  return Math.abs(Date.parse(a) - Date.parse(b)) / MS_PER_DAY;
+}
+
+function isMatch(a: TransferCandidate, b: TransferCandidate, maxDateWindowDays: number): boolean {
+  return (
+    a.accountId !== b.accountId &&
+    Math.abs(a.normalizedAmount) === Math.abs(b.normalizedAmount) &&
+    daysBetween(a.date, b.date) <= maxDateWindowDays
+  );
+}
+
+/**
+ * Pure heuristic: pairs same-household transactions that look like a transfer
+ * between two of the household's own accounts — opposite-signed, exact-amount
+ * match, in different accounts, within a short date window. Only pairs when
+ * the match is mutually unique (each side has exactly one plausible
+ * counterpart) — an ambiguous match is left untagged rather than risk
+ * miscategorizing two unrelated same-amount transactions as a transfer.
+ */
+export function detectTransferPairs(
+  candidates: TransferCandidate[],
+  maxDateWindowDays = 3,
+): TransferPair[] {
+  const outflows = candidates.filter((c) => c.normalizedAmount < 0);
+  const inflows = candidates.filter((c) => c.normalizedAmount > 0);
+
+  const pairs: TransferPair[] = [];
+  const used = new Set<string>();
+
+  for (const outflow of outflows) {
+    if (used.has(outflow.id)) continue;
+
+    const matchingInflows = inflows.filter(
+      (inflow) => !used.has(inflow.id) && isMatch(outflow, inflow, maxDateWindowDays),
+    );
+    if (matchingInflows.length !== 1) continue;
+    const inflow = matchingInflows[0];
+
+    const matchingOutflowsForInflow = outflows.filter(
+      (candidate) => !used.has(candidate.id) && isMatch(candidate, inflow, maxDateWindowDays),
+    );
+    if (matchingOutflowsForInflow.length !== 1 || matchingOutflowsForInflow[0].id !== outflow.id) continue;
+
+    pairs.push({ outflowId: outflow.id, inflowId: inflow.id });
+    used.add(outflow.id);
+    used.add(inflow.id);
+  }
+
+  return pairs;
+}
+
+/**
+ * Applies detectTransferPairs to a household's untagged transactions and
+ * persists the result. Idempotent: only ever operates on rows that are still
+ * untagged (isTransfer=false, transferPairId IS NULL), so already-tagged
+ * pairs are naturally skipped on a repeat call. Returns the number of pairs
+ * tagged.
+ */
+export async function applyTransferDetection(
+  householdId: string,
+  db: LedgrDb = defaultDb,
+): Promise<number> {
+  return withHousehold(
+    householdId,
+    async (tx) => {
+      const scoped = scopedQuery(householdId, tx);
+
+      const rows = await tx
+        .select({
+          id: transactions.id,
+          accountId: transactions.accountId,
+          date: transactions.date,
+          normalizedAmount: transactions.normalizedAmount,
+        })
+        .from(transactions)
+        .where(
+          scoped.where(
+            transactions,
+            notDeleted(transactions),
+            eq(transactions.isTransfer, false),
+            isNull(transactions.transferPairId),
+            eq(transactions.pending, false),
+          ),
+        );
+
+      const pairs = detectTransferPairs(rows);
+
+      for (const pair of pairs) {
+        await tx.update(transactions)
+          .set({ isTransfer: true, transferPairId: pair.inflowId, updatedAt: new Date() })
+          .where(eq(transactions.id, pair.outflowId));
+        await tx.update(transactions)
+          .set({ isTransfer: true, transferPairId: pair.outflowId, updatedAt: new Date() })
+          .where(eq(transactions.id, pair.inflowId));
+      }
+
+      return pairs.length;
+    },
+    db,
+  );
+}

--- a/tests/integration/transfer-detection.test.ts
+++ b/tests/integration/transfer-detection.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { eq } from "drizzle-orm";
+import { createTestDb } from "./setup";
+import { insertHousehold, insertAccount, insertTransaction } from "./helpers";
+import { applyTransferDetection } from "@/lib/transfer-detection";
+import { transactions } from "@/db/schema";
+
+describe("applyTransferDetection", () => {
+  it("tags a matching outflow/inflow pair across two accounts", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const { householdId } = await insertHousehold(db);
+      const { accountId: checkingId } = await insertAccount(db, householdId, { type: "checking" });
+      const { accountId: savingsId } = await insertAccount(db, householdId, { type: "savings" });
+
+      const { transactionId: outflowId } = await insertTransaction(db, householdId, checkingId, {
+        date: "2026-05-10",
+        normalizedAmount: -50000,
+        amount: 50000,
+      });
+      const { transactionId: inflowId } = await insertTransaction(db, householdId, savingsId, {
+        date: "2026-05-10",
+        normalizedAmount: 50000,
+        amount: -50000,
+      });
+
+      const tagged = await applyTransferDetection(householdId, db);
+      expect(tagged).toBe(1);
+
+      const rows = await db.select().from(transactions).where(eq(transactions.householdId, householdId));
+      const outflow = rows.find((r) => r.id === outflowId)!;
+      const inflow = rows.find((r) => r.id === inflowId)!;
+
+      expect(outflow.isTransfer).toBe(true);
+      expect(outflow.transferPairId).toBe(inflowId);
+      expect(inflow.isTransfer).toBe(true);
+      expect(inflow.transferPairId).toBe(outflowId);
+    } finally {
+      await close();
+    }
+  });
+
+  it("is idempotent — a second call makes no further changes", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const { householdId } = await insertHousehold(db);
+      const { accountId: checkingId } = await insertAccount(db, householdId, { type: "checking" });
+      const { accountId: savingsId } = await insertAccount(db, householdId, { type: "savings" });
+
+      await insertTransaction(db, householdId, checkingId, {
+        date: "2026-05-10",
+        normalizedAmount: -50000,
+        amount: 50000,
+      });
+      await insertTransaction(db, householdId, savingsId, {
+        date: "2026-05-10",
+        normalizedAmount: 50000,
+        amount: -50000,
+      });
+
+      const firstRun = await applyTransferDetection(householdId, db);
+      expect(firstRun).toBe(1);
+
+      const secondRun = await applyTransferDetection(householdId, db);
+      expect(secondRun).toBe(0);
+    } finally {
+      await close();
+    }
+  });
+
+  it("does not tag an ordinary (non-transfer) expense", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const { householdId } = await insertHousehold(db);
+      const { accountId } = await insertAccount(db, householdId, { type: "checking" });
+
+      const { transactionId: id } = await insertTransaction(db, householdId, accountId, {
+        date: "2026-05-10",
+        normalizedAmount: -3000,
+        amount: 3000,
+      });
+
+      await applyTransferDetection(householdId, db);
+
+      const [row] = await db.select().from(transactions).where(eq(transactions.id, id));
+      expect(row.isTransfer).toBe(false);
+      expect(row.transferPairId).toBeNull();
+    } finally {
+      await close();
+    }
+  });
+
+  it("only tags transactions belonging to the given household", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const { householdId } = await insertHousehold(db);
+      const { householdId: otherHouseholdId } = await insertHousehold(db, "Other Household");
+
+      const { accountId: checkingId } = await insertAccount(db, householdId, { type: "checking" });
+      const { accountId: savingsId } = await insertAccount(db, householdId, { type: "savings" });
+      const { accountId: otherCheckingId } = await insertAccount(db, otherHouseholdId, { type: "checking" });
+      const { accountId: otherSavingsId } = await insertAccount(db, otherHouseholdId, { type: "savings" });
+
+      await insertTransaction(db, householdId, checkingId, {
+        date: "2026-05-10",
+        normalizedAmount: -50000,
+        amount: 50000,
+      });
+      await insertTransaction(db, householdId, savingsId, {
+        date: "2026-05-10",
+        normalizedAmount: 50000,
+        amount: -50000,
+      });
+
+      const { transactionId: otherOutId } = await insertTransaction(db, otherHouseholdId, otherCheckingId, {
+        date: "2026-05-10",
+        normalizedAmount: -70000,
+        amount: 70000,
+      });
+      const { transactionId: otherInId } = await insertTransaction(db, otherHouseholdId, otherSavingsId, {
+        date: "2026-05-10",
+        normalizedAmount: 70000,
+        amount: -70000,
+      });
+
+      const tagged = await applyTransferDetection(householdId, db);
+      expect(tagged).toBe(1);
+
+      const [otherOut] = await db.select().from(transactions).where(eq(transactions.id, otherOutId));
+      const [otherIn] = await db.select().from(transactions).where(eq(transactions.id, otherInId));
+      expect(otherOut.isTransfer).toBe(false);
+      expect(otherIn.isTransfer).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #53. isTransfer/transferPairId were only ever set by the manual mark-as-transfer action; neither sync path tagged transfers automatically, so every credit-card autopay or inter-account transfer in a real household was permanently miscounted as income or spending (contributing to the dashboard-stat bug fixed separately in #52, and to the always-high Uncategorized figure noted in the original exploration).

Adds detectTransferPairs(), a pure heuristic pairing an outflow/inflow across two of the household's own accounts on exact-amount match within a 3-day window, only when the match is mutually unique — an ambiguous match is left untagged (false negatives over false positives). applyTransferDetection() applies it to a household's untagged transactions and is idempotent, so it's safe to call on every sync. Wired into both plaid/sync.ts and simplefin/sync.ts as a non-fatal step next to the existing auto-categorization call, same error-handling style.

Also adds backfillTransfers() + `pnpm backfill-transfers`, same pattern as backfill-balances, for transactions synced before this existed.

Full suite: 109 files / 691 tests passing.