### PR TITLE
fix: narrow the proxy matcher and actually test it

### DIFF
--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { NextRequest } from "next/server";
-import { proxy } from "@/proxy";
+import { proxy, matcherPattern } from "@/proxy";
 
 function requestFor(pathname: string): NextRequest {
   return new NextRequest(new URL(pathname, "http://localhost:4200"));
+}
+
+/** Mirrors what Next.js does: only run the middleware on matching paths. */
+function wouldRunMiddleware(pathname: string): boolean {
+  return matcherPattern.test(pathname);
 }
 
 describe("proxy", () => {
@@ -16,5 +21,29 @@ describe("proxy", () => {
     const response = proxy(requestFor("/dashboard"));
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toContain("/login");
+  });
+});
+
+describe("proxy matcher", () => {
+  // Next.js applies config.matcher itself, so this has to be asserted against
+  // the pattern directly — calling proxy() never exercises it.
+  it("skips the framework and public static assets", () => {
+    for (const p of ["/_next/static/chunk.js", "/_next/image", "/favicon.ico", "/icon-192.png"]) {
+      expect(wouldRunMiddleware(p)).toBe(false);
+    }
+  });
+
+  it("still runs for pages, API routes, and the manifest", () => {
+    for (const p of ["/", "/dashboard", "/transactions", "/api/export/transactions", "/manifest.json"]) {
+      expect(wouldRunMiddleware(p)).toBe(true);
+    }
+  });
+
+  it("does not exempt a route merely because it ends in a static-looking extension", () => {
+    // Regression guard: a broad extension exclusion here would silently take
+    // routes like these outside the auth middleware entirely.
+    for (const p of ["/api/export/transactions.json", "/api/reports/data.xml", "/secret.txt"]) {
+      expect(wouldRunMiddleware(p)).toBe(true);
+    }
   });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,9 +22,15 @@ export function proxy(request: NextRequest) {
   return NextResponse.next();
 }
 
+// Kept deliberately narrow. An earlier version excluded every path ending in a
+// static-looking extension (.json, .txt, .xml, …), which would have silently
+// exempted any future route such as /api/export/transactions.json from auth.
+// Files served out of `public/` live at the URL root — there is no `/public`
+// prefix to exclude — so name the handful of real ones instead. Anything else
+// public belongs in `publicPaths` above, which is covered by tests.
 export const config = {
-  // `public/` files are served at the URL root (not under a `/public` prefix), so
-  // excluding the literal segment "public" here matches nothing — exclude by
-  // static file extension instead.
-  matcher: ["/((?!_next/static|_next/image|.*\\.(?:ico|png|jpg|jpeg|svg|json|txt|xml|webmanifest)$).*)"],
+  matcher: ["/((?!_next/static|_next/image|favicon\\.ico|icon-\\d+\\.png).*)"],
 };
+
+/** Exported for tests: the matcher above, as a RegExp over the pathname. */
+export const matcherPattern = new RegExp(`^${config.matcher[0]}$`);


### PR DESCRIPTION
Fixes #70. Two problems from #59.

The matcher excluded every path ending in .ico/.png/.jpg/.jpeg/.svg/.json/.txt/.xml/.webmanifest. That was redundant - adding /manifest.json and /robots.txt to publicPaths already fixed the manifest bug on its own - and it broadened the auth-bypass surface: any future route ending in one of those extensions (an export endpoint, say) would silently never reach the middleware. Not exploitable today, since pages check getSession() and API routes check getHouseholdId() independently, but it erodes defense-in-depth for no benefit. Narrowed to the framework paths plus the handful of real public/ files.

The tests were worse than absent. They call proxy() directly, but Next.js applies config.matcher in the framework, never in that function - so the regex had zero coverage and both tests passed identically with the original matcher, the broadened one, or a catastrophically broad one, while reading as green validation of the change. The pattern is now exported and asserted directly, including a regression guard that routes ending in .json/.xml/.txt still go through auth.