### PR TITLE
chore(lint): ignore .claude/worktrees, the way .stryker-tmp already is

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,6 +23,12 @@ const eslintConfig = defineConfig([
     // repeats every finding once per sandbox and fails the run on code that
     // is not ours to fix.
     ".stryker-tmp/**",
+    // Claude Code checks agent worktrees out here — full copies of the repo,
+    // ignored by git via .git/info/exclude. Same problem as .stryker-tmp:
+    // every finding repeats once per worktree, and the noise buries real ones.
+    // CI starts from a clean checkout, so this is invisible there and constant
+    // locally, which is the worst way round.
+    ".claude/worktrees/**",
   ]),
 ]);
 


### PR DESCRIPTION
## Mechanism

Claude Code checks agent worktrees out under `.claude/worktrees/` — full copies of the repo. They are ignored by git (via `.git/info/exclude`), but **ESLint 9's flat config does not read git's ignore files**, so every finding in the tree repeats once per worktree.

Observed on `main` today with a single worktree present:

```
$ pnpm lint
✖ 246 problems (119 errors, 127 warnings)
```

All 628 reported files were under `.claude/worktrees/`. Zero were real.

## Why it matters

CI starts from a clean checkout, so this is **invisible where it would be caught and constant where it is most annoying** — the worst way round. It also buries genuine findings: `pnpm lint` had just been brought to zero problems in #105, and a single worktree took it back to 246.

It also breaks the local workflow CLAUDE.md documents, where `pnpm lint` and the pre-commit hook are the fast feedback layer before CI.

## Fix

One entry in `globalIgnores`, next to `.stryker-tmp/**` — this is exactly the mechanism fixed for Stryker's sandbox in #92, so it gets the same treatment and the same reasoning in the comment.

`pnpm lint` returns to clean. Typecheck unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)