### PR TITLE
perf(ci): stop the mutation job from starving blocking checks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# Custom labels for the self-hosted runner pool (an M4 Mac mini). Declaring
+# them here lets `actionlint .github/workflows/*.yml` run clean locally instead
+# of flagging every `runs-on: [self-hosted, macmini]` as an unknown label.
+self-hosted-runner:
+  labels:
+    - macmini

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,50 +42,18 @@ jobs:
       # self-hosted runner. No secrets required.
       - run: pnpm test
 
-  # Cheap gate on a GitHub-hosted runner (free + unlimited concurrency on this
-  # public repo) so a PR that changes no mutatable source never occupies a
-  # self-hosted slot. The single macmini runner pool is the scarce resource —
-  # queueing, not compute, dominates PR wall-clock — so trading ~20s of hosted
-  # latency for a freed slot is worth it. Shares scripts/mutate-diff.sh with the
-  # run itself, so the gate and the run agree on what "mutatable" means.
-  mutation-gate:
-    name: mutation gate
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    outputs:
-      should-run: ${{ steps.check.outputs.should-run }}
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - id: check
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          FILES=$(bash scripts/mutate-diff.sh --list-only "$BASE_SHA" "$HEAD_SHA")
-          if [ -n "$FILES" ]; then
-            echo "should-run=true" >> "$GITHUB_OUTPUT"
-            echo "Mutatable source changed — mutation job will run:"
-            echo "$FILES" | awk '{print "  " $0}'
-          else
-            echo "should-run=false" >> "$GITHUB_OUTPUT"
-            echo "No mutatable source changed — skipping the mutation job."
-          fi
-
   mutation:
     name: mutation (diff)
     runs-on: [self-hosted, macmini]
-    needs: mutation-gate
+    # Runs only after `test` releases its runner. Mutation is non-blocking, but
+    # a wide diff can keep Stryker busy for 30+ min (observed on a 9-file diff),
+    # and while it held the runner the *blocking* typecheck/lint/test jobs of
+    # every other PR queued behind a job nobody gates on. Ordering it after test
+    # keeps the blocking checks first without giving up the self-hosted runner.
+    needs: test
     # Self-hosted runner: never execute a fork PR's code here — only PRs from
-    # this same repo (see the test job's comment for why). The gate job carries
-    # the same guard, so this is belt-and-braces: a fork PR skips the gate, and
-    # a skipped gate yields an empty output that fails this check too. Kept
-    # explicit so the protection is visible in the job it protects.
-    if: >-
-      needs.mutation-gate.outputs.should-run == 'true' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+    # this same repo (see the test job's comment for why).
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     # Diff-scoped: only the source files changed in the PR are mutated, so runs
     # take minutes instead of a full cold sweep. Non-blocking (reports only):
     # Stryker currently runs just the unit suite, so files covered mainly by

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,14 @@ jobs:
         with:
           version: 11.5.2
 
+      # No `cache: pnpm` on purpose. The runner is self-hosted, so the pnpm
+      # store already persists in $HOME between jobs — actions/cache would
+      # round-trip a tarball over the network for zero benefit. Measured cost
+      # when it was enabled: up to 79s in the post-job cache save, longer than
+      # the test step it was meant to speed up.
       - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - run: pnpm install --frozen-lockfile
 
@@ -34,21 +38,60 @@ jobs:
 
       - run: pnpm lint
 
-      # Integration tests start Postgres via testcontainers; Docker is
-      # preinstalled on ubuntu-latest. No secrets required.
+      # Integration tests start Postgres via testcontainers; Docker runs on the
+      # self-hosted runner. No secrets required.
       - run: pnpm test
+
+  # Cheap gate on a GitHub-hosted runner (free + unlimited concurrency on this
+  # public repo) so a PR that changes no mutatable source never occupies a
+  # self-hosted slot. The single macmini runner pool is the scarce resource —
+  # queueing, not compute, dominates PR wall-clock — so trading ~20s of hosted
+  # latency for a freed slot is worth it. Shares scripts/mutate-diff.sh with the
+  # run itself, so the gate and the run agree on what "mutatable" means.
+  mutation-gate:
+    name: mutation gate
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - id: check
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          FILES=$(bash scripts/mutate-diff.sh --list-only "$BASE_SHA" "$HEAD_SHA")
+          if [ -n "$FILES" ]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            echo "Mutatable source changed — mutation job will run:"
+            echo "$FILES" | awk '{print "  " $0}'
+          else
+            echo "should-run=false" >> "$GITHUB_OUTPUT"
+            echo "No mutatable source changed — skipping the mutation job."
+          fi
 
   mutation:
     name: mutation (diff)
     runs-on: [self-hosted, macmini]
+    needs: mutation-gate
     # Self-hosted runner: never execute a fork PR's code here — only PRs from
-    # this same repo (see the test job's comment for why).
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    # this same repo (see the test job's comment for why). The gate job carries
+    # the same guard, so this is belt-and-braces: a fork PR skips the gate, and
+    # a skipped gate yields an empty output that fails this check too. Kept
+    # explicit so the protection is visible in the job it protects.
+    if: >-
+      needs.mutation-gate.outputs.should-run == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     # Diff-scoped: only the source files changed in the PR are mutated, so runs
-    # take minutes instead of a full sweep. Non-blocking (reports only): Stryker
-    # currently runs just the unit suite, so files covered mainly by integration
-    # tests score artificially low — a blocking gate would fail legitimate PRs.
-    # Flip to blocking once the mutation harness also runs the integration suite.
+    # take minutes instead of a full cold sweep. Non-blocking (reports only):
+    # Stryker currently runs just the unit suite, so files covered mainly by
+    # integration tests score artificially low — a blocking gate would fail
+    # legitimate PRs. Flip to blocking once the mutation harness also runs the
+    # integration suite.
     continue-on-error: true
     steps:
       - uses: actions/checkout@v7
@@ -59,10 +102,10 @@ jobs:
         with:
           version: 11.5.2
 
+      # No `cache: pnpm` — see the test job for why.
       - uses: actions/setup-node@v7
         with:
           node-version: 24
-          cache: pnpm
 
       - run: pnpm install --frozen-lockfile
 

--- a/scripts/mutate-diff.sh
+++ b/scripts/mutate-diff.sh
@@ -6,18 +6,7 @@
 # Uses a two-dot diff of explicit commits so CI can pass the PR's exact base and
 # head SHAs — a three-dot/merge-base diff against a moving branch tip pulls in
 # files the PR never touched.
-#
-# With --list-only, prints the changed mutatable files (one per line) and exits
-# without running Stryker. CI's cheap hosted gate job uses this to decide
-# whether the mutation job is worth a self-hosted runner slot at all, so the
-# gate and the run can never disagree about what counts as mutatable.
 set -euo pipefail
-
-LIST_ONLY=false
-if [ "${1:-}" = "--list-only" ]; then
-  LIST_ONLY=true
-  shift
-fi
 
 BASE="${1:-origin/main}"
 HEAD="${2:-HEAD}"
@@ -25,11 +14,6 @@ HEAD="${2:-HEAD}"
 FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" "$HEAD" -- \
   src/lib src/actions src/queries \
   | grep -E '\.ts$' | grep -vE '\.test\.ts$' || true)
-
-if [ "$LIST_ONLY" = true ]; then
-  printf '%s' "$FILES"
-  exit 0
-fi
 
 if [ -z "$FILES" ]; then
   echo "No mutatable source changed between ${BASE} and ${HEAD} — skipping mutation testing."

--- a/scripts/mutate-diff.sh
+++ b/scripts/mutate-diff.sh
@@ -6,7 +6,18 @@
 # Uses a two-dot diff of explicit commits so CI can pass the PR's exact base and
 # head SHAs — a three-dot/merge-base diff against a moving branch tip pulls in
 # files the PR never touched.
+#
+# With --list-only, prints the changed mutatable files (one per line) and exits
+# without running Stryker. CI's cheap hosted gate job uses this to decide
+# whether the mutation job is worth a self-hosted runner slot at all, so the
+# gate and the run can never disagree about what counts as mutatable.
 set -euo pipefail
+
+LIST_ONLY=false
+if [ "${1:-}" = "--list-only" ]; then
+  LIST_ONLY=true
+  shift
+fi
 
 BASE="${1:-origin/main}"
 HEAD="${2:-HEAD}"
@@ -14,6 +25,11 @@ HEAD="${2:-HEAD}"
 FILES=$(git diff --name-only --diff-filter=ACMR "$BASE" "$HEAD" -- \
   src/lib src/actions src/queries \
   | grep -E '\.ts$' | grep -vE '\.test\.ts$' || true)
+
+if [ "$LIST_ONLY" = true ]; then
+  printf '%s' "$FILES"
+  exit 0
+fi
 
 if [ -z "$FILES" ]; then
   echo "No mutatable source changed between ${BASE} and ${HEAD} — skipping mutation testing."


### PR DESCRIPTION
## Problem

PR wall-clock has been **13–20 min** against only **~3.5 min** of actual compute. Two causes, both about the self-hosted runner pool being the scarce resource:

1. `macmini-ledgr` was the **only** runner, so ledgr's runner concurrency was 1 — even `test` and `mutation` from the same PR queued behind each other.
2. The `mutation` job is `continue-on-error: true` and gates nothing, but a wide diff keeps Stryker busy for a long time. Observed live: a 9-file diff on `fix/liability-sign-convention` held the runner for **30+ minutes** while the *blocking* `typecheck · lint · test` jobs of two other PRs sat queued behind it.

## Changes

**1. `needs: test` on the mutation job.**
Orders mutation after the blocking job releases the runner, so blocking checks always go first. Stays on the self-hosted runner — no GitHub-hosted runners are used.

Wanted side effect: a red `test` job now skips mutation rather than mutating an already-broken build.

**2. Drop `cache: pnpm` from both jobs.**
On a self-hosted runner the pnpm store already persists in `$HOME` between jobs, so `actions/cache` was round-tripping a tarball over the network for zero benefit. Measured cost: up to **79s** in the post-job cache save — longer than the test step it was supposedly accelerating.

**3. `.github/actionlint.yaml`** declaring the custom `macmini` label, so `actionlint .github/workflows/*.yml` runs clean locally instead of flagging every self-hosted `runs-on`.

## Also done (not a repo change)

Registered a **second runner service** on the mini (`macmini-ledgr-2`, agent id 22), so `test` jobs from different PRs now run in parallel instead of serially.

## Verification

- `actionlint .github/workflows/*.yml` — clean across all three workflows
- Fork guard on the `mutation` job kept explicit rather than inherited, so the protection is visible in the job it protects
- No `ubuntu-latest` in `ci.yml`; `codeql.yml` and `docker-publish.yml` are untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)