### PR TITLE
fix: refuse cross-household backfills that RLS would silently empty

### DIFF
--- a/src/lib/jobs/backfill-balances.ts
+++ b/src/lib/jobs/backfill-balances.ts
@@ -3,6 +3,7 @@ import { db as defaultDb, type LedgrDb } from "@/db";
 import { accounts, balanceHistory, transactions, households } from "@/db/schema";
 import { todayDateString } from "@/lib/date-utils";
 import { withHousehold } from "@/lib/household-context";
+import { assertCanEnumerateHouseholds } from "@/lib/jobs/cross-household";
 import { v4 as uuid } from "uuid";
 
 /**
@@ -23,6 +24,7 @@ import { v4 as uuid } from "uuid";
  * APP_DATABASE_URL role instead of the admin one (docs/rls-pilot.md).
  */
 export async function backfillAccountBalances(db: LedgrDb = defaultDb): Promise<void> {
+  await assertCanEnumerateHouseholds(db);
   const allHouseholds = await db.select({ id: households.id }).from(households);
   for (const { id: householdId } of allHouseholds) {
     await backfillForHousehold(householdId, db);

--- a/src/lib/jobs/backfill-transfers.ts
+++ b/src/lib/jobs/backfill-transfers.ts
@@ -1,6 +1,7 @@
 import { db as defaultDb, type LedgrDb } from "@/db";
 import { households } from "@/db/schema";
 import { applyTransferDetection } from "@/lib/transfer-detection";
+import { assertCanEnumerateHouseholds } from "@/lib/jobs/cross-household";
 
 /**
  * One-time operator job: runs applyTransferDetection for every household, so
@@ -14,6 +15,7 @@ import { applyTransferDetection } from "@/lib/transfer-detection";
  * internally per call).
  */
 export async function backfillTransfers(db: LedgrDb = defaultDb): Promise<{ households: number; tagged: number }> {
+  await assertCanEnumerateHouseholds(db);
   const allHouseholds = await db.select({ id: households.id }).from(households);
 
   let tagged = 0;

--- a/src/lib/jobs/cross-household.test.ts
+++ b/src/lib/jobs/cross-household.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { assertCanEnumerateHouseholds } from "./cross-household";
+import type { LedgrDb } from "@/db";
+
+function dbReturning(rows: unknown[]): LedgrDb {
+  return { execute: vi.fn().mockResolvedValue({ rows }) } as unknown as LedgrDb;
+}
+
+describe("assertCanEnumerateHouseholds", () => {
+  it("allows the job when RLS is not enabled on households", async () => {
+    const db = dbReturning([{ rls_enabled: false, bypasses_rls: false }]);
+    await expect(assertCanEnumerateHouseholds(db)).resolves.toBeUndefined();
+  });
+
+  it("allows the job when RLS is enabled but the role bypasses it", async () => {
+    const db = dbReturning([{ rls_enabled: true, bypasses_rls: true }]);
+    await expect(assertCanEnumerateHouseholds(db)).resolves.toBeUndefined();
+  });
+
+  it("refuses rather than silently processing zero households", async () => {
+    const db = dbReturning([{ rls_enabled: true, bypasses_rls: false }]);
+    await expect(assertCanEnumerateHouseholds(db)).rejects.toThrow(
+      /Cannot enumerate households/,
+    );
+  });
+
+  it("stays out of the way when the table cannot be resolved", async () => {
+    const db = dbReturning([]);
+    await expect(assertCanEnumerateHouseholds(db)).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/jobs/cross-household.ts
+++ b/src/lib/jobs/cross-household.ts
@@ -1,0 +1,38 @@
+import { sql } from "drizzle-orm";
+import type { LedgrDb } from "@/db";
+
+/**
+ * Guards the operator backfill jobs, which enumerate every household rather
+ * than working inside a single withHousehold() scope.
+ *
+ * The RLS policies fail closed: with no `app.household_id` set, a restricted
+ * role sees zero rows. Today only `transactions` has RLS enabled, so these
+ * jobs work — but the documented plan (docs/rls-pilot.md) is to extend it to
+ * the remaining household-scoped tables. The day `households` is covered,
+ * these jobs would quietly iterate nothing and report success, which looks
+ * exactly like "there was nothing to do". Fail loudly instead.
+ */
+export async function assertCanEnumerateHouseholds(db: LedgrDb): Promise<void> {
+  // to_regclass respects search_path, so this resolves correctly under the
+  // per-file schemas the integration tests run in.
+  const result = await db.execute(sql`
+    SELECT c.relrowsecurity AS rls_enabled,
+           COALESCE((SELECT r.rolbypassrls FROM pg_roles r WHERE r.rolname = current_user), false) AS bypasses_rls
+    FROM pg_class c
+    WHERE c.oid = to_regclass('households')
+  `);
+
+  const row = (result.rows ?? result)[0] as
+    | { rls_enabled: boolean; bypasses_rls: boolean }
+    | undefined;
+  if (!row) return; // No such table — let the caller's own query surface it.
+
+  if (row.rls_enabled && !row.bypasses_rls) {
+    throw new Error(
+      "Cannot enumerate households: row-level security is enabled on `households` and the " +
+        "current role does not bypass it, so this job would silently process zero households " +
+        "and report success. Run it with the admin DATABASE_URL rather than APP_DATABASE_URL " +
+        "(see docs/rls-pilot.md).",
+    );
+  }
+}


### PR DESCRIPTION
Fixes #73. Latent rather than currently broken.

backfillAccountBalances and backfillTransfers both begin with db.select().from(households) with no app.household_id GUC set, because they are cross-household operator jobs rather than scoped app code. That works today only because docs/rls-pilot.md has RLS enabled on transactions alone. The documented plan is to extend it to the remaining household-scoped tables, and the policy fails closed - with no GUC set, a restricted role sees zero rows. The day households is covered, both jobs would iterate nothing, do nothing, and print a successful-looking summary (households=0 tagged=0).

Adds assertCanEnumerateHouseholds(), called at the top of both jobs. It asks Postgres whether RLS is enabled on households and whether the current role bypasses it, and throws with a message pointing at the admin DATABASE_URL vs APP_DATABASE_URL distinction when the combination would silently hide everything. Uses to_regclass so it resolves correctly under the per-file schemas the integration tests run in.

Deliberately does not just treat 'zero households' as an error, since a genuinely fresh install legitimately has none - the check distinguishes 'hidden by RLS' from 'actually empty'.

Verified against the dev DB: pnpm backfill-transfers still reports households=6. Full suite 112 files / 723 tests passing.