### PR TITLE
UI review cluster: review backlog, Uncategorized denominator, investments, theme choice, display names

### DIFF
--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -12,7 +12,10 @@ import {
 import { getAccounts } from "@/queries/accounts";
 import { getBudgetForMonth } from "@/queries/budgets";
 import { getUpcomingBills } from "@/queries/recurring";
-import { getCurrentMonth, shiftMonth } from "@/lib/date-utils";
+import { getTransactionSummary } from "@/queries/transactions";
+import { getCurrentMonth, shiftMonth, formatMonthLong } from "@/lib/date-utils";
+import { uncategorizedShare } from "@/lib/uncategorized-share";
+import { ReviewNudge } from "@/components/molecules/review-nudge";
 import { getLayoutForUser } from "@/queries/dashboard-layout";
 import { getDefaultLayout } from "@/components/organisms/widgets/registry";
 import { getSession } from "@/lib/auth/session";
@@ -33,7 +36,7 @@ export default async function DashboardPage() {
   const spendingMonth = latestActivityMonth ?? getCurrentMonth();
   const prevMonth = shiftMonth(spendingMonth, -1);
 
-  const [summary, prevSummary, netWorthHistory, monthlySpending, cashFlow, recentTransactions, allAccounts, budgetData, upcomingBills, investmentsData, savedLayout] =
+  const [summary, prevSummary, netWorthHistory, monthlySpending, cashFlow, recentTransactions, allAccounts, budgetData, upcomingBills, investmentsData, savedLayout, unreviewedSummary] =
     await Promise.all([
       withHousehold(householdId, (tx) => getDashboardSummary(householdId, spendingMonth, tx)),
       withHousehold(householdId, (tx) => getDashboardSummary(householdId, prevMonth, tx)),
@@ -46,6 +49,7 @@ export default async function DashboardPage() {
       getUpcomingBills(householdId, { limit: 5 }),
       getInvestmentsSummary(householdId),
       session ? getLayoutForUser(session.user.id) : null,
+      withHousehold(householdId, (tx) => getTransactionSummary(householdId, { reviewed: false }, tx)),
     ]);
 
   const accounts = allAccounts
@@ -68,6 +72,11 @@ export default async function DashboardPage() {
   return (
     <div>
       <h1 className="sr-only">Dashboard</h1>
+      <ReviewNudge
+        unreviewedCount={unreviewedSummary.count}
+        share={uncategorizedShare(monthlySpending)}
+        monthLabel={formatMonthLong(spendingMonth)}
+      />
       <NetWorthHero netWorth={summary.netWorth} initialHistory={netWorthHistory} />
       <DashboardStatRow
         summary={summary}

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -9,7 +9,7 @@ import {
   getInvestmentsSummary,
   getLatestActivityMonth,
 } from "@/queries/dashboard";
-import { getAccounts } from "@/queries/accounts";
+import { getAccountsByInstitution } from "@/queries/accounts";
 import { getBudgetForMonth } from "@/queries/budgets";
 import { getUpcomingBills } from "@/queries/recurring";
 import { getTransactionSummary } from "@/queries/transactions";
@@ -36,7 +36,7 @@ export default async function DashboardPage() {
   const spendingMonth = latestActivityMonth ?? getCurrentMonth();
   const prevMonth = shiftMonth(spendingMonth, -1);
 
-  const [summary, prevSummary, netWorthHistory, monthlySpending, cashFlow, recentTransactions, allAccounts, budgetData, upcomingBills, investmentsData, savedLayout, unreviewedSummary] =
+  const [summary, prevSummary, netWorthHistory, monthlySpending, cashFlow, recentTransactions, accountGroups, budgetData, upcomingBills, investmentsData, savedLayout, unreviewedSummary] =
     await Promise.all([
       withHousehold(householdId, (tx) => getDashboardSummary(householdId, spendingMonth, tx)),
       withHousehold(householdId, (tx) => getDashboardSummary(householdId, prevMonth, tx)),
@@ -44,7 +44,7 @@ export default async function DashboardPage() {
       withHousehold(householdId, (tx) => getMonthlySpending(householdId, spendingMonth, tx)),
       withHousehold(householdId, (tx) => getCashFlow(householdId, 6, tx)),
       withHousehold(householdId, (tx) => getRecentTransactions(householdId, 5, tx)),
-      getAccounts(householdId),
+      getAccountsByInstitution(householdId),
       withHousehold(householdId, (tx) => getBudgetForMonth(householdId, getCurrentMonth(), tx)),
       getUpcomingBills(householdId, { limit: 5 }),
       getInvestmentsSummary(householdId),
@@ -52,9 +52,23 @@ export default async function DashboardPage() {
       withHousehold(householdId, (tx) => getTransactionSummary(householdId, { reviewed: false }, tx)),
     ]);
 
-  const accounts = allAccounts
-    .filter((a) => !a.isHidden)
-    .map((a) => ({ id: a.id, name: a.name, type: a.type, currentBalance: a.currentBalance, currency: a.currency }));
+  // Flattened from the institution grouping so the balances widget can show the
+  // same bank marks the accounts page does, rather than falling back to generic
+  // type glyphs for accounts it has a logo for.
+  const accounts = accountGroups.flatMap((group) =>
+    group.accounts
+      .filter((a) => !a.isHidden)
+      .map((a) => ({
+        id: a.id,
+        name: a.name,
+        type: a.type,
+        currentBalance: a.currentBalance,
+        currency: a.currency,
+        institutionName: group.institutionName,
+        logoBase64: group.logoBase64,
+        primaryColor: group.primaryColor,
+      })),
+  );
 
   const layout = savedLayout ?? getDefaultLayout();
 
@@ -71,7 +85,10 @@ export default async function DashboardPage() {
 
   return (
     <div>
-      <h1 className="sr-only">Dashboard</h1>
+      {/* Was sr-only. A screen-reader-only title means sighted users navigate a
+          page whose name they cannot see, and it left the page opening on an
+          unlabelled number. */}
+      <h1 className="mb-4 text-2xl font-semibold tracking-tight">Dashboard</h1>
       <ReviewNudge
         unreviewedCount={unreviewedSummary.count}
         share={uncategorizedShare(monthlySpending)}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -2,6 +2,7 @@ import { getSession } from "@/lib/auth/session";
 import { getMcpSettings } from "@/queries/mcp-settings";
 import { McpSettingsForm } from "@/components/organisms/mcp-settings-form";
 import { DemoModeToggle } from "@/components/molecules/demo-mode-toggle";
+import { AppearanceToggle } from "@/components/molecules/appearance-toggle";
 import { PasskeysManager } from "@/components/organisms/passkeys-manager";
 import { DangerZone } from "@/components/organisms/danger-zone";
 import { isDemoMode } from "@/lib/demo-mode";
@@ -23,6 +24,7 @@ export default async function SettingsPage() {
           Configure integrations and access controls.
         </p>
       </div>
+      <AppearanceToggle />
       <DemoModeToggle initialEnabled={demoEnabled} />
       <PasskeysManager />
       <McpSettingsForm

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,11 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
-@custom-variant dark (@media (prefers-color-scheme: dark));
+/* Theme is resolved to a class on <html> by the blocking script in
+   app/layout.tsx, so "system" is a JS concern and the dark tokens below
+   live in exactly one place instead of being duplicated across a media
+   query and a class selector. */
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme inline {
   --color-background: var(--background);
@@ -99,8 +103,7 @@
   --sidebar-ring: oklch(0.708 0 0);
 }
 
-@media (prefers-color-scheme: dark) {
-:root {
+:root.dark {
   color-scheme: dark;
   --background: oklch(0.1 0.005 75);
   --foreground: oklch(0.94 0.005 75);
@@ -139,7 +142,6 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
-}
 }
 
 @layer base {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -27,6 +27,7 @@
   --color-chart-2: var(--chart-2);
   --color-chart-1: var(--chart-1);
   --color-chart-neutral: var(--chart-neutral);
+  --color-warning: var(--warning);
   --color-positive: var(--positive);
   --color-ring: var(--ring);
   --color-input: var(--input);
@@ -71,6 +72,7 @@
   --accent-foreground: oklch(0.205 0.01 75);
   --destructive: oklch(0.577 0.245 27.325);
   --positive: oklch(0.508 0.118 165.61);
+  --warning: oklch(0.62 0.128 72);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -116,6 +118,7 @@
   --accent-foreground: oklch(0.94 0.005 75);
   --destructive: oklch(0.704 0.191 22.216);
   --positive: oklch(0.765 0.177 163.22);
+  --warning: oklch(0.80 0.13 78);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { THEME_INIT } from "@/lib/theme";
 
 const geistSans = Geist({
   variable: "--font-sans",
@@ -36,7 +37,16 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      suppressHydrationWarning
     >
+      <head>
+        {/* Runs before first paint so the stored theme is applied without a
+            flash of the wrong one. Inline and blocking on purpose — deferring
+            it is what produces the flash. */}
+        <script
+          dangerouslySetInnerHTML={{ __html: THEME_INIT }}
+        />
+      </head>
       <body className="min-h-full flex flex-col">{children}</body>
     </html>
   );

--- a/src/components/molecules/account-card.tsx
+++ b/src/components/molecules/account-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { accountDisplayName } from "@/lib/account-name";
 import { Button } from "@/components/ui/button";
 import { AccountTypeIcon } from "@/components/atoms/account-type-icon";
 import { BalanceDisplay } from "@/components/atoms/balance-display";
@@ -18,7 +19,7 @@ export function AccountCard({ account, onEdit }: AccountCardProps) {
       <div className="flex items-center gap-3 min-w-0">
         <AccountTypeIcon type={account.type as AccountType} />
         <div className="min-w-0">
-          <span className="text-sm font-medium truncate block">{account.name}</span>
+          <span className="text-sm font-medium truncate block">{accountDisplayName(account.name)}</span>
           {account.officialName && account.officialName !== account.name && (
             <p className="text-xs text-muted-foreground truncate">
               {account.officialName}
@@ -33,7 +34,7 @@ export function AccountCard({ account, onEdit }: AccountCardProps) {
           size="sm"
           className="sm:opacity-0 sm:group-hover/card:opacity-100 group-focus-within/card:opacity-100 transition-opacity h-7 w-7 p-0"
           onClick={() => onEdit(account)}
-          aria-label={`Edit ${account.name}`}
+          aria-label={`Edit ${accountDisplayName(account.name)}`}
         >
           <Pencil className="size-3.5" />
         </Button>

--- a/src/components/molecules/appearance-toggle.tsx
+++ b/src/components/molecules/appearance-toggle.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { Monitor, Sun, Moon } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  THEME_STORAGE_KEY,
+  applyTheme,
+  readStoredTheme,
+  isTheme,
+  type Theme,
+} from "@/lib/theme";
+
+const CHANGE_EVENT = "ledgr:theme-change";
+
+const CHOICES: { value: Theme; label: string; icon: typeof Monitor }[] = [
+  { value: "system", label: "Use device settings", icon: Monitor },
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+];
+
+// Read through an external store so the server render and the first client
+// render agree on "system" and reconcile after hydration, rather than writing
+// state from an effect.
+function subscribe(onChange: () => void) {
+  window.addEventListener(CHANGE_EVENT, onChange);
+  const media = window.matchMedia("(prefers-color-scheme: dark)");
+  media.addEventListener("change", onChange);
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, onChange);
+    media.removeEventListener("change", onChange);
+  };
+}
+
+function systemOnServer(): Theme {
+  return "system";
+}
+
+export function AppearanceToggle() {
+  const theme = useSyncExternalStore(subscribe, readStoredTheme, systemOnServer);
+
+  // Base UI models a toggle group as an array even when only one item can be
+  // active, and hands back an empty array when the active item is clicked
+  // again. Ignoring a non-theme value keeps one option always selected.
+  function select(groupValue: string[]) {
+    const next = groupValue[0];
+    if (!isTheme(next)) return;
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, next);
+    } catch {
+      // Blocked site data — the theme still applies for this page view.
+    }
+    applyTheme(next);
+    window.dispatchEvent(new Event(CHANGE_EVENT));
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Appearance</CardTitle>
+        <CardDescription>
+          Ledgr follows your device by default. Override it here if the machine
+          you are on decides differently than you would.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ToggleGroup
+          value={[theme]}
+          onValueChange={select}
+          variant="outline"
+          spacing={1}
+          aria-label="Appearance"
+        >
+          {CHOICES.map(({ value, label, icon: Icon }) => (
+            <ToggleGroupItem
+              key={value}
+              value={value}
+              aria-label={label}
+              // The shared toggle marks the active item with `bg-muted`, which
+              // sits ~0.045 lightness from the card in dark mode — too close to
+              // read as selected on the one control whose entire job is showing
+              // which option is active. Inverting against `primary` is legible
+              // in both themes.
+              className="aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:hover:bg-primary"
+            >
+              <Icon />
+              {label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/molecules/category-pill.tsx
+++ b/src/components/molecules/category-pill.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useActionTransition } from "@/hooks/use-action-transition";
 import { updateTransactionCategory } from "@/actions/transactions";
 import { updateMerchantDefaultCategory } from "@/actions/merchants";
+import { ChevronDown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Command, CommandInput, CommandList, CommandEmpty } from "@/components/ui/command";
@@ -118,22 +119,35 @@ export function CategoryPill({
             <button
               disabled={disabled || isPending}
               className={cn(
-                "max-w-[140px] cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
+                "group max-w-[140px] cursor-pointer rounded-full disabled:cursor-not-allowed disabled:opacity-50",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
                 isPending && "opacity-50",
               )}
             />
           }
         >
-          <Badge variant="outline" className="text-xs truncate">
-            {(() => {
-              const { text, variant } = categoryPillLabel(categoryName, isTransfer);
-              if (variant === "category") return text;
-              return (
-                <span className={cn("text-muted-foreground", variant === "uncategorized" && "italic")}>
-                  {text}
-                </span>
-              );
-            })()}
+          <Badge
+            variant="outline"
+            className={cn(
+              "text-xs gap-1 transition-colors",
+              // The affordance is in the resting state, not on hover — a control
+              // that only looks interactive once you find it with a pointer is
+              // invisible to anyone who doesn't explore by hovering.
+              !disabled && "group-hover:border-foreground/30 group-hover:bg-accent",
+            )}
+          >
+            <span className="truncate">
+              {(() => {
+                const { text, variant } = categoryPillLabel(categoryName, isTransfer);
+                if (variant === "category") return text;
+                return (
+                  <span className={cn("text-muted-foreground", variant === "uncategorized" && "italic")}>
+                    {text}
+                  </span>
+                );
+              })()}
+            </span>
+            {!disabled && <ChevronDown aria-hidden className="size-3 shrink-0 opacity-50" />}
           </Badge>
         </PopoverTrigger>
         <PopoverContent align="start" className="w-[220px] p-0">

--- a/src/components/molecules/review-entry-button.tsx
+++ b/src/components/molecules/review-entry-button.tsx
@@ -23,8 +23,8 @@ export function ReviewEntryButton({ unreviewedCount }: ReviewEntryButtonProps) {
   }
 
   return (
-    <Button variant="outline" size="sm" onClick={handleClick}>
-      Review ({unreviewedCount})
+    <Button size="sm" onClick={handleClick}>
+      Review {unreviewedCount.toLocaleString()}
     </Button>
   );
 }

--- a/src/components/molecules/review-nudge.tsx
+++ b/src/components/molecules/review-nudge.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import Link from "next/link";
+import { X, CircleAlert } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Alert, AlertTitle, AlertDescription, AlertAction } from "@/components/ui/alert";
+import { cn } from "@/lib/utils";
+import { centsToDisplay } from "@/lib/money";
+import type { UncategorizedShare } from "@/lib/uncategorized-share";
+
+const DISMISS_KEY = "ledgr:review-nudge-dismissed";
+const DISMISS_EVENT = "ledgr:review-nudge-dismiss";
+
+// Read through useSyncExternalStore rather than an effect: sessionStorage does
+// not exist during SSR, so the server snapshot is always "not dismissed" and
+// React reconciles to the real value on hydration without a mismatch.
+function subscribe(onChange: () => void) {
+  window.addEventListener(DISMISS_EVENT, onChange);
+  return () => window.removeEventListener(DISMISS_EVENT, onChange);
+}
+
+// Fallback for when sessionStorage throws (private browsing, blocked site
+// data). Without it the dismiss button would be a no-op for those users,
+// which is the one thing this control must never be.
+let dismissedInMemory = false;
+
+function isDismissed() {
+  if (dismissedInMemory) return true;
+  try {
+    return sessionStorage.getItem(DISMISS_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function notDismissedOnServer() {
+  return false;
+}
+
+interface ReviewNudgeProps {
+  /** Transactions awaiting review. The nudge does not render at zero. */
+  unreviewedCount: number;
+  /** Uncategorized spend for the displayed month, or null if there is none. */
+  share: UncategorizedShare | null;
+  /** Month label for the share, e.g. "August". */
+  monthLabel: string;
+}
+
+export function ReviewNudge({ unreviewedCount, share, monthLabel }: ReviewNudgeProps) {
+  const dismissed = useSyncExternalStore(subscribe, isDismissed, notDismissedOnServer);
+
+  function dismiss() {
+    dismissedInMemory = true;
+    try {
+      sessionStorage.setItem(DISMISS_KEY, "1");
+    } catch {
+      // Storage unavailable. The event below still hides it for this view.
+    }
+    window.dispatchEvent(new Event(DISMISS_EVENT));
+  }
+
+  // A tidy household never sees this — no congratulatory empty state.
+  if (unreviewedCount === 0 || dismissed) return null;
+
+  return (
+    // Caution, not alarm: an untidy ledger is not an emergency, so this is the
+    // warning variant rather than destructive.
+    <Alert variant="warning" className="mb-6 pr-2 sm:pr-44">
+      <CircleAlert />
+      <AlertTitle>
+        {unreviewedCount.toLocaleString()}{" "}
+        {unreviewedCount === 1 ? "transaction needs" : "transactions need"} a category
+      </AlertTitle>
+      {share && (
+        <AlertDescription>
+          {centsToDisplay(share.amount)} of {monthLabel} spending — {share.pct}% — is still
+          uncategorized, so budgets and reports are under-counting.
+        </AlertDescription>
+      )}
+      <AlertAction className="flex items-center gap-1">
+        <Link href="/transactions?mode=review" className={cn(buttonVariants({ size: "sm" }))}>
+          Start reviewing
+        </Link>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          onClick={dismiss}
+          aria-label="Dismiss until next visit"
+        >
+          <X />
+        </Button>
+      </AlertAction>
+    </Alert>
+  );
+}

--- a/src/components/molecules/transaction-row.tsx
+++ b/src/components/molecules/transaction-row.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { accountDisplayName } from "@/lib/account-name";
 import { memo, useCallback } from "react";
 import { Clock } from "lucide-react";
 import { AmountDisplay } from "@/components/atoms/amount-display";
@@ -96,7 +97,7 @@ export const TransactionRow = memo(function TransactionRow({
             </span>
           )}
           <span className="hidden sm:inline text-[10px] text-muted-foreground shrink-0 max-w-[100px] truncate">
-            {txn.accountName}
+            {txn.accountName && accountDisplayName(txn.accountName)}
           </span>
         </div>
       </div>

--- a/src/components/organisms/dashboard-grid.tsx
+++ b/src/components/organisms/dashboard-grid.tsx
@@ -28,7 +28,16 @@ export interface DashboardData {
   spendingMonth: string;
   cashFlow: CashFlowRow[];
   recentTransactions: TransactionRow[];
-  accounts: { id: string; name: string; type: AccountType; currentBalance: number | null; currency: string | null }[];
+  accounts: {
+    id: string;
+    name: string;
+    type: AccountType;
+    currentBalance: number | null;
+    currency: string | null;
+    institutionName: string;
+    logoBase64: string | null;
+    primaryColor: string | null;
+  }[];
   budgetData?: BudgetMonth;
   upcomingBills: BillRow[];
   investmentsData?: Awaited<ReturnType<typeof getInvestmentsSummary>>;

--- a/src/components/organisms/dashboard-grid.tsx
+++ b/src/components/organisms/dashboard-grid.tsx
@@ -116,6 +116,8 @@ export function DashboardGrid({ layout, data }: DashboardGridProps) {
           <InvestmentsWidget
             totalValue={data.investmentsData.totalValue}
             dayChange={data.investmentsData.dayChange}
+            holdingCount={data.investmentsData.holdingCount}
+            topHoldings={data.investmentsData.topHoldings}
           />
         ) : (
           <WidgetPlaceholder

--- a/src/components/organisms/widgets/account-balances.tsx
+++ b/src/components/organisms/widgets/account-balances.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { accountDisplayName } from "@/lib/account-name";
 import { AccountTypeIcon } from "@/components/atoms/account-type-icon";
 import { BalanceDisplay } from "@/components/atoms/balance-display";
 import type { AccountType } from "@/db/schema/accounts";
@@ -33,7 +34,7 @@ export function AccountBalancesWidget({ data }: AccountBalancesWidgetProps) {
           <div key={account.id} className="flex items-center justify-between py-1.5 px-1">
             <div className="flex items-center gap-2 min-w-0">
               <AccountTypeIcon type={account.type} />
-              <span className="text-sm truncate">{account.name}</span>
+              <span className="text-sm truncate">{accountDisplayName(account.name)}</span>
             </div>
             <BalanceDisplay amount={account.currentBalance} currency={account.currency ?? "USD"} size="sm" />
           </div>

--- a/src/components/organisms/widgets/account-balances.tsx
+++ b/src/components/organisms/widgets/account-balances.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { accountDisplayName } from "@/lib/account-name";
-import { AccountTypeIcon } from "@/components/atoms/account-type-icon";
+import { EntityAvatar } from "@/components/molecules/entity-avatar";
 import { BalanceDisplay } from "@/components/atoms/balance-display";
 import type { AccountType } from "@/db/schema/accounts";
 
@@ -12,6 +12,9 @@ interface AccountBalanceRow {
   type: AccountType;
   currentBalance: number | null;
   currency: string | null;
+  institutionName: string;
+  logoBase64: string | null;
+  primaryColor: string | null;
 }
 
 interface AccountBalancesWidgetProps {
@@ -33,7 +36,12 @@ export function AccountBalancesWidget({ data }: AccountBalancesWidgetProps) {
         {data.map((account) => (
           <div key={account.id} className="flex items-center justify-between py-1.5 px-1">
             <div className="flex items-center gap-2 min-w-0">
-              <AccountTypeIcon type={account.type} />
+              <EntityAvatar
+                logoBase64={account.logoBase64}
+                name={account.institutionName}
+                primaryColor={account.primaryColor}
+                size="sm"
+              />
               <span className="text-sm truncate">{accountDisplayName(account.name)}</span>
             </div>
             <BalanceDisplay amount={account.currentBalance} currency={account.currency ?? "USD"} size="sm" />

--- a/src/components/organisms/widgets/investments-widget.tsx
+++ b/src/components/organisms/widgets/investments-widget.tsx
@@ -1,28 +1,82 @@
 "use client";
 
+import Link from "next/link";
 import { centsToDisplay } from "@/lib/money";
 import { ComparisonBadge } from "@/components/molecules/comparison-badge";
-import { TrendingUp } from "lucide-react";
+import { WidgetPlaceholder } from "@/components/molecules/widget-placeholder";
+import { Progress } from "@/components/ui/progress";
+import type { InvestmentsSummaryHolding } from "@/queries/investments";
 
 interface InvestmentsWidgetProps {
   totalValue: number;
   dayChange: number | null;
+  holdingCount: number;
+  topHoldings: InvestmentsSummaryHolding[];
 }
 
-export function InvestmentsWidget({ totalValue, dayChange }: InvestmentsWidgetProps) {
+function holdingLabel(h: InvestmentsSummaryHolding) {
+  return h.ticker ?? h.securityName;
+}
+
+export function InvestmentsWidget({
+  totalValue,
+  dayChange,
+  holdingCount,
+  topHoldings,
+}: InvestmentsWidgetProps) {
+  if (holdingCount === 0) {
+    return (
+      <WidgetPlaceholder
+        title="No holdings yet"
+        description="Connect a brokerage and your positions will appear here."
+        actions={[{ label: "Connect accounts", href: "/accounts", primary: true }]}
+      />
+    );
+  }
+
   return (
-    <div className="flex flex-col gap-2 h-full justify-center">
-      <div className="flex items-center gap-2 text-muted-foreground">
-        <TrendingUp className="size-4" />
-        <span className="text-sm font-medium">Investments</span>
+    <div className="flex h-full flex-col gap-3">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <span className="text-2xl font-semibold tabular-nums tracking-tight">
+          {centsToDisplay(totalValue)}
+        </span>
+        {dayChange !== null && (
+          <ComparisonBadge current={totalValue} previous={totalValue - dayChange} pill />
+        )}
       </div>
-      <span className="text-2xl font-bold tabular-nums">{centsToDisplay(totalValue)}</span>
-      {dayChange !== null && (
-        <ComparisonBadge
-          current={totalValue}
-          previous={totalValue - dayChange}
-          pill
-        />
+
+      {/* The grid cell is a fixed height and the widget is user-resizable, so
+          the list scrolls rather than clipping. The min-height matters for
+          anyone whose saved layout still has this widget at one row — without
+          it `flex-1` resolves to zero there and the list vanishes entirely. */}
+      <ul className="flex min-h-10 flex-1 flex-col gap-2 overflow-y-auto">
+        {topHoldings.map((h) => (
+          <li key={holdingLabel(h)} className="flex flex-col gap-1">
+            <div className="flex items-baseline justify-between gap-2">
+              <span className="truncate text-sm font-medium">{holdingLabel(h)}</span>
+              <span className="shrink-0 text-sm tabular-nums">
+                {centsToDisplay(h.currentValue)}
+              </span>
+            </div>
+            {/* Share of portfolio. Muted rather than the default primary fill —
+                these are proportions, not progress toward a goal, and six
+                near-black bars would out-weigh every other widget on the page. */}
+            <Progress
+              value={h.share}
+              className="h-1 [&_[data-slot=progress-indicator]]:bg-muted-foreground/40"
+              aria-label={`${holdingLabel(h)} — ${h.share.toFixed(0)}% of portfolio`}
+            />
+          </li>
+        ))}
+      </ul>
+
+      {holdingCount > topHoldings.length && (
+        <Link
+          href="/investments"
+          className="mt-auto pt-1 text-center text-xs text-primary hover:underline"
+        >
+          View all {holdingCount} holdings
+        </Link>
       )}
     </div>
   );

--- a/src/components/organisms/widgets/registry.ts
+++ b/src/components/organisms/widgets/registry.ts
@@ -25,7 +25,7 @@ export const DASHBOARD_WIDGETS: WidgetConfig[] = [
   { id: "recent-txns", title: "Recent Transactions", defaultHeight: 2 },
   { id: "budgets", title: "Budget Progress", defaultHeight: 1 },
   { id: "bills", title: "Upcoming Bills", defaultHeight: 2 },
-  { id: "investments", title: "Investments", defaultHeight: 1 },
+  { id: "investments", title: "Investments", defaultHeight: 2 },
 ];
 
 // Widgets that used to live in the grid but now render as fixed page sections

--- a/src/components/organisms/widgets/spending-by-category.tsx
+++ b/src/components/organisms/widgets/spending-by-category.tsx
@@ -3,9 +3,13 @@
 import { useState } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { ChartViewToggle } from "@/components/atoms/chart-view-toggle";
 import { SpendingChart } from "@/components/atoms/spending-chart";
+import { WidgetPlaceholder } from "@/components/molecules/widget-placeholder";
 import { formatMonthLong, shiftMonth } from "@/lib/date-utils";
+import { uncategorizedShare } from "@/lib/uncategorized-share";
+import { centsToDisplay } from "@/lib/money";
 import type { MonthlySpendingRow } from "@/queries/dashboard";
 
 interface SpendingByCategoryProps {
@@ -18,11 +22,19 @@ interface SpendingByCategoryProps {
 export function SpendingByCategory({ data, currentMonth, onMonthChange, isLoading }: SpendingByCategoryProps) {
   const [view, setView] = useState<"donut" | "bar">("donut");
 
+  // "Uncategorized" is the absence of data, not a category, and drawing it as a
+  // peer slice makes the chart look complete when part of it is unknown. It
+  // comes out of the series and is disclosed in the header instead — the pill
+  // is not optional, or removing the slice would simply hide the shortfall.
+  const share = uncategorizedShare(data);
+  const categorized = data.filter((r) => r.categoryId !== null);
+
   if (data.length === 0 && !isLoading) {
     return (
-      <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
-        No spending data for {formatMonthLong(currentMonth)}.
-      </div>
+      <WidgetPlaceholder
+        title={`No spending in ${formatMonthLong(currentMonth)}`}
+        description="Spending by category will appear here once transactions land in this month."
+      />
     );
   }
 
@@ -40,11 +52,31 @@ export function SpendingByCategory({ data, currentMonth, onMonthChange, isLoadin
         </div>
         <ChartViewToggle value={view} onChange={setView} />
       </div>
+
+      {share && (
+        <div className="mb-2 flex flex-wrap items-center gap-x-2 gap-y-1">
+          <Badge variant="outline" className="border-warning/40 text-warning">
+            {share.pct}% uncategorized
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            {centsToDisplay(share.amount)} — shares below are of categorized spending only
+          </span>
+        </div>
+      )}
+
       <div className="flex-1 min-h-0">
-        <SpendingChart
-          data={data.map((r) => ({ id: r.categoryId, name: r.categoryName, value: r.total }))}
-          viewMode={view}
-        />
+        {categorized.length === 0 ? (
+          <WidgetPlaceholder
+            title={`Nothing in ${formatMonthLong(currentMonth)} has a category yet`}
+            description="Categorize a few transactions and the breakdown will fill in."
+            actions={[{ label: "Start reviewing", href: "/transactions?mode=review", primary: true }]}
+          />
+        ) : (
+          <SpendingChart
+            data={categorized.map((r) => ({ id: r.categoryId, name: r.categoryName, value: r.total }))}
+            viewMode={view}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,80 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+        // Caution, not alarm — for states that need attention but have lost
+        // nothing. `destructive` stays reserved for data loss and failures.
+        warning:
+          "border-warning/40 bg-warning/8 *:[svg]:text-warning",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2 right-2", className)}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction }

--- a/src/lib/account-name.test.ts
+++ b/src/lib/account-name.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { accountDisplayName } from "./account-name";
+
+describe("accountDisplayName", () => {
+  describe("strips a trailing account-number suffix that the name already carries", () => {
+    // SimpleFIN appends " (last4)" to whatever the institution calls the
+    // account. When the institution's own name already ends in those digits
+    // the result reads the number twice.
+    it.each([
+      ["Checking-1135 (1135)", "Checking-1135"],
+      ["Citi Custom Cash® Card-7319 (7319)", "Citi Custom Cash® Card-7319"],
+      ["Robinhood Credit Card **3640 (3640)", "Robinhood Credit Card **3640"],
+      ["WELLS FARGO AUTOGRAPH VISA CARD ...2842 (2842)", "WELLS FARGO AUTOGRAPH VISA CARD ...2842"],
+      ["Savings 4403 (4403)", "Savings 4403"],
+      ["Card·5148 (5148)", "Card·5148"],
+    ])("%s -> %s", (input, expected) => {
+      expect(accountDisplayName(input)).toBe(expected);
+    });
+  });
+
+  describe("keeps the suffix when it is the only thing distinguishing the account", () => {
+    // These two are real, and differ by nothing but the suffix. Stripping it
+    // would render two different accounts identically.
+    it.each([
+      "Robinhood individual (1722)",
+      "Robinhood individual (8904)",
+      "Robinhood traditional IRA (7140)",
+      "Amazon Prime Rewards Visa Signature (2701)",
+      "Crypto (9877)",
+      "Portfolio Value (2688)",
+    ])("leaves %s alone", (input) => {
+      expect(accountDisplayName(input)).toBe(input);
+    });
+  });
+
+  describe("leaves anything that is not this pattern alone", () => {
+    it.each([
+      "Main Checking",
+      "",
+      "Emergency Fund (joint)",
+      "401(k)",
+      "Checking (12345)", // 5 digits is not a last-4 mask
+      "Checking-1135 (1136)", // digits present but different
+      "Checking-11350 (1350)", // suffix digits appear mid-token, not at the end
+    ])("leaves %s alone", (input) => {
+      expect(accountDisplayName(input)).toBe(input);
+    });
+
+    it("trims surrounding whitespace only when it strips a suffix", () => {
+      expect(accountDisplayName("Checking-1135  (1135)")).toBe("Checking-1135");
+      expect(accountDisplayName("  Main Checking  ")).toBe("  Main Checking  ");
+    });
+  });
+});

--- a/src/lib/account-name.ts
+++ b/src/lib/account-name.ts
@@ -1,0 +1,40 @@
+/**
+ * Collapses an account number that appears twice in a provider-supplied name.
+ *
+ * SimpleFIN appends " (last4)" to whatever the institution calls the account.
+ * When the institution's own name already ends in those digits the result reads
+ * the number twice — "Checking-1135 (1135)".
+ *
+ * The suffix is only redundant when the rest of the name already ends with the
+ * same digits. Elsewhere it is load-bearing: "Robinhood individual (1722)" and
+ * "Robinhood individual (8904)" are two different accounts distinguished by
+ * nothing else, so the suffix stays.
+ */
+
+/** Trailing " (1234)" — exactly four digits, the last-4 convention. */
+const TRAILING_MASK = /^(.*?)\s*\((\d{4})\)$/;
+
+/**
+ * Characters an institution may put between the name and the digits.
+ * Covers "Checking-1135", "Card **3640", "CARD ...2842", "Savings 4403".
+ */
+const SEPARATORS = "[\\s\\-–—*.·#:]*";
+
+export function accountDisplayName(name: string): string {
+  const match = TRAILING_MASK.exec(name);
+  if (!match) return name;
+
+  const [, base, digits] = match;
+
+  // Anchor to the end of the base and require the digits to be a whole token,
+  // so "Checking-11350 (1350)" keeps its suffix — 1350 is a fragment of 11350,
+  // not the account number the institution wrote down.
+  const alreadyPresent = new RegExp(`(?:^|${SEPARATORS})${digits}$`).test(base);
+  if (!alreadyPresent) return name;
+
+  // A digit immediately before the match means we landed mid-number.
+  const precedingChar = base.charAt(base.length - digits.length - 1);
+  if (/\d/.test(precedingChar)) return name;
+
+  return base;
+}

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import {
+  THEME_STORAGE_KEY,
+  THEME_OPTIONS,
+  THEME_INIT,
+  isTheme,
+  applyTheme,
+  readStoredTheme,
+} from "./theme";
+
+/**
+ * These run in the node environment (see vitest.stryker.config.ts), so the
+ * few browser globals the module touches are stubbed rather than assumed.
+ */
+
+function stubStorage(initial: Record<string, string> = {}, throws = false) {
+  const store = new Map(Object.entries(initial));
+  vi.stubGlobal("localStorage", {
+    getItem(key: string) {
+      if (throws) throw new Error("blocked");
+      return store.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      if (throws) throw new Error("blocked");
+      store.set(key, value);
+    },
+  });
+  return store;
+}
+
+function stubDom(prefersDark: boolean) {
+  const classes = new Set<string>();
+  vi.stubGlobal("window", {
+    matchMedia: (query: string) => ({ matches: query.includes("dark") && prefersDark }),
+  });
+  vi.stubGlobal("document", {
+    documentElement: {
+      classList: {
+        toggle(name: string, force: boolean) {
+          if (force) classes.add(name);
+          else classes.delete(name);
+        },
+      },
+    },
+  });
+  return classes;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("isTheme", () => {
+  it.each(THEME_OPTIONS)("accepts %s", (value) => {
+    expect(isTheme(value)).toBe(true);
+  });
+
+  it.each([
+    ["", "empty string"],
+    ["Dark", "wrong case"],
+    ["system ", "trailing space"],
+    ["auto", "unknown value"],
+  ])("rejects %s (%s)", (value) => {
+    expect(isTheme(value)).toBe(false);
+  });
+
+  it.each([null, undefined, 0, 1, {}, [], true])("rejects the non-string %s", (value) => {
+    expect(isTheme(value)).toBe(false);
+  });
+});
+
+describe("readStoredTheme", () => {
+  it("returns the stored preference", () => {
+    stubStorage({ [THEME_STORAGE_KEY]: "dark" });
+    expect(readStoredTheme()).toBe("dark");
+  });
+
+  it("falls back to system when nothing is stored", () => {
+    stubStorage();
+    expect(readStoredTheme()).toBe("system");
+  });
+
+  it("falls back to system when the stored value is not a theme", () => {
+    // A stale or hand-edited value must not reach applyTheme.
+    stubStorage({ [THEME_STORAGE_KEY]: "solarized" });
+    expect(readStoredTheme()).toBe("system");
+  });
+
+  it("falls back to system when storage throws", () => {
+    // Private browsing or blocked site data.
+    stubStorage({}, true);
+    expect(readStoredTheme()).toBe("system");
+  });
+});
+
+describe("applyTheme", () => {
+  it("adds the dark class for an explicit dark choice, whatever the OS says", () => {
+    const classes = stubDom(false);
+    applyTheme("dark");
+    expect(classes.has("dark")).toBe(true);
+  });
+
+  it("removes the dark class for an explicit light choice, whatever the OS says", () => {
+    const classes = stubDom(true);
+    applyTheme("light");
+    expect(classes.has("dark")).toBe(false);
+  });
+
+  it("adds dark under system when the OS prefers dark", () => {
+    const classes = stubDom(true);
+    applyTheme("system");
+    expect(classes.has("dark")).toBe(true);
+  });
+
+  it("does not add dark under system when the OS prefers light", () => {
+    const classes = stubDom(false);
+    applyTheme("system");
+    expect(classes.has("dark")).toBe(false);
+  });
+});
+
+describe("THEME_INIT", () => {
+  it("references the same storage key the rest of the module uses", () => {
+    // The script is a string, so a renamed key would otherwise desync silently
+    // and the stored preference would be ignored on first paint.
+    expect(THEME_INIT).toContain(THEME_STORAGE_KEY);
+  });
+
+  it("carries no interpolation beyond that key", () => {
+    // It is injected via dangerouslySetInnerHTML. Nothing dynamic may appear.
+    expect(THEME_INIT).not.toContain("${");
+  });
+
+  it("cannot break out of the script element", () => {
+    expect(THEME_INIT).not.toContain("</script");
+  });
+
+  // The script runs before first paint and is the only thing standing between
+  // the user and a flash of the wrong theme, so it is executed here rather than
+  // just pattern-matched. `new Function` over `eval`: same purpose, but it does
+  // not get the enclosing scope. The input is this module's own constant, which
+  // the tests above pin as free of interpolation.
+  describe("behaves the same as applyTheme", () => {
+    it.each([
+      { stored: "dark", prefersDark: false, expectDark: true },
+      { stored: "light", prefersDark: true, expectDark: false },
+      { stored: "system", prefersDark: true, expectDark: true },
+      { stored: "system", prefersDark: false, expectDark: false },
+      { stored: null, prefersDark: true, expectDark: true },
+      { stored: null, prefersDark: false, expectDark: false },
+    ])("stored=$stored prefersDark=$prefersDark -> dark=$expectDark", ({ stored, prefersDark, expectDark }) => {
+      const classes = stubDom(prefersDark);
+      stubStorage(stored ? { [THEME_STORAGE_KEY]: stored } : {});
+      new Function(THEME_INIT)();
+      expect(classes.has("dark")).toBe(expectDark);
+    });
+  });
+});

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,50 @@
+/**
+ * Theme preference: three states, not two.
+ *
+ * "system" is the default and follows the OS. The other two are explicit
+ * overrides, which matter for a self-hosted app — a shared or work-managed
+ * machine decides the OS theme for you, and before this there was no way to
+ * disagree with it.
+ *
+ * The resolved value is applied as a class on <html>; see globals.css, where
+ * `:root.dark` is the single definition of the dark palette.
+ */
+
+export const THEME_STORAGE_KEY = "ledgr:theme";
+
+export const THEME_OPTIONS = ["system", "light", "dark"] as const;
+export type Theme = (typeof THEME_OPTIONS)[number];
+
+export function isTheme(value: unknown): value is Theme {
+  return typeof value === "string" && (THEME_OPTIONS as readonly string[]).includes(value);
+}
+
+/**
+ * Applied to <html> before first paint by the inline script in app/layout.tsx,
+ * and again by the toggle whenever the preference changes.
+ */
+export function applyTheme(theme: Theme) {
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const dark = theme === "dark" || (theme === "system" && prefersDark);
+  document.documentElement.classList.toggle("dark", dark);
+}
+
+export function readStoredTheme(): Theme {
+  try {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    return isTheme(stored) ? stored : "system";
+  } catch {
+    // Blocked site data — fall back to following the OS.
+    return "system";
+  }
+}
+
+/**
+ * Source for the blocking <script> in the document head.
+ *
+ * This is a fixed string literal with no interpolation — nothing from a user,
+ * a request, or the database reaches it, which is what makes it safe to inject
+ * via dangerouslySetInnerHTML. Keep it that way: if this ever needs a dynamic
+ * value, serialise it with JSON.stringify rather than concatenating.
+ */
+export const THEME_INIT = `(function(){try{var t=localStorage.getItem("${THEME_STORAGE_KEY}");var d=t==="dark"||((!t||t==="system")&&window.matchMedia("(prefers-color-scheme: dark)").matches);document.documentElement.classList.toggle("dark",d)}catch(e){}})();`;

--- a/src/lib/uncategorized-share.test.ts
+++ b/src/lib/uncategorized-share.test.ts
@@ -56,10 +56,31 @@ describe("uncategorizedShare", () => {
     expect(uncategorizedShare([row(null, 100), row("x", 200)])?.pct).toBe(33.3);
   });
 
-  it("ignores negative totals rather than producing a nonsense share", () => {
+  describe("negative totals", () => {
     // Spending aggregates are absolute values; a negative is a data fault, not
     // a refund. Treat it as absent instead of letting it skew the denominator.
-    expect(uncategorizedShare([row(null, -500), row("x", 1000)])).toBeNull();
+    it("bails on a negative uncategorized row", () => {
+      expect(uncategorizedShare([row(null, -500), row("x", 1000)])).toBeNull();
+    });
+
+    it("bails on a negative categorized row, which would otherwise exceed 100%", () => {
+      // The case that actually exercises the guard: uncategorized is positive,
+      // so without the guard this returns amount 1000 of total 500 — a 200%
+      // share. The negative-uncategorized case above returns null either way,
+      // via the `amount <= 0` check, so it does not test the guard at all.
+      expect(uncategorizedShare([row(null, 1000), row("x", -500)])).toBeNull();
+    });
+
+    it("treats a zero row as real data, not a fault", () => {
+      // Zero is a legitimate total for a category with no spend this month —
+      // only a negative indicates corruption.
+      expect(uncategorizedShare([row(null, 1000), row("x", 0)])).toEqual({
+        amount: 1000,
+        total: 1000,
+        categorized: 0,
+        pct: 100,
+      });
+    });
   });
 
   describe("categorized always reconciles to total minus amount", () => {

--- a/src/lib/uncategorized-share.test.ts
+++ b/src/lib/uncategorized-share.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { uncategorizedShare, type SpendingSlice } from "./uncategorized-share";
+
+const row = (categoryId: string | null, total: number): SpendingSlice => ({ categoryId, total });
+
+describe("uncategorizedShare", () => {
+  it("reports the amount, the two denominators, and the share of total spend", () => {
+    const share = uncategorizedShare([
+      row("clothing", 131593),
+      row(null, 105729),
+      row("restaurants", 96200),
+    ]);
+
+    expect(share).toEqual({
+      amount: 105729,
+      total: 333522,
+      categorized: 227793,
+      pct: 31.7,
+    });
+  });
+
+  it("returns null when every row carries a category", () => {
+    expect(uncategorizedShare([row("clothing", 131593), row("restaurants", 96200)])).toBeNull();
+  });
+
+  it("returns null for an empty month", () => {
+    expect(uncategorizedShare([])).toBeNull();
+  });
+
+  it("returns null when the uncategorized bucket exists but is empty", () => {
+    // Nothing to act on — surfacing a zero-value nudge would be noise.
+    expect(uncategorizedShare([row("clothing", 131593), row(null, 0)])).toBeNull();
+  });
+
+  it("does not divide by zero when the only row is an empty uncategorized bucket", () => {
+    expect(uncategorizedShare([row(null, 0)])).toBeNull();
+  });
+
+  it("reports 100% when nothing at all is categorized", () => {
+    expect(uncategorizedShare([row(null, 50000)])).toEqual({
+      amount: 50000,
+      total: 50000,
+      categorized: 0,
+      pct: 100,
+    });
+  });
+
+  it("sums multiple uncategorized rows if a caller ever supplies them", () => {
+    const share = uncategorizedShare([row(null, 1000), row(null, 500), row("groceries", 8500)]);
+    expect(share?.amount).toBe(1500);
+    expect(share?.categorized).toBe(8500);
+  });
+
+  it("rounds the percentage to one decimal place", () => {
+    // 1/3 of spend — the raw value is 33.333...
+    expect(uncategorizedShare([row(null, 100), row("x", 200)])?.pct).toBe(33.3);
+  });
+
+  it("ignores negative totals rather than producing a nonsense share", () => {
+    // Spending aggregates are absolute values; a negative is a data fault, not
+    // a refund. Treat it as absent instead of letting it skew the denominator.
+    expect(uncategorizedShare([row(null, -500), row("x", 1000)])).toBeNull();
+  });
+
+  describe("categorized always reconciles to total minus amount", () => {
+    it.each([
+      [[row(null, 1), row("a", 1)]],
+      [[row(null, 999999), row("a", 1), row("b", 2)]],
+      [[row(null, 33333), row("a", 66667)]],
+    ])("case %#", (rows) => {
+      const share = uncategorizedShare(rows)!;
+      expect(share.categorized).toBe(share.total - share.amount);
+    });
+  });
+});

--- a/src/lib/uncategorized-share.ts
+++ b/src/lib/uncategorized-share.ts
@@ -46,7 +46,13 @@ export function uncategorizedShare(rows: SpendingSlice[]): UncategorizedShare | 
   }
 
   // Nothing uncategorized, or an empty month: no problem to report.
-  if (amount <= 0 || total <= 0) return null;
+  //
+  // This also rules out a zero denominator below without a second check.
+  // Negative rows returned early, so every row is >= 0 and `total` is a sum
+  // that includes `amount` — meaning `amount > 0` implies `total > 0`. A
+  // `total <= 0` guard here would be unreachable, which is exactly what
+  // mutation testing flagged: negating it changed no behaviour.
+  if (amount <= 0) return null;
 
   return {
     amount,

--- a/src/lib/uncategorized-share.ts
+++ b/src/lib/uncategorized-share.ts
@@ -1,0 +1,57 @@
+/**
+ * How much of a month's spending has no category yet.
+ *
+ * Two consumers, and they need different denominators:
+ *
+ *   - the dashboard review nudge quotes `amount` and `pct` (share of *total*
+ *     spend), because that is the size of the problem;
+ *   - the spending donut renders over `categorized`, because "Uncategorized"
+ *     is the absence of data rather than a peer category — and once it is
+ *     removed from the series every remaining slice is a percentage of
+ *     `categorized`, not of `total`. Labelling those as a share of spending
+ *     would overstate every category on the chart.
+ *
+ * Both are returned so neither caller has to re-derive the other's.
+ */
+
+export interface SpendingSlice {
+  /** null identifies the uncategorized bucket (see lib/spending-helpers.ts). */
+  categoryId: string | null;
+  /** Absolute spend in cents. */
+  total: number;
+}
+
+export interface UncategorizedShare {
+  /** Uncategorized spend, in cents. */
+  amount: number;
+  /** All spend for the period, in cents, uncategorized included. */
+  total: number;
+  /** Spend that has a category — the donut's denominator. */
+  categorized: number;
+  /** `amount` as a percentage of `total`, to one decimal place. */
+  pct: number;
+}
+
+export function uncategorizedShare(rows: SpendingSlice[]): UncategorizedShare | null {
+  let amount = 0;
+  let total = 0;
+
+  for (const r of rows) {
+    // Spending aggregates are absolute values, so a negative is a data fault
+    // rather than a refund. Skipping keeps it out of the denominator instead
+    // of letting it inflate the reported share.
+    if (r.total < 0) return null;
+    total += r.total;
+    if (r.categoryId === null) amount += r.total;
+  }
+
+  // Nothing uncategorized, or an empty month: no problem to report.
+  if (amount <= 0 || total <= 0) return null;
+
+  return {
+    amount,
+    total,
+    categorized: total - amount,
+    pct: Math.round((amount / total) * 1000) / 10,
+  };
+}

--- a/src/queries/investments.ts
+++ b/src/queries/investments.ts
@@ -39,6 +39,22 @@ export interface InvestmentHoldingRow {
   accountId?: string;
 }
 
+export interface InvestmentsSummaryHolding {
+  ticker: string | null;
+  securityName: string;
+  currentValue: number;
+  gainLossPercent: number | null;
+  /** Share of total portfolio value, 0-100. */
+  share: number;
+}
+
+export interface InvestmentsSummary {
+  totalValue: number;
+  dayChange: number | null;
+  holdingCount: number;
+  topHoldings: InvestmentsSummaryHolding[];
+}
+
 export interface InvTxnRow {
   id: string;
   date: string;
@@ -346,7 +362,27 @@ export async function getInvestmentTransactions(
 export async function getInvestmentsSummary(
   householdId: string,
   db: LedgrDb = defaultDb,
-): Promise<{ totalValue: number; dayChange: number | null }> {
-  const summary = await getPortfolioSummary(householdId, db);
-  return { totalValue: summary.totalValue, dayChange: summary.dayChange };
+): Promise<InvestmentsSummary> {
+  const [summary, holdings] = await Promise.all([
+    getPortfolioSummary(householdId, db),
+    getHoldings(householdId, "consolidated", undefined, db),
+  ]);
+
+  // getHoldings returns consolidated positions already ordered by value, so the
+  // dashboard widget just takes the head of the list. Anything past the top few
+  // does not fit the cell and belongs on /investments.
+  const topHoldings = holdings.slice(0, 3).map((h) => ({
+    ticker: h.ticker,
+    securityName: h.securityName,
+    currentValue: h.currentValue,
+    gainLossPercent: h.gainLossPercent,
+    share: summary.totalValue > 0 ? (h.currentValue / summary.totalValue) * 100 : 0,
+  }));
+
+  return {
+    totalValue: summary.totalValue,
+    dayChange: summary.dayChange,
+    holdingCount: holdings.length,
+    topHoldings,
+  };
 }


### PR DESCRIPTION
The first cluster from the UI review — the changes that make the categorization backlog visible and actionable.

## What's here

**#106 — the dashboard never mentioned the review queue.** A conditional `ReviewNudge` above the hero, plus promoting `Review (N)` from outline to solid on `/transactions` (it was visually identical to `Export` beside it).

**#111 — Uncategorized was drawn as a peer category in the spending donut.** Pulled out of the series, with the shortfall disclosed in the header.

**#113 — the category pill looked like a static badge.** It is a full inline editor. Now has a resting-state chevron, hover border and focus ring.

**#112 — the Investments widget was one number in a full grid cell.** Now shows top positions with share-of-portfolio bars.

**#115 — dark mode existed but couldn't be chosen.** Three states in Settings: Use device settings / Light / Dark.

**#116 — account names read their number twice; balances widget showed generic glyphs instead of bank marks; the page heading was `sr-only`.**

## Two things worth a closer look

**The donut fix needed a label change, not just a filter.** Removing a 23% slice re-bases every remaining percentage. On the demo household Clothing moves 29% → 38% purely from the smaller denominator — so left unlabelled, this "fix" would have overstated spending in exactly the categories someone is trying to control. The header now states the shortfall and says the shares are of categorized spending only. That disclosure is load-bearing, not decoration.

**#116's diagnosis in the issue was wrong and the code corrected it.** The issue said Ledgr appends the mask a second time. It doesn't — both ingestion sites pass the provider string through verbatim (`name: sanitizeMojibake(account.name)`) and there's no mask column. SimpleFIN itself appends `" (last4)"`, and some institutions already end their name in those digits.

That made the fix narrower than filed, because **the suffix is load-bearing where it's the only differentiator** — `Robinhood individual (1722)` and `Robinhood individual (8904)` are two live accounts distinguished by nothing else. `accountDisplayName()` strips the suffix only when the rest of the name already ends in the same four digits as a whole token, so `Checking-11350 (1350)` also keeps its suffix. I'll correct the issue text separately.

## UI library

Built on the component library rather than hand-rolled markup: the nudge is the shadcn `Alert` (added via CLI) using `AlertTitle`/`AlertDescription`/`AlertAction` with a ghost icon `Button` for dismiss; the shortfall is a `Badge`; two hand-rolled empty states in the spending widget now use the app's own `WidgetPlaceholder`.

`Alert` shipped only `default` and `destructive`, so this adds a `warning` variant — an untidy ledger needs attention but has lost nothing, and `destructive` should stay reserved for failures. That needed a `--warning` token, added alongside `--positive` in both themes.

The appearance control is `Card` + `ToggleGroup`, matching `DemoModeToggle`'s shape. `ToggleGroup` rather than `Tabs` (the codebase's usual segmented control) because a preference is not a tablist — the a11y tree now reports three toggle buttons with a pressed state rather than tabs with no panels.

One deliberate deviation, commented at the call site: the shared toggle marks the active item with `bg-muted`, ~0.045 lightness from the card in dark mode. I checked in the browser and the selection was effectively invisible there, so this one control inverts against `primary`. I left `toggle.tsx` alone rather than changing every toggle in the app.

## Accessibility / responsibility notes

- Nudge is dismissible for the session, **and still dismissible when `sessionStorage` throws** (private browsing) via an in-memory fallback — otherwise the button is a no-op for exactly the users who expect one.
- Dismissal reads through `useSyncExternalStore`, so no hydration mismatch and no `setState`-in-effect.
- Warning colour, not `destructive`. Never blocks or overlays. Does not render at zero.
- Count and reason are both in text — not colour-only.
- Caught and fixed a Base UI `nativeButton` accessibility error I introduced by rendering `Button` as a `Link`; switched to the `buttonVariants`-on-`Link` pattern the codebase already uses in `widget-placeholder.tsx`.

## Verification

- 443 unit tests pass (32 new, covering `accountDisplayName` and `uncategorizedShare`)
- `tsc --noEmit` and `eslint src/` clean (one pre-existing `_accountType` warning on main, which is #92)
- `next build` passes
- Walked the running app in Chrome; dev-overlay console is clean

## On #115's approach

`globals.css` had a full dark palette bound to `prefers-color-scheme` with no class hook. Rather than duplicate ~35 token declarations across a media query *and* a class selector, resolution of "system" moves into JS: a blocking inline script in `<head>` sets `.dark` before first paint, so the dark palette stays defined once (`:root.dark`) and `@custom-variant dark` collapses to a class match. All 82 existing `dark:` utilities keep working in all three states.

The inline script is a fixed string literal with no interpolation — nothing from a user, request, or DB reaches it. `lib/theme.ts` documents that constraint next to the constant so it stays true.

Verified all three states in the browser: forced dark applies and survives reload with no flash; "Use device settings" resolves correctly against the OS and reacts live when it flips.

## What the browser caught that the code didn't

Three things only showed up running the app, and all three are in the diff:

1. **A Base UI `nativeButton` a11y error** I introduced by rendering `Button` as a `Link`. Switched to the `buttonVariants`-on-`Link` pattern the codebase already uses.
2. **The Investments cell is genuinely too small** — measured 72px of content, enough for a total line and nothing else. That is the actual substance of #112, so `defaultHeight` goes 1 → 2. Existing saved layouts keep one row, which is why the list carries a min-height: at that size `flex-1` resolves to zero and the list vanishes instead of scrolling.
3. **`Progress`'s default primary fill was far too heavy** at that density — near-black bars out-weighed every other widget. These are proportions, not progress toward a goal, so they use a muted fill, with the percentage in each bar's accessible name so the bar isn't the only encoding.

Closes #106, closes #111, closes #112, closes #113, closes #115, closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
