### PR TITLE
fix: detect cash and money-market holdings instead of charting them as stock

### DIFF
--- a/src/lib/simplefin/sync.test.ts
+++ b/src/lib/simplefin/sync.test.ts
@@ -178,6 +178,16 @@ describe("processHoldings", () => {
     expect(result[0].type).toBe("stock");
   });
 
+  it("classifies a SimpleFIN currency symbol as cash, not stock", () => {
+    const result = processHoldings([makeAccount({ holdings: [makeHolding({ symbol: "CUR:USD" })] })]);
+    expect(result[0].type).toBe("cash");
+  });
+
+  it("classifies a money-market sweep fund as cash, not stock", () => {
+    const result = processHoldings([makeAccount({ holdings: [makeHolding({ symbol: "SPAXX" })] })]);
+    expect(result[0].type).toBe("cash");
+  });
+
   it("falls back to type other when there's no ticker at all", () => {
     const result = processHoldings([makeAccount({ holdings: [makeHolding({ symbol: null })] })]);
     expect(result[0].type).toBe("other");

--- a/src/lib/simplefin/sync.ts
+++ b/src/lib/simplefin/sync.ts
@@ -25,10 +25,25 @@ const KNOWN_ETF_SYMBOLS = new Set([
   "VOO", "VTI", "SPY", "IVV", "QQQ", "QQQM", "VXUS", "VUG", "VYM", "VEA", "VWO",
   "SCHD", "ARKK", "IWM", "DIA", "GLD", "SLV", "XLK", "XLF", "XLE", "XLV",
 ]);
+// Sweep/money-market positions. Without these they'd fall through to the
+// "stock" default and be charted as equity exposure, which is the opposite of
+// what they are.
+const KNOWN_CASH_SYMBOLS = new Set([
+  "SPAXX", "VMFXX", "SWVXX", "FDRXX", "VMRXX", "SPRXX", "FZFXX", "SNVXX", "SNSXX",
+]);
+
+/**
+ * SimpleFIN denotes a plain currency balance as `CUR:USD` and similar, rather
+ * than a security symbol.
+ */
+function isCurrencySymbol(ticker: string): boolean {
+  return ticker.startsWith("CUR:");
+}
 
 function inferHoldingType(symbol: string | null): HoldingRow["type"] {
   if (!symbol) return "other";
   const ticker = symbol.toUpperCase();
+  if (isCurrencySymbol(ticker) || KNOWN_CASH_SYMBOLS.has(ticker)) return "cash";
   if (KNOWN_CRYPTO_SYMBOLS.has(ticker)) return "crypto";
   if (KNOWN_BOND_SYMBOLS.has(ticker)) return "bond";
   if (KNOWN_ETF_SYMBOLS.has(ticker)) return "etf";
@@ -79,7 +94,7 @@ export interface HoldingRow {
   quantity: number;
   costBasis: number | null;
   currentValue: number;
-  type: "crypto" | "etf" | "bond" | "stock" | "other";
+  type: "crypto" | "etf" | "bond" | "stock" | "cash" | "other";
   currency: string;
 }
 


### PR DESCRIPTION
Fixes #71. #61 changed the fallback for unrecognized tickers from 'other' to 'stock', which made the Asset Allocation chart useful but turned one class of uncertainty into a confident error: SimpleFIN currency balances (CUR:USD) and money-market sweep funds (SPAXX, VMFXX, SWVXX, …) were charted as equity exposure.

Both are now detected explicitly - CUR: by prefix, money-market by a static list - and map to the existing 'cash' holding type, which until now was only ever produced by the Plaid path.

Kept 'stock' as the fallback rather than reverting to 'other': on a retail brokerage the remaining long tail really is mostly individual equities, and reverting would restore the original 'Other 100%' chart that #57 was filed about. Cash was the case with a clean detection rule and a clearly wrong answer.

Note for existing data: SimpleFIN holdings are replaced as a full snapshot each sync, so live holdings re-type on the next sync rather than immediately - all 8 holdings in the dev DB are still 'other' from before #61.