### PR TITLE
fix: carry balances forward in net-worth history; detect interior snapshot gaps

### DIFF
--- a/src/lib/jobs/snapshot-balances.ts
+++ b/src/lib/jobs/snapshot-balances.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNotNull, isNull, ne, sql } from "drizzle-orm";
+import { and, eq, isNotNull, isNull, ne } from "drizzle-orm";
 import { v4 as uuid } from "uuid";
 import { db as defaultDb, type LedgrDb } from "@/db";
 import { accounts, balanceHistory } from "@/db/schema";
@@ -29,10 +29,15 @@ export async function snapshotBalances(dbInstance: LedgrDb = defaultDb): Promise
   }
 }
 
-/** Most recent balance_history date across every household, or null if there are no snapshots yet. */
-export async function getLastSnapshotDate(dbInstance: LedgrDb = defaultDb): Promise<string | null> {
-  const [row] = await dbInstance
-    .select({ maxDate: sql<string | null>`MAX(${balanceHistory.date})` })
-    .from(balanceHistory);
-  return row?.maxDate ?? null;
+/**
+ * Every distinct balance_history date across all households, ascending. The
+ * caller needs the whole series, not just the newest date, to tell a covered
+ * history apart from one with holes in it.
+ */
+export async function getSnapshotDates(dbInstance: LedgrDb = defaultDb): Promise<string[]> {
+  const rows = await dbInstance
+    .selectDistinct({ date: balanceHistory.date })
+    .from(balanceHistory)
+    .orderBy(balanceHistory.date);
+  return rows.map((r) => r.date);
 }

--- a/src/lib/scheduler/tasks/startup-backfill-check.test.ts
+++ b/src/lib/scheduler/tasks/startup-backfill-check.test.ts
@@ -1,55 +1,89 @@
 import { describe, it, expect, vi } from "vitest";
-import { checkBalanceHistoryGap } from "./startup-backfill-check";
+import { checkBalanceHistoryGap, largestGapDays } from "./startup-backfill-check";
 import type { LedgrDb } from "@/db";
+
+/** N days before `today`, as YYYY-MM-DD. */
+function daysBefore(today: string, n: number): string {
+  const d = new Date(today + "T00:00:00.000Z");
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+describe("largestGapDays", () => {
+  const today = "2026-08-29";
+
+  it("is Infinity when there are no snapshots at all", () => {
+    expect(largestGapDays([], today)).toBe(Infinity);
+  });
+
+  it("measures a hole in the middle of the series, not just staleness", () => {
+    // The real-world shape this was written for: yesterday's snapshot exists,
+    // so recency looks fine, but there is a 3.5-month hole behind it.
+    const dates = ["2026-05-12", "2026-08-28"];
+    expect(largestGapDays(dates, today)).toBeGreaterThan(100);
+  });
+
+  it("is small for a dense, current series", () => {
+    const dates = [3, 2, 1, 0].map((n) => daysBefore(today, n));
+    expect(largestGapDays(dates, today)).toBe(1);
+  });
+
+  it("counts the stretch from the newest snapshot to today", () => {
+    expect(largestGapDays([daysBefore(today, 30)], today)).toBe(30);
+  });
+});
 
 describe("checkBalanceHistoryGap", () => {
   const fakeDb = {} as LedgrDb;
+  const today = new Date().toISOString().slice(0, 10);
 
-  it("does nothing when the last snapshot is recent", async () => {
+  it("does nothing when history is dense and current", async () => {
     const backfill = vi.fn();
-    const today = new Date().toISOString().slice(0, 10);
-
     await checkBalanceHistoryGap({
       db: fakeDb,
-      getLastSnapshotDate: vi.fn().mockResolvedValue(today),
+      getSnapshotDates: vi.fn().mockResolvedValue([2, 1, 0].map((n) => daysBefore(today, n))),
       backfill,
     });
-
     expect(backfill).not.toHaveBeenCalled();
   });
 
-  it("triggers a backfill and warns when the gap exceeds the threshold", async () => {
+  it("backfills an interior gap even when the newest snapshot is recent", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const backfill = vi.fn().mockResolvedValue(undefined);
 
-    const staleDate = (() => {
-      const d = new Date();
-      d.setDate(d.getDate() - 10);
-      return d.toISOString().slice(0, 10);
-    })();
-
     await checkBalanceHistoryGap({
       db: fakeDb,
-      getLastSnapshotDate: vi.fn().mockResolvedValue(staleDate),
+      getSnapshotDates: vi
+        .fn()
+        .mockResolvedValue([daysBefore(today, 108), daysBefore(today, 1)]),
       backfill,
     });
 
     expect(backfill).toHaveBeenCalledWith(fakeDb);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("balance_history gap detected"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("balance_history gap"));
   });
 
-  it("triggers a backfill when there are no snapshots at all", async () => {
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  it("backfills when the newest snapshot is stale", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     const backfill = vi.fn().mockResolvedValue(undefined);
-
     await checkBalanceHistoryGap({
       db: fakeDb,
-      getLastSnapshotDate: vi.fn().mockResolvedValue(null),
+      getSnapshotDates: vi.fn().mockResolvedValue([daysBefore(today, 30)]),
       backfill,
     });
-
     expect(backfill).toHaveBeenCalledWith(fakeDb);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("no balance_history snapshots found"));
+  });
+
+  it("backfills when there are no snapshots at all", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const backfill = vi.fn().mockResolvedValue(undefined);
+    await checkBalanceHistoryGap({
+      db: fakeDb,
+      getSnapshotDates: vi.fn().mockResolvedValue([]),
+      backfill,
+    });
+    expect(backfill).toHaveBeenCalledWith(fakeDb);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("no balance_history snapshots"));
   });
 
   it("logs an error but does not throw when the backfill itself fails", async () => {
@@ -60,7 +94,7 @@ describe("checkBalanceHistoryGap", () => {
     await expect(
       checkBalanceHistoryGap({
         db: fakeDb,
-        getLastSnapshotDate: vi.fn().mockResolvedValue(null),
+        getSnapshotDates: vi.fn().mockResolvedValue([]),
         backfill,
       }),
     ).resolves.toBeUndefined();

--- a/src/lib/scheduler/tasks/startup-backfill-check.ts
+++ b/src/lib/scheduler/tasks/startup-backfill-check.ts
@@ -1,40 +1,62 @@
 import { db as defaultDb, type LedgrDb } from "@/db";
-import { getLastSnapshotDate as defaultGetLastSnapshotDate } from "@/lib/jobs/snapshot-balances";
+import { getSnapshotDates as defaultGetSnapshotDates } from "@/lib/jobs/snapshot-balances";
 import { backfillAccountBalances as defaultBackfillAccountBalances } from "@/lib/jobs/backfill-balances";
 import { todayDateString } from "@/lib/date-utils";
 
-/** Beyond this many days without a snapshot, assume the server was down through one or more nightly windows. */
-const GAP_WARNING_DAYS = 2;
+/** Beyond this many consecutive days with no snapshot, the series has a hole worth filling. */
+const GAP_THRESHOLD_DAYS = 2;
+
+const MS_PER_DAY = 86_400_000;
 
 type Deps = {
   db?: LedgrDb;
-  getLastSnapshotDate?: (db: LedgrDb) => Promise<string | null>;
+  getSnapshotDates?: (db: LedgrDb) => Promise<string[]>;
   backfill?: (db: LedgrDb) => Promise<void>;
 };
 
 /**
+ * Widest run of consecutive days with no snapshot, including the stretch from
+ * the newest snapshot up to `today`. Infinity when there are none at all.
+ *
+ * Looking only at the newest snapshot is not enough: a nightly snapshot taken
+ * yesterday says nothing about whether the months behind it are covered, and
+ * downtime leaves exactly that shape — a current tail over an interior hole.
+ */
+export function largestGapDays(dates: string[], today: string): number {
+  if (dates.length === 0) return Infinity;
+
+  const sorted = [...dates].sort();
+  let largest = 0;
+  for (let i = 1; i < sorted.length; i++) {
+    const gap = (Date.parse(sorted[i]) - Date.parse(sorted[i - 1])) / MS_PER_DAY;
+    if (gap > largest) largest = gap;
+  }
+
+  const trailing = (Date.parse(today) - Date.parse(sorted[sorted.length - 1])) / MS_PER_DAY;
+  return Math.max(largest, trailing);
+}
+
+/**
  * Runs once at server startup. Self-hosted containers aren't guaranteed to run
  * 24/7, and balance_history is otherwise only ever written by the nightly
- * cron — so any downtime through that window leaves a permanent,
- * unrecoverable gap in net-worth history unless something notices and
- * backfills it. This is that something.
+ * cron — so any downtime through that window leaves a gap in net-worth history
+ * that nothing else repairs. The backfill is non-destructive
+ * (onConflictDoNothing), so re-running it is always safe.
  */
 export async function checkBalanceHistoryGap(deps: Deps = {}): Promise<void> {
   const db = deps.db ?? defaultDb;
-  const getLastSnapshotDate = deps.getLastSnapshotDate ?? defaultGetLastSnapshotDate;
+  const getSnapshotDates = deps.getSnapshotDates ?? defaultGetSnapshotDates;
   const backfill = deps.backfill ?? defaultBackfillAccountBalances;
 
-  const lastDate = await getLastSnapshotDate(db);
-  const gapDays = lastDate
-    ? Math.floor((Date.parse(todayDateString()) - Date.parse(lastDate)) / 86_400_000)
-    : Infinity;
+  const dates = await getSnapshotDates(db);
+  const gap = largestGapDays(dates, todayDateString());
 
-  if (gapDays <= GAP_WARNING_DAYS) return;
+  if (gap <= GAP_THRESHOLD_DAYS) return;
 
   console.warn(
-    lastDate
-      ? `[scheduler] balance_history gap detected: last snapshot was ${lastDate} (${gapDays} days ago) — running backfill`
-      : "[scheduler] no balance_history snapshots found — running backfill",
+    dates.length === 0
+      ? "[scheduler] no balance_history snapshots found — running backfill"
+      : `[scheduler] balance_history gap of ${gap} days detected — running backfill`,
   );
 
   try {

--- a/src/queries/dashboard.ts
+++ b/src/queries/dashboard.ts
@@ -1,4 +1,4 @@
-import { eq, gte, lte, and, desc, inArray, isNull, sql } from "drizzle-orm";
+import { eq, gte, lte, lt, and, desc, inArray, isNull, sql } from "drizzle-orm";
 export { getInvestmentsSummary } from "./investments";
 import { db as defaultDb, type LedgrDb } from "@/db";
 import {
@@ -146,38 +146,80 @@ export async function getNetWorthHistory(
   const assetIds = accountIds.filter(
     (id) => classifyAccountType(accountTypeMap.get(id) ?? "other") === "asset",
   );
-  const liabilityIds = accountIds.filter(
-    (id) => classifyAccountType(accountTypeMap.get(id) ?? "other") === "liability",
-  );
-
-  let result: NetWorthPoint[] = [];
+  // classifyAccountType is total over asset|liability, so anything not an
+  // asset is a liability — no separate liability list needed.
+  const result: NetWorthPoint[] = [];
   if (accountIds.length > 0) {
-    const inAssets = assetIds.length > 0 ? inArray(balanceHistory.accountId, assetIds) : sql`false`;
-    const inLiabilities =
-      liabilityIds.length > 0 ? inArray(balanceHistory.accountId, liabilityIds) : sql`false`;
+    const assetIdSet = new Set(assetIds);
+
+    // Last known balance per account, carried across dates. Snapshot coverage
+    // is uneven in practice — balance reconstruction fills depository accounts
+    // densely but leaves investment accounts with only occasional rows — so a
+    // date with no row for an account means "unchanged", never "worth zero".
+    // Summing only the rows present on each date silently zeroes those
+    // accounts and produces a wildly wrong series.
+    const lastBalanceByAccount = new Map<string, number>();
+
+    // Seed from the most recent balance *before* the window, so an account
+    // whose only snapshot predates dateFrom still contributes to every point.
+    if (dateFrom) {
+      const seeds = await db
+        .selectDistinctOn([balanceHistory.accountId], {
+          accountId: balanceHistory.accountId,
+          balance: balanceHistory.balance,
+        })
+        .from(balanceHistory)
+        .where(
+          and(
+            inArray(balanceHistory.accountId, accountIds),
+            lt(balanceHistory.date, dateFrom),
+          ),
+        )
+        .orderBy(balanceHistory.accountId, desc(balanceHistory.date));
+
+      for (const seed of seeds) {
+        lastBalanceByAccount.set(seed.accountId, seed.balance ?? 0);
+      }
+    }
 
     const conditions = [inArray(balanceHistory.accountId, accountIds)];
     if (dateFrom) {
       conditions.push(gte(balanceHistory.date, dateFrom));
     }
 
+    // Row volume here is accounts x snapshot-days, small enough that folding
+    // in JS is clearer than the SQL gap-fill equivalent.
     const rows = await db
       .select({
         date: balanceHistory.date,
-        assets: sql<number>`COALESCE(SUM(CASE WHEN ${inAssets} THEN ${balanceHistory.balance} ELSE 0 END), 0)`.mapWith(Number),
-        liabilities: sql<number>`COALESCE(SUM(CASE WHEN ${inLiabilities} THEN ${balanceHistory.balance} ELSE 0 END), 0)`.mapWith(Number),
+        accountId: balanceHistory.accountId,
+        balance: balanceHistory.balance,
       })
       .from(balanceHistory)
       .where(and(...conditions))
-      .groupBy(balanceHistory.date)
       .orderBy(balanceHistory.date);
 
-    result = rows.map(({ date, assets, liabilities }) => ({
-      date,
-      assets,
-      liabilities,
-      netWorth: assets - liabilities,
-    }));
+    const byDate = new Map<string, { accountId: string; balance: number }[]>();
+    for (const row of rows) {
+      const bucket = byDate.get(row.date) ?? [];
+      bucket.push({ accountId: row.accountId, balance: row.balance ?? 0 });
+      byDate.set(row.date, bucket);
+    }
+
+    for (const date of [...byDate.keys()].sort()) {
+      for (const row of byDate.get(date)!) {
+        lastBalanceByAccount.set(row.accountId, row.balance);
+      }
+
+      let assets = 0;
+      let liabilities = 0;
+      for (const [id, balance] of lastBalanceByAccount) {
+        if (assetIdSet.has(id)) assets += balance;
+        else liabilities += balance;
+      }
+
+      result.push({ date, assets, liabilities, netWorth: assets - liabilities });
+    }
   }
 
   // Synthetic today point from live currentBalance. Only emit it when at least

--- a/tests/integration/balance-snapshot.test.ts
+++ b/tests/integration/balance-snapshot.test.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from "uuid";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { createTestDb } from "./setup";
 import { insertHousehold, insertAccount } from "./helpers";
-import { snapshotBalances, getLastSnapshotDate } from "@/lib/jobs/snapshot-balances";
+import { snapshotBalances, getSnapshotDates } from "@/lib/jobs/snapshot-balances";
 import { balanceHistory } from "@/db/schema";
 import type { LedgrDb } from "@/db";
 
@@ -70,7 +70,7 @@ describe("snapshotBalances", () => {
   });
 });
 
-describe("getLastSnapshotDate", () => {
+describe("getSnapshotDates", () => {
   let db: LedgrDb;
   let close: () => Promise<void>;
 
@@ -82,20 +82,23 @@ describe("getLastSnapshotDate", () => {
     await close();
   });
 
-  it("returns null when there are no snapshots at all", async () => {
-    expect(await getLastSnapshotDate(db)).toBeNull();
+  it("returns an empty list when there are no snapshots at all", async () => {
+    expect(await getSnapshotDates(db)).toEqual([]);
   });
 
-  it("returns the most recent date across all households", async () => {
+  it("returns every distinct date ascending, deduplicated across accounts", async () => {
     const { householdId } = await insertHousehold(db);
     const { accountId } = await insertAccount(db, householdId, { currentBalance: 1000 });
+    const { accountId: second } = await insertAccount(db, householdId, { currentBalance: 500 });
 
     await db.insert(balanceHistory).values([
       { id: uuid(), accountId, date: "2026-01-01", balance: 900 },
       { id: uuid(), accountId, date: "2026-03-15", balance: 1000 },
       { id: uuid(), accountId, date: "2026-02-10", balance: 950 },
+      // Same date on a second account must not appear twice.
+      { id: uuid(), accountId: second, date: "2026-02-10", balance: 500 },
     ]);
 
-    expect(await getLastSnapshotDate(db)).toBe("2026-03-15");
+    expect(await getSnapshotDates(db)).toEqual(["2026-01-01", "2026-02-10", "2026-03-15"]);
   });
 });

--- a/tests/integration/dashboard-queries.test.ts
+++ b/tests/integration/dashboard-queries.test.ts
@@ -184,6 +184,71 @@ describe("getNetWorthHistory", () => {
     expect(point.netWorth).toBe(70000);
   });
 
+  it("carries an account's last known balance forward to dates it has no row for", async () => {
+    // The real-world shape: balance reconstruction covers depository accounts
+    // densely but leaves investment accounts with only sparse snapshots. A
+    // missing row must mean "unchanged", not "worth zero".
+    const { householdId } = await insertHousehold(db);
+    const { accountId: checkingId } = await insertAccount(db, householdId, {
+      type: "checking",
+      currentBalance: 10000,
+    });
+    const { accountId: brokerageId } = await insertAccount(db, householdId, {
+      type: "investment",
+      currentBalance: 500000,
+    });
+
+    const day = (n: number) => {
+      const d = new Date();
+      d.setUTCDate(d.getUTCDate() - n);
+      return d.toISOString().slice(0, 10);
+    };
+
+    // Checking has a row on both days; the brokerage only on the earlier one.
+    await db.insert(balanceHistory).values([
+      { id: uuid(), accountId: checkingId, date: day(20), balance: 9000 },
+      { id: uuid(), accountId: checkingId, date: day(10), balance: 10000 },
+      { id: uuid(), accountId: brokerageId, date: day(20), balance: 400000 },
+    ]);
+
+    const result = await getNetWorthHistory(householdId, "3M", db);
+
+    const later = result.find((p) => p.date === day(10))!;
+    expect(later).toBeDefined();
+    // 10000 checking + 400000 brokerage carried forward — not 10000 alone.
+    expect(later.assets).toBe(410000);
+  });
+
+  it("seeds carry-forward from the last balance before the window starts", async () => {
+    const { householdId } = await insertHousehold(db);
+    const { accountId: brokerageId } = await insertAccount(db, householdId, {
+      type: "investment",
+      currentBalance: 500000,
+    });
+    const { accountId: checkingId } = await insertAccount(db, householdId, {
+      type: "checking",
+      currentBalance: 10000,
+    });
+
+    const day = (n: number) => {
+      const d = new Date();
+      d.setUTCDate(d.getUTCDate() - n);
+      return d.toISOString().slice(0, 10);
+    };
+
+    // The brokerage's only snapshot predates the 1M window entirely.
+    await db.insert(balanceHistory).values([
+      { id: uuid(), accountId: brokerageId, date: day(120), balance: 400000 },
+      { id: uuid(), accountId: checkingId, date: day(5), balance: 10000 },
+    ]);
+
+    const result = await getNetWorthHistory(householdId, "1M", db);
+
+    const point = result.find((p) => p.date === day(5))!;
+    expect(point).toBeDefined();
+    expect(point.assets).toBe(410000);
+  });
+
   it("returns empty array when no account has a balance", async () => {
     // The CSV-import scenario: accounts exist but carry no balance, so there is
     // no net worth to plot. The chart must see an empty series to render its


### PR DESCRIPTION
Fixes #68. Refs #67.

getNetWorthHistory aggregated with SUM(CASE WHEN account_id IN (...) THEN balance ELSE 0 END) GROUP BY date, which sums only the rows that exist on each date. An account with no snapshot that day was counted as worth zero rather than unchanged. Snapshot coverage is uneven in practice - balance reconstruction fills depository accounts densely and skips investment accounts entirely - so this silently zeroed the largest accounts across most of the series.

Each account's last known balance now carries across dates, seeded via a DISTINCT ON query from the most recent balance before the window so an account whose only snapshot predates dateFrom still contributes. Folded in JS rather than SQL gap-fill: row volume is accounts x snapshot-days, and the JS version is far easier to read and test. Also drops the now-redundant liabilityIds list, since classifyAccountType is total over asset|liability.

checkBalanceHistoryGap (from #63) inspected only MAX(balance_history.date), so it detected a stale tail but was blind to holes behind it - which is exactly the shape downtime leaves. Replaced getLastSnapshotDate with getSnapshotDates and added a pure largestGapDays() that measures the widest uncovered run across the series, including the stretch up to today.

Four new tests: two integration tests proving carry-forward and pre-window seeding, plus unit tests for largestGapDays covering the interior-hole case that let the original bug ship green.

IMPORTANT - #67 stays open deliberately. On real data this is necessary but not sufficient: 97% of the test household's net worth sits in investment accounts whose first balance_history row is 2026-08-28, and holdings_history starts there too. There is no source of truth for their earlier value, so carry-forward has nothing to carry and any backfill still renders a cliff. The startup gate is therefore intentionally left as-is (currently a no-op for this shape) rather than enabled. See #67 for the remaining work.

Full suite: 111 files / 714 tests passing.