### PR TITLE
fix: retire stale SimpleFIN streams and back-link their transactions

### DIFF
--- a/src/lib/simplefin/recurring.ts
+++ b/src/lib/simplefin/recurring.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, inArray, notInArray } from "drizzle-orm";
 import { db as defaultDb, type LedgrDb } from "@/db";
 import { transactions, recurringTransactions } from "@/db/schema";
 import { scopedQuery } from "@/lib/scoped-query";
@@ -127,7 +127,11 @@ export function detectRecurringGroups(candidates: RecurringCandidate[], today: s
  * rows have no plaidStreamId, so an existing row is matched by
  * (accountId, name) among rows where plaidStreamId IS NULL. Idempotent: a
  * repeat call with no new transactions updates existing rows to the same
- * values rather than duplicating them. Returns the number of groups applied.
+ * values rather than duplicating them.
+ *
+ * Each detected stream's transactions are back-linked via
+ * recurringTransactionId, and any SimpleFIN-sourced stream this pass did not
+ * re-detect is deactivated. Returns the number of groups applied.
  */
 export async function applyRecurringDetection(householdId: string, db: LedgrDb = defaultDb): Promise<number> {
   return withHousehold(
@@ -156,6 +160,7 @@ export async function applyRecurringDetection(householdId: string, db: LedgrDb =
 
       const groups = detectRecurringGroups(rows, todayDateString());
       const now = new Date();
+      const upsertedIds: string[] = [];
 
       for (const group of groups) {
         const [existing] = await tx
@@ -186,18 +191,53 @@ export async function applyRecurringDetection(householdId: string, db: LedgrDb =
           updatedAt: now,
         };
 
+        let recurringId: string;
         if (existing) {
+          recurringId = existing.id;
           await tx.update(recurringTransactions).set(fields).where(eq(recurringTransactions.id, existing.id));
         } else {
+          recurringId = uuid();
           await tx.insert(recurringTransactions).values({
-            id: uuid(),
+            id: recurringId,
             householdId,
             plaidStreamId: null,
             createdAt: now,
             ...fields,
           });
         }
+        upsertedIds.push(recurringId);
+
+        // Back-link the occurrences, matching what the Plaid path does with
+        // stream.transaction_ids. One batched UPDATE per stream.
+        if (group.occurrenceIds.length > 0) {
+          await tx.update(transactions)
+            .set({ recurringTransactionId: recurringId, updatedAt: now })
+            .where(
+              and(
+                inArray(transactions.id, group.occurrenceIds),
+                eq(transactions.householdId, householdId),
+              ),
+            );
+        }
       }
+
+      // Retire anything this pass didn't re-detect, mirroring the Plaid path's
+      // seenStreamIds sweep. Scoped to SimpleFIN-sourced rows so Plaid's
+      // streams — which the other path owns — are never touched. This also
+      // collects rows orphaned by `accountId onDelete: "set null"`, which can
+      // no longer be matched by (accountId, name) and would otherwise
+      // accumulate as active duplicates beside each re-detected stream.
+      const sweepConditions = [
+        eq(recurringTransactions.householdId, householdId),
+        isNull(recurringTransactions.plaidStreamId),
+        eq(recurringTransactions.isActive, true),
+      ];
+      if (upsertedIds.length > 0) {
+        sweepConditions.push(notInArray(recurringTransactions.id, upsertedIds));
+      }
+      await tx.update(recurringTransactions)
+        .set({ isActive: false, updatedAt: now })
+        .where(and(...sweepConditions));
 
       return groups.length;
     },

--- a/tests/integration/simplefin-recurring.test.ts
+++ b/tests/integration/simplefin-recurring.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { eq } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
 import { createTestDb } from "./setup";
 import { insertHousehold, insertAccount, insertTransaction } from "./helpers";
 import { applyRecurringDetection } from "@/lib/simplefin/recurring";
-import { recurringTransactions } from "@/db/schema";
+import { recurringTransactions, transactions } from "@/db/schema";
 
 // Derived relative to "now" so the monthly pattern's predicted next
 // occurrence stays inside the isActive window regardless of when the suite runs
@@ -142,6 +143,143 @@ describe("applyRecurringDetection", () => {
         .from(recurringTransactions)
         .where(eq(recurringTransactions.householdId, householdId));
       expect(rows).toHaveLength(0);
+    } finally {
+      await close();
+    }
+  });
+
+  it("retires a stream that is no longer detected", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const { householdId } = await insertHousehold(db);
+      const { accountId } = await insertAccount(db, householdId, { type: "credit" });
+
+      // A previously-detected stream that today's transactions no longer support.
+      const staleId = uuid();
+      await db.insert(recurringTransactions).values({
+        id: staleId,
+        householdId,
+        accountId,
+        plaidStreamId: null,
+        name: "Cancelled Subscription",
+        frequency: "monthly",
+        isActive: true,
+      });
+
+      await applyRecurringDetection(householdId, db);
+
+      const [stale] = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.id, staleId));
+      expect(stale.isActive).toBe(false);
+    } finally {
+      await close();
+    }
+  });
+
+  it("leaves Plaid-sourced streams alone when sweeping", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const { householdId } = await insertHousehold(db);
+      const { accountId } = await insertAccount(db, householdId, { type: "credit" });
+
+      const plaidId = uuid();
+      await db.insert(recurringTransactions).values({
+        id: plaidId,
+        householdId,
+        accountId,
+        plaidStreamId: "stream-owned-by-plaid",
+        name: "Plaid Stream",
+        frequency: "monthly",
+        isActive: true,
+      });
+
+      await applyRecurringDetection(householdId, db);
+
+      const [row] = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.id, plaidId));
+      expect(row.isActive).toBe(true);
+    } finally {
+      await close();
+    }
+  });
+
+  it("retires an orphaned row instead of duplicating alongside it", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const { householdId } = await insertHousehold(db);
+      const { accountId } = await insertAccount(db, householdId, { type: "credit" });
+
+      // What onDelete: "set null" leaves behind once an account is removed.
+      await db.insert(recurringTransactions).values({
+        id: uuid(),
+        householdId,
+        accountId: null,
+        plaidStreamId: null,
+        name: "Netflix",
+        frequency: "monthly",
+        isActive: true,
+      });
+
+      for (const date of [monthsAgoDate(2), monthsAgoDate(1), monthsAgoDate(0)]) {
+        await insertTransaction(db, householdId, accountId, {
+          date,
+          name: "Netflix",
+          normalizedAmount: -1599,
+          amount: 1599,
+          provider: "simplefin",
+        });
+      }
+
+      await applyRecurringDetection(householdId, db);
+
+      const rows = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.householdId, householdId));
+
+      // The freshly detected stream is active; the orphan is not left active
+      // beside it.
+      expect(rows.filter((r) => r.isActive).length).toBe(1);
+      expect(rows.find((r) => r.isActive)!.accountId).toBe(accountId);
+    } finally {
+      await close();
+    }
+  });
+
+  it("back-links the transactions that make up a detected stream", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const { householdId } = await insertHousehold(db);
+      const { accountId } = await insertAccount(db, householdId, { type: "credit" });
+
+      for (const date of [monthsAgoDate(2), monthsAgoDate(1), monthsAgoDate(0)]) {
+        await insertTransaction(db, householdId, accountId, {
+          date,
+          name: "Netflix",
+          normalizedAmount: -1599,
+          amount: 1599,
+          provider: "simplefin",
+        });
+      }
+
+      await applyRecurringDetection(householdId, db);
+
+      const [recurring] = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.householdId, householdId));
+
+      const txns = await db
+        .select()
+        .from(transactions)
+        .where(eq(transactions.householdId, householdId));
+
+      expect(txns).toHaveLength(3);
+      expect(txns.every((t) => t.recurringTransactionId === recurring.id)).toBe(true);
     } finally {
       await close();
     }


### PR DESCRIPTION
Fixes #72. Three low-severity cleanups from the post-merge review of #65.

**Deactivation sweep.** The Plaid path tracks seenStreamIds and retires any still-active stream absent from the latest response. applyRecurringDetection only ever upserted the groups it currently detected, so a stream that stops being detected (a cancelled subscription, say) stayed isActive forever. Added the equivalent sweep, scoped to plaidStreamId IS NULL so Plaid-owned rows are never touched — covered by a test asserting a Plaid-sourced row survives it.

**Orphan duplicates — judgment call.** recurringTransactions.accountId is nullable with onDelete: "set null". An orphaned row can never match the (householdId, accountId, name) lookup, so every re-detection inserted a duplicate beside it. Rather than add a second mechanism, I let the sweep handle it: an orphan is by definition not among the rows just upserted, so it gets deactivated on the next run. A recurring stream with no account can't render meaningfully anyway, and deactivating is reversible where deleting isn't.

**occurrenceIds — judgment call.** Implemented the back-link rather than dropping the field. The ids were already computed, the Plaid path does exactly this via stream.transaction_ids, and it makes the two providers consistent — one batched UPDATE per stream setting transactions.recurringTransactionId.

Four new integration tests (stale retired, Plaid untouched, orphan not duplicated, transactions back-linked), all derived from dates relative to now per the repo convention. Full suite: 112 files / 727 tests passing.