### PR TITLE
fix: add the missing pnpm backfill-balances operator entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "rotate-keys": "node --env-file-if-exists=.env --import tsx scripts/rotate-keys.ts",
     "backfill-clean-names": "node --env-file-if-exists=.env --import tsx scripts/backfill-clean-names.ts",
     "backfill-transfers": "node --env-file-if-exists=.env --import tsx scripts/backfill-transfers.ts",
+    "backfill-balances": "node --env-file-if-exists=.env --import tsx scripts/backfill-balances.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/scripts/backfill-balances.ts
+++ b/scripts/backfill-balances.ts
@@ -1,0 +1,19 @@
+/**
+ * Operator entry point for reconstructing historical daily balances.
+ * Usage: pnpm backfill-balances
+ * Walks backward from each account's current balance using posted transactions
+ * to fill gaps in balance_history. Non-destructive (onConflictDoNothing), so
+ * re-running it is safe. Requires DATABASE_URL (loaded from .env when present).
+ */
+import { backfillAccountBalances } from "@/lib/jobs/backfill-balances";
+
+async function main() {
+  await backfillAccountBalances();
+  console.log("[backfill-balances] done");
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes out the last remaining piece of #67.

## What was already fixed

Most of #67 was resolved by b63e386 (#77), which landed both halves of the bug but was tagged `Refs #67` rather than `Fixes #67`, so the issue stayed open:

- **The gate** — `checkBalanceHistoryGap` no longer reads only `MAX(balance_history.date)`. `largestGapDays` now walks the sorted distinct dates, takes the widest run between consecutive snapshots, and maxes that against the trailing stretch to today. The `["2026-05-12", "2026-08-28"]` shape from the issue body is covered by a test.
- **The blocker** — carry-forward is in `getNetWorthHistory`. Each account's last known balance carries across dates, seeded from the most recent balance before the window, so a date with no row means "unchanged" rather than "worth zero".

## What this PR adds

The one item from #67 still outstanding: the script itself.

`src/lib/jobs/backfill-balances.ts` has always documented itself as "an operator maintenance job, run via `pnpm backfill-balances`" — but neither the `package.json` entry nor `scripts/backfill-balances.ts` existed, so the documented command was unrunnable. The job is reachable from the startup scheduler now, but an operator still had no way to invoke it on demand after downtime.

Mirrors the existing `backfill-transfers` / `backfill-clean-names` wrappers. The job is non-destructive (`onConflictDoNothing`), so re-running is safe.

## Verification

- `pnpm typecheck` clean
- `pnpm exec eslint scripts/backfill-balances.ts` clean
- `startup-backfill-check` suite: 9/9 passing
- The wrapper was **not** executed against a live database on purpose — it writes to `balance_history`, and the reconstructed rows for this household were deliberately reverted to keep the net-worth chart honest rather than inflating investment accounts that have no pre-2026-08-28 raw data. The underlying job has its own coverage in `src/lib/jobs/backfill-balances.test.ts`.

Fixes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)