### PR TITLE
perf(mutation): stop booting a Postgres container for every mutant

### DIFF
--- a/stryker.config.json
+++ b/stryker.config.json
@@ -13,7 +13,9 @@
     "@stryker-mutator/typescript-checker"
   ],
   "testRunner": "vitest",
-  "checkers": ["typescript"],
+  "checkers": [
+    "typescript"
+  ],
   "tsconfigFile": "tsconfig.json",
   "coverageAnalysis": "perTest",
   "thresholds": {
@@ -21,8 +23,16 @@
     "low": 60,
     "break": 60
   },
-  "reporters": ["html", "clear-text", "progress"],
+  "reporters": [
+    "html",
+    "clear-text",
+    "progress"
+  ],
   "htmlReporter": {
     "fileName": "reports/mutation/mutation.html"
-  }
+  },
+  "vitest": {
+    "configFile": "vitest.stryker.config.ts"
+  },
+  "ignoreStatic": true
 }

--- a/vitest.stryker.config.ts
+++ b/vitest.stryker.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from "vitest/config";
+
+// Vitest config used ONLY by Stryker (wired via stryker.config.json's
+// `vitest.configFile`). It deliberately omits the `globalSetup` that starts a
+// Postgres testcontainer.
+//
+// Why: Stryker runs vitest once per mutant batch across `concurrency` workers
+// (default: CPU cores - 1). globalSetup fires on every one of those, so a
+// Postgres container was being booted and fully migrated to run unit tests that
+// take milliseconds — measured at 8.92s of setup for 29ms of tests, and 18
+// concurrent containers observed on the runner.
+//
+// Consequence: tests that need a database can't run here, so the DB-backed
+// files below are excluded along with tests/ (integration). Mutants covered
+// only by those report as NoCoverage rather than Survived, which is honest
+// signal about unit-test strength instead of a container tax.
+export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    exclude: [
+      "node_modules/**",
+      "e2e/**",
+      // Need a live Postgres via tests/global-setup.ts.
+      "src/lib/demo-mode.test.ts",
+      "src/lib/simplefin/queries.test.ts",
+      "src/lib/plaid/queries.test.ts",
+      "src/lib/jobs/backfill-balances.test.ts",
+      "src/lib/jobs/backfill-transfers.test.ts",
+    ],
+    testTimeout: 30_000,
+  },
+});


### PR DESCRIPTION
Split out from #99 — that PR is pure CI config; this one changes mutation scores and deserves its own review.

## Problem

Stryker was spending most of its runtime **starting databases, not testing mutants**. A 9-file diff kept the mutation job busy for **30+ minutes** on the CI runner, with **18 Postgres containers alive simultaneously** and the 16GB mini swapping (991k pageouts).

## Cause

Three things compound:

1. Stryker runs vitest once per mutant batch across `concurrency` workers — default is `cpuCores - 1`, so **9** on the Mac mini.
2. `vitest.config.ts` declares `globalSetup`, which boots a testcontainers Postgres **and replays the entire migration chain**. That fires on *every* worker.
3. `vitest.related` (default `true`) already limits which tests run — but **`globalSetup` runs regardless of which tests are selected**. So Postgres booted even to run `money.test.ts`.

Net effect: 8.92s of database bootstrap to run 29ms of tests.

## Fix

A Stryker-only vitest config via the supported [`vitest.configFile`](https://stryker-mutator.io/docs/stryker-js/vitest-runner/) option, with no `globalSetup`, excluding `tests/` and the five colocated `src` tests that need a live database. Plus `ignoreStatic: true`, which skips mutants that only execute at file load — precisely the ones that force an environment reload.

`vitest.config.ts` is **untouched**, so `pnpm test` and CI's test job are unaffected.

## Measured

| | Before | After |
|---|---|---|
| One test file (29ms of tests) | 6.66s | **1.37s** |
| Full unit suite (53 files, 390 tests) | — | **6.47s, 0 containers** |
| Stryker on `money.ts` — dry run | 24s, 192 tests | **3s, 111 tests** |
| Stryker on `money.ts` — mutation phase | 2m42s | **1m52s** |
| Peak Postgres containers | 7 (this machine) / 18 (mini) | **0** |

Measured on an M4 Pro (14 cores, 48GB). The gap is far wider on the mini — 10 cores and 16GB with swapping is where 7 containers became 18 and minutes became 30.

## The score change, stated plainly

Mutation score on `money.ts` moves **77.32% → 75.26%**. The composition is better than the number:

```
before: 71 killed, 4 timeout, 22 survived
after:  73 killed, 0 timeout, 24 survived
```

It kills **more** mutants outright. The old run's 4 timeouts — which Stryker counts as kills — were mutants timing out on container contention, not tests catching them. Part of the old score was infrastructure noise scored as success.

Mutants covered only by DB-backed tests now report `NoCoverage`. That's honest signal about unit-test strength, and it makes `ci.yml`'s claim that Stryker *"currently runs just the unit suite"* **true** — it wasn't before.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors (1 warning, pre-existing on `main`, verified by stashing)
- `pnpm test` — **113 files / 751 tests pass** in 32s
- Full unit suite under the new config — 53 files / 390 tests pass, zero containers
- End-to-end Stryker runs both ways on `money.ts`, numbers above

## Note

`coverageAnalysis: "perTest"` is kept for documentation only — the vitest runner [ignores it and always uses perTest](https://stryker-mutator.io/docs/stryker-js/vitest-runner/#limitations), but `ignoreStatic` documents perTest as a prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)