### PR TITLE
fix(tests): stop exhausting test-db connections and migrate once

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,10 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Stryker leaves sandbox copies of the whole tree behind. Linting those
+    // repeats every finding once per sandbox and fails the run on code that
+    // is not ours to fix.
+    ".stryker-tmp/**",
   ]),
 ]);
 

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -1,10 +1,57 @@
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { Pool } from "pg";
+import path from "node:path";
 
 let container: StartedPostgreSqlContainer;
 
+// Every test file clones this database instead of replaying the migration
+// chain itself. Shared with tests/integration/setup.ts via TEST_TEMPLATE_DB.
+const TEMPLATE_DB = "ledgr_test_template";
+
 export async function setup() {
-  container = await new PostgreSqlContainer("postgres:17-alpine").start();
-  process.env.DATABASE_URL = container.getConnectionUri();
+  container = await new PostgreSqlContainer("postgres:17-alpine")
+    .withCommand([
+      "postgres",
+      // One throwaway database per test file, all on this single server. The
+      // default max_connections (100) sits below what the fork pool can demand
+      // — 14 workers holding a pool each exhausts it, and Postgres starts
+      // terminating connections mid-run (57P01).
+      "-c",
+      "max_connections=300",
+      // Durability buys nothing for a server destroyed at teardown.
+      "-c",
+      "fsync=off",
+      "-c",
+      "synchronous_commit=off",
+      "-c",
+      "full_page_writes=off",
+    ])
+    .start();
+
+  const connectionString = container.getConnectionUri();
+  process.env.DATABASE_URL = connectionString;
+  process.env.TEST_TEMPLATE_DB = TEMPLATE_DB;
+
+  // Migrate once, here, into a template database. Cloning that template per
+  // test file replaces one full migration run per file with a file copy.
+  const admin = new Pool({ connectionString, max: 1 });
+  await admin.query(`CREATE DATABASE "${TEMPLATE_DB}"`);
+  await admin.end();
+
+  const templateUrl = new URL(connectionString);
+  templateUrl.pathname = `/${TEMPLATE_DB}`;
+  const pool = new Pool({ connectionString: templateUrl.toString(), max: 1 });
+  try {
+    await migrate(drizzle({ client: pool }), {
+      migrationsFolder: path.join(process.cwd(), "src/db/migrations"),
+    });
+  } finally {
+    // The template must have no open connections, or CREATE DATABASE ...
+    // TEMPLATE fails with 55006 for every test file that follows.
+    await pool.end();
+  }
 }
 
 export async function teardown() {

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -5,11 +5,35 @@ import { randomUUID } from "crypto";
 import * as schema from "../../src/db/schema";
 import path from "node:path";
 
+// Each worker holds a pool for the life of its test file. Left at pg's default
+// of 10 these overrun the server's connection limit once vitest scales forks to
+// the core count; the suite needs only a couple of concurrent queries per file.
+const POOL_MAX = 4;
+
+// CREATE DATABASE ... TEMPLATE briefly conflicts when several workers clone the
+// same template at once (55006). It clears on its own, so retry rather than
+// serialize every worker behind a lock.
+const CLONE_RETRIES = 10;
+
+async function cloneTemplate(admin: Pool, dbName: string, template: string) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await admin.query(`CREATE DATABASE "${dbName}" TEMPLATE "${template}"`);
+      return;
+    } catch (error) {
+      const code = (error as { code?: string }).code;
+      if (code !== "55006" || attempt >= CLONE_RETRIES) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+    }
+  }
+}
+
 export async function createTestDb() {
   const connectionString =
     process.env.DATABASE_URL || "postgresql://ledgr:ledgr@localhost:5432/ledgr_test";
 
   const dbName = `test_${randomUUID().replace(/-/g, "")}`;
+  const template = process.env.TEST_TEMPLATE_DB;
 
   // Isolate each test file in its own *database* (not a schema). Migrations
   // reference tables as `"public"."<table>"`, which only resolves when the
@@ -17,18 +41,27 @@ export async function createTestDb() {
   // on those qualified references. A throwaway database per file gives every test
   // its own public schema, keeps the concurrent suite isolated, and is robust to
   // future migrations regardless of how they qualify identifiers.
-  const admin = new Pool({ connectionString });
-  await admin.query(`CREATE DATABASE "${dbName}"`);
+  const admin = new Pool({ connectionString, max: 1 });
+  if (template) {
+    await cloneTemplate(admin, dbName, template);
+  } else {
+    await admin.query(`CREATE DATABASE "${dbName}"`);
+  }
   await admin.end();
 
   const url = new URL(connectionString);
   url.pathname = `/${dbName}`;
 
-  const pool = new Pool({ connectionString: url.toString() });
+  const pool = new Pool({ connectionString: url.toString(), max: POOL_MAX });
   const db = drizzle({ client: pool, schema });
-  await migrate(db, {
-    migrationsFolder: path.join(process.cwd(), "src/db/migrations"),
-  });
+
+  // The template arrives already migrated. Without one (a direct DATABASE_URL,
+  // no global setup) fall back to replaying the chain.
+  if (!template) {
+    await migrate(db, {
+      migrationsFolder: path.join(process.cwd(), "src/db/migrations"),
+    });
+  }
 
   return {
     db,
@@ -36,7 +69,7 @@ export async function createTestDb() {
       await pool.end();
       // DROP DATABASE cannot run while connections are open; FORCE terminates any
       // stragglers (Postgres 13+).
-      const admin2 = new Pool({ connectionString });
+      const admin2 = new Pool({ connectionString, max: 1 });
       await admin2.query(`DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE)`);
       await admin2.end();
     },


### PR DESCRIPTION
## The problem

`pnpm test` at vitest's default concurrency reported **137 failures that were not real**:

```
Test Files  56 failed | 56 passed (112)
     Tests  137 failed | 479 passed | 123 skipped (739)
  Duration  339.05s
```

Errors were `57P01 ProcessInterrupts` — Postgres terminating connections — attributed to whichever tests were in flight, not to any actual defect.

### Root cause

Each integration file opens its own `pg.Pool` against the single shared testcontainer. `pg` pools default to **10** connections. On a 14-core machine vitest runs ~14 workers, demanding up to **140** connections against a server whose `max_connections` is **100** (verified against `postgres:17-alpine`).

Postgres starts dropping connections, and the failures land wherever they land. That also explains the **flakiness**: three runs on identical code gave 5 → 1 → 0 failures.

## The fix

**Connections.** `max_connections=300` on the container; each pool capped at 4. The suite needs a couple of concurrent queries per file, not ten.

**Migrations — the dominant cost.** All 52 integration files replayed the full 9-migration chain: 468 migration runs per suite. Now migrated **once** into a template database in global setup, with each file cloning it via `CREATE DATABASE ... TEMPLATE`. Concurrent clones briefly conflict (`55006`), so that specific error retries with backoff. When no template is present the old path still replays migrations, so a bare `DATABASE_URL` keeps working.

**Durability.** `fsync`, `synchronous_commit`, and `full_page_writes` off — the server is destroyed at teardown.

## Results

`pnpm test`, default concurrency, no worker cap:

| | Before | After |
|---|---|---|
| Result | 137 failed / 479 passed | **727 passed / 727** |
| Duration | 339s | **21s** |

**16x faster, and green.** Five consecutive integration runs all passed 301/301, where the suite previously varied run to run.

This should also help the CI backlog: there is one self-hosted runner (`macmini-ledgr`) and every branch's jobs queue behind it serially, so shortening each job compounds.

## Also: ESLint

`.stryker-tmp/**` added to `globalIgnores`. Stryker leaves sandbox copies of the entire tree behind, and linting them produced **981 of 1024 errors**, failing `pnpm lint` on duplicated copies of our own code. Lint is now 0 errors (1 pre-existing warning, `_accountType` in `src/lib/money.ts`).

## Verification

Run in an isolated worktree off `main`:

- `pnpm install --frozen-lockfile` — clean
- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (verified with a sandbox present that previously errored)
- `pnpm test` — 727 passed / 112 files
- 5x consecutive integration runs — 301/301 each

🤖 Generated with [Claude Code](https://claude.com/claude-code)