### PR TITLE
fix: fail loudly when migrations are silently skipped

### DIFF
--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -1,7 +1,9 @@
-import { dirname } from "node:path";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { drizzle } from "drizzle-orm/node-postgres";
 import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { sql } from "drizzle-orm";
 import pg from "pg";
 
 if (!process.env.DATABASE_URL) {
@@ -14,6 +16,32 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const MAX_RETRIES = 5;
 const RETRY_DELAY_MS = 3_000;
 
+/**
+ * drizzle-kit decides what to apply by comparing each journal entry's `when`
+ * against the newest `created_at` already recorded. One entry with a
+ * out-of-order (e.g. future) timestamp therefore makes every later migration
+ * look already-applied, and they are skipped *while the run reports success* —
+ * the schema silently drifts behind the code. Comparing counts catches that.
+ */
+async function assertNoSilentDrift(db) {
+  const journal = JSON.parse(readFileSync(join(__dirname, "meta", "_journal.json"), "utf8"));
+  const expected = journal.entries.length;
+
+  const result = await db.execute(
+    sql`SELECT count(*)::int AS count FROM drizzle.__drizzle_migrations`,
+  );
+  const applied = Number((result.rows ?? result)[0].count);
+
+  if (applied < expected) {
+    throw new Error(
+      `Migration drift: ${applied} of ${expected} migrations are recorded as applied, ` +
+        `but the run reported success. This usually means a journal entry carries an ` +
+        `out-of-order timestamp, causing drizzle-kit to skip later migrations silently. ` +
+        `Compare src/db/migrations/meta/_journal.json against drizzle.__drizzle_migrations.`,
+    );
+  }
+}
+
 for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
   const pool = new pg.Pool({
     connectionString: process.env.DATABASE_URL,
@@ -24,6 +52,17 @@ for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
   try {
     const db = drizzle({ client: pool });
     await migrate(db, { migrationsFolder: __dirname });
+
+    // Drift is a deterministic bug in the journal, never a transient fault —
+    // fail immediately instead of burning the retry budget on it.
+    try {
+      await assertNoSilentDrift(db);
+    } catch (driftErr) {
+      console.error(driftErr.message);
+      await pool.end();
+      process.exit(1);
+    }
+
     console.log("Migrations complete");
     await pool.end();
     process.exit(0);


### PR DESCRIPTION
Fixes #75.

drizzle-kit decides what to apply by comparing each journal entry's when against the newest created_at already recorded in drizzle.__drizzle_migrations. A single entry with an out-of-order timestamp therefore makes every later migration look already-applied: they get skipped while the run prints 'migrations applied successfully', and the schema drifts behind the code with no signal at all.

This is the root cause of the drift hit repeatedly in this repo. Journal entry 0005 carried when=1788478800000 (2026-09-03, in the future and out of order with its neighbours), which became max(created_at). The 0008 migration added in #76 reported success three runs in a row and never created its column. The journal entry itself was corrected in #76; this PR adds the guard so the next occurrence cannot pass unnoticed.

scripts/migrate.mjs now compares the recorded migration count against the journal entry count after migrating and exits 1 on a shortfall, with a message pointing at both sides to compare. Drift is a deterministic journal bug rather than a transient fault, so it bypasses the connection retry loop instead of burning all five attempts.

Verified both directions against the dev DB: passes normally, and reproducing the real condition (a valid migration file whose journal entry carries an out-of-order timestamp) produces 'Migration drift: 9 of 10 migrations are recorded as applied' and exit 1.

Note for operators: any database that already recorded the bad timestamp still needs a one-row UPDATE on drizzle.__drizzle_migrations.created_at, or its next migration will silently no-op. This guard turns that into a loud failure rather than fixing it automatically.