### PR TITLE
chore(deps): upgrade @modelcontextprotocol/server to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ai-sdk/react": "^4.0.82",
     "@base-ui/react": "^1.7.0",
     "@better-auth/passkey": "^1.7.1",
-    "@modelcontextprotocol/server": "2.0.0-beta.5",
+    "@modelcontextprotocol/server": "2.0.0",
     "ai": "^7.0.79",
     "better-auth": "^1.7.1",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^1.7.1
         version: 1.7.1(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.29.5)(nanostores@1.5.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-auth@1.7.1(@opentelemetry/api@1.9.0)(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.23.1)(better-sqlite3@12.9.0)(kysely@0.29.5)(pg@8.23.0))(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(@types/node@26.3.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(pg@8.23.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11))(better-call@1.4.0(zod@4.4.3))(nanostores@1.5.2)
       '@modelcontextprotocol/server':
-        specifier: 2.0.0-beta.5
-        version: 2.0.0-beta.5
+        specifier: 2.0.0
+        version: 2.0.0
       ai:
         specifier: ^7.0.79
         version: 7.0.79(zod@4.4.3)
@@ -1649,8 +1649,8 @@ packages:
   '@levischuck/tiny-cbor@0.2.11':
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
 
-  '@modelcontextprotocol/core@2.0.0-beta.5':
-    resolution: {integrity: sha512-HKbY9XTbsDy1Y6r2I55TGE3JEapM0vg96e1MUmBIF9LGjos5gjhcIrTz1yvBPLg2aFKHjwhUAQfRdrCEnPxNew==}
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
     engines: {node: '>=20'}
 
   '@modelcontextprotocol/sdk@1.30.0':
@@ -1663,8 +1663,8 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@modelcontextprotocol/server@2.0.0-beta.5':
-    resolution: {integrity: sha512-i1E5l75rQKsgY/AKAIspgMBH1vEL7dqiK7tHr0L+raYcb0SWOziqNGJXGIG6NY4AlXDWIKGJQGB7Nqfs3oUi5g==}
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
     engines: {node: '>=20'}
 
   '@mswjs/interceptors@0.41.8':
@@ -7539,7 +7539,7 @@ snapshots:
 
   '@levischuck/tiny-cbor@0.2.11': {}
 
-  '@modelcontextprotocol/core@2.0.0-beta.5':
+  '@modelcontextprotocol/core@2.0.0':
     dependencies:
       zod: 4.4.3
 
@@ -7565,9 +7565,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@modelcontextprotocol/server@2.0.0-beta.5':
+  '@modelcontextprotocol/server@2.0.0':
     dependencies:
-      '@modelcontextprotocol/core': 2.0.0-beta.5
+      '@modelcontextprotocol/core': 2.0.0
       zod: 4.4.3
 
   '@mswjs/interceptors@0.41.8':


### PR DESCRIPTION
## What

Moves the MCP server SDK off a pre-release: `@modelcontextprotocol/server` `2.0.0-beta.5` → `2.0.0`.

Stable `2.0.0` shipped (`npm dist-tags: latest = 2.0.0`); we were pinned to the last beta. Nothing was broken, but running a pre-release SDK against real financial data isn't ideal, and the beta→stable gap is where trailing API adjustments land.

## Protocol version

Unchanged — we were already current. Both beta.5 and 2.0.0 bundle the same two revisions:

| Revision | Role |
|---|---|
| `2026-07-28` | current wire revision (`MODERN_WIRE_REVISION`) |
| `2025-11-25` | legacy-era fallback |

`2026-07-28` is the latest published MCP spec revision. Note this is the stateless revision — no initialization handshake, no protocol-level sessions, no GET stream endpoint. The SDK's inbound legacy routing handles method rejection, so `export const GET = POST` in `src/app/api/mcp/route.ts` remains correct.

## No API drift

`src/lib/mcp/server.ts` needed no changes — `createMcpHandler` and `McpServer` have identical signatures. Diff is two files: `package.json` and `pnpm-lock.yaml`.

## Verification

Run on a clean `main` base in an isolated worktree:

| Check | Result |
|---|---|
| `pnpm install --frozen-lockfile` | clean |
| `pnpm typecheck` | clean |
| Unit tests | 426 passed (60 files) |
| Integration tests | 301 passed / 301 |
| Live MCP call | `get_dashboard_summary` returns correct data |

## Note for reviewers

Integration tests were run with `--maxWorkers=4`. At vitest's default concurrency the suite reports mass failures that are pure infrastructure noise — the Postgres testcontainer gets killed mid-run (`57P01 ProcessInterrupts`) plus a Docker 409 container-removal race. Capping workers takes the suite from 339s/137-fake-failures to 50s/green. That is a pre-existing issue, not something this PR introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)