### PR TITLE
fix(investments): type unrecognized tickers as 'other', not 'stock'

### DIFF
--- a/src/lib/simplefin/sync.test.ts
+++ b/src/lib/simplefin/sync.test.ts
@@ -173,9 +173,19 @@ describe("processHoldings", () => {
     expect(result[0].type).toBe("bond");
   });
 
-  it("falls back to type stock for an unrecognized ticker", () => {
+  it("falls back to type other, not stock, for an unrecognized ticker", () => {
     const result = processHoldings([makeAccount({ holdings: [makeHolding({ symbol: "NVDA" })] })]);
-    expect(result[0].type).toBe("stock");
+    expect(result[0].type).toBe("other");
+  });
+
+  it("does not chart an unlisted ETF as equity", () => {
+    // IBIT is a spot-bitcoin ETF absent from KNOWN_ETF_SYMBOLS. Guessing
+    // "stock" inflated the equity slice of the allocation chart; "other"
+    // reports the uncertainty instead of misstating it.
+    const result = processHoldings([
+      makeAccount({ holdings: [makeHolding({ symbol: "IBIT", description: "iShares Bitcoin Trust" })] }),
+    ]);
+    expect(result[0].type).toBe("other");
   });
 
   it("classifies a SimpleFIN currency symbol as cash, not stock", () => {

--- a/src/lib/simplefin/sync.ts
+++ b/src/lib/simplefin/sync.ts
@@ -17,8 +17,8 @@ import { withHousehold } from "@/lib/household-context";
 
 // SimpleFIN brokerages don't send a security type the way Plaid does. These
 // static lists cover the tickers common enough to be worth a dedicated
-// allocation bucket; anything else with a ticker is assumed to be an
-// individual stock, and anything with no ticker at all falls back to "other".
+// allocation bucket. Anything we cannot place -- an unlisted ticker, or no
+// ticker at all -- falls back to "other" rather than being guessed at.
 const KNOWN_CRYPTO_SYMBOLS = new Set(["BTC", "ETH", "SOL", "DOGE", "LTC", "BCH", "ADA", "XRP", "USDC", "USDT"]);
 const KNOWN_BOND_SYMBOLS = new Set(["BND", "AGG", "TLT", "IEF", "SHY", "LQD", "HYG", "MUB", "BNDX", "VCIT", "VCSH"]);
 const KNOWN_ETF_SYMBOLS = new Set([
@@ -26,8 +26,8 @@ const KNOWN_ETF_SYMBOLS = new Set([
   "SCHD", "ARKK", "IWM", "DIA", "GLD", "SLV", "XLK", "XLF", "XLE", "XLV",
 ]);
 // Sweep/money-market positions. Without these they'd fall through to the
-// "stock" default and be charted as equity exposure, which is the opposite of
-// what they are.
+// "other" default and sit in the unclassified bucket, when they are in fact
+// known cash and belong in the cash slice.
 const KNOWN_CASH_SYMBOLS = new Set([
   "SPAXX", "VMFXX", "SWVXX", "FDRXX", "VMRXX", "SPRXX", "FZFXX", "SNVXX", "SNSXX",
 ]);
@@ -47,7 +47,10 @@ function inferHoldingType(symbol: string | null): HoldingRow["type"] {
   if (KNOWN_CRYPTO_SYMBOLS.has(ticker)) return "crypto";
   if (KNOWN_BOND_SYMBOLS.has(ticker)) return "bond";
   if (KNOWN_ETF_SYMBOLS.has(ticker)) return "etf";
-  return "stock";
+  // Unrecognized ticker. The allowlists above cannot cover the long tail, so
+  // guessing "stock" turns an unknown into a confident misclassification --
+  // IBIT (a spot-bitcoin ETF) was charted as equity. "other" is honest.
+  return "other";
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #91 — the unfinished half of #71.

## Problem

`inferHoldingType` (`src/lib/simplefin/sync.ts`) fell through to `return "stock"` for any ticker outside its static allowlists. A 21-symbol ETF list cannot cover the long tail, so unknowns became confident misclassifications.

Observed on the real household: **IBIT** (iShares Bitcoin Trust, a spot-bitcoin ETF) typed as `Stock`, inflating the equity slice of the Asset Allocation donut. Bond ETFs outside `KNOWN_BOND_SYMBOLS` got the same treatment — charted as equity, which is the opposite of what they are.

#71 specified two changes. The cash/money-market list landed; the `'other'` fallback did not. This is that half.

## Change

Default to `other` for unrecognized tickers. `other` is already a first-class value — it renders as its own badge (`investment-type-badge.tsx`) and its own allocation slice — so the uncertainty is displayed rather than misstated.

Also refreshed two comments that still described the old `"stock"` default.

## Tradeoff worth reviewing

`other` is now the fallback for **every** unlisted ticker, not just misclassified ETFs. Genuine single stocks outside the allowlist (NVDA, AAPL, …) will now read "Other" too, so a typical portfolio's donut grows a large grey slice.

That is what #71 and #91 both specify — honest uncertainty over a confident wrong answer — so it is implemented as written. The alternative, if the grey slice proves worse in practice, is to classify off the `description` SimpleFIN already sends (`iShares Bitcoin Trust`, `NVIDIA Corp`): `Trust|Fund|ETF|Index` → `etf`, else `stock`. That catches IBIT without demoting real stocks, but it is more code and beyond what the issue asks. Happy to follow up if you prefer it.

## Migration

None needed. Holdings are deleted and re-inserted wholesale on every sync (`sync.ts:311` — SimpleFIN has no delta/cursor for positions), so existing rows re-type themselves on the next sync.

## Tests

Two behavioral tests, written red first:
- the existing "falls back to type stock" test flipped to expect `other`
- a new regression test pinning IBIT specifically, so the reported symptom cannot come back

Full suite green locally: **752 passed / 113 files**, typecheck clean, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)