### PR TITLE
fix(investments): reconcile the portfolio total against account balances

### DIFF
--- a/src/app/(dashboard)/investments/page.tsx
+++ b/src/app/(dashboard)/investments/page.tsx
@@ -4,6 +4,7 @@ import {
   getPortfolioSummary,
   getPortfolioHistory,
   getAssetAllocation,
+  getAccountReconciliation,
   getHoldings,
   getInvestmentTransactions,
   type InvestmentFilters,
@@ -48,10 +49,11 @@ export default async function InvestmentsPage({
   const accountsPromise = getAccounts(householdId);
   const accIds = await getInvestmentAccountIds(householdId);
 
-  const [summary, history, allocation, holdings, transactions] = await Promise.all([
+  const [summary, history, allocation, reconciliation, holdings, transactions] = await Promise.all([
     getPortfolioSummary(householdId, undefined, undefined, accIds),
     getPortfolioHistory(householdId, { dateFrom: dateFrom ?? dateTo, dateTo }, undefined, accIds),
     getAssetAllocation(householdId, undefined, accIds),
+    getAccountReconciliation(householdId, undefined, accIds),
     tab === "holdings"
       ? getHoldings(householdId, view, accountId, undefined, accIds)
       : Promise.resolve(null),
@@ -72,6 +74,7 @@ export default async function InvestmentsPage({
         summary={summary}
         history={history}
         allocation={allocation}
+        reconciliation={reconciliation}
         holdings={holdings}
         transactions={
           transactions

--- a/src/components/organisms/investment-page-layout.tsx
+++ b/src/components/organisms/investment-page-layout.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TrendingUp } from "lucide-react";
 import { PortfolioSummaryHeader } from "@/components/organisms/portfolio-summary-header";
+import { PortfolioReconciliation } from "@/components/organisms/portfolio-reconciliation";
 import { HoldingsTable } from "@/components/organisms/holdings-table";
 import { InvestmentTransactionList } from "@/components/organisms/investment-transaction-list";
 import type { SpendingChartItem } from "@/components/atoms/spending-chart";
@@ -26,6 +27,7 @@ import type {
   PortfolioSummary,
   PortfolioPoint,
   AllocationSlice,
+  AccountReconciliationRow,
   InvestmentHoldingRow,
   InvTxnRow,
   InvestmentFilters as IFilters,
@@ -35,6 +37,7 @@ interface InvestmentPageLayoutProps {
   summary: PortfolioSummary;
   history: PortfolioPoint[];
   allocation: AllocationSlice[];
+  reconciliation: AccountReconciliationRow[];
   holdings: InvestmentHoldingRow[] | null;
   transactions: { rows: InvTxnRow[]; nextCursor: string | null } | null;
   activeTab: string;
@@ -50,7 +53,7 @@ function formatAllocationTypeLabel(type: string): string {
   return type.charAt(0).toUpperCase() + type.slice(1).replace("_", " ");
 }
 
-export function InvestmentPageLayout({ summary, history, allocation, holdings, transactions, activeTab, view, filters, accounts }: InvestmentPageLayoutProps) {
+export function InvestmentPageLayout({ summary, history, allocation, reconciliation, holdings, transactions, activeTab, view, filters, accounts }: InvestmentPageLayoutProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -93,6 +96,7 @@ export function InvestmentPageLayout({ summary, history, allocation, holdings, t
           </div>
         </div>
       </div>
+      <PortfolioReconciliation rows={reconciliation} />
       <Tabs value={activeTab} onValueChange={handleTabChange}>
         <TabsList>
           <TabsTrigger value="holdings">Holdings</TabsTrigger>

--- a/src/components/organisms/portfolio-reconciliation.tsx
+++ b/src/components/organisms/portfolio-reconciliation.tsx
@@ -1,0 +1,94 @@
+import { centsToDisplay } from "@/lib/money";
+import type { AccountReconciliationRow } from "@/queries/investments";
+
+interface PortfolioReconciliationProps {
+  rows: AccountReconciliationRow[];
+}
+
+/**
+ * Balance-versus-holdings, per account.
+ *
+ * Investments used to report only the holdings sum, so an account reporting a
+ * balance it had not itemized lost the difference with nothing on screen to
+ * explain it (#88). This table is where that difference becomes visible.
+ */
+export function PortfolioReconciliation({ rows }: PortfolioReconciliationProps) {
+  // Nothing to reconcile when every account's holdings account for its balance.
+  if (rows.length === 0 || rows.every((r) => r.cashValue === 0)) return null;
+
+  const totals = rows.reduce(
+    (acc, r) => ({
+      balance: acc.balance + r.balance,
+      holdingsValue: acc.holdingsValue + r.holdingsValue,
+      cashValue: acc.cashValue + r.cashValue,
+    }),
+    { balance: 0, holdingsValue: 0, cashValue: 0 },
+  );
+
+  return (
+    <div className="rounded-lg border">
+      <div className="border-b px-4 py-3">
+        <h3 className="text-sm font-medium">Account reconciliation</h3>
+        <p className="text-xs text-muted-foreground">
+          What each account reports, against the holdings Ledgr can itemize.
+        </p>
+      </div>
+      {/* Wide content scrolls inside its own container so the page never
+          scrolls sideways on a phone. */}
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[560px] text-sm">
+          <thead>
+            <tr className="border-b text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="px-4 py-2 text-left font-medium">Account</th>
+              <th className="px-4 py-2 text-right font-medium">Balance</th>
+              <th className="px-4 py-2 text-right font-medium">Holdings</th>
+              <th className="px-4 py-2 text-right font-medium">Cash / unallocated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.accountId} className="border-b last:border-b-0">
+                <td className="px-4 py-2">
+                  {row.accountName}
+                  {/* A balance with no holdings at all is a connector that
+                      itemized nothing, not a cash position -- worth saying so
+                      rather than labelling the whole balance "cash". */}
+                  {!row.hasHoldings && row.balance > 0 && (
+                    <span className="ml-2 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
+                      not itemized
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-2 text-right tabular-nums">{centsToDisplay(row.balance)}</td>
+                <td className="px-4 py-2 text-right tabular-nums">
+                  {centsToDisplay(row.holdingsValue)}
+                </td>
+                <td className="px-4 py-2 text-right tabular-nums">
+                  {row.cashValue > 0 ? (
+                    centsToDisplay(row.cashValue)
+                  ) : (
+                    <span className="text-muted-foreground">&mdash;</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr className="border-t font-medium">
+              <td className="px-4 py-2">Total</td>
+              <td className="px-4 py-2 text-right tabular-nums">
+                {centsToDisplay(totals.balance)}
+              </td>
+              <td className="px-4 py-2 text-right tabular-nums">
+                {centsToDisplay(totals.holdingsValue)}
+              </td>
+              <td className="px-4 py-2 text-right tabular-nums">
+                {centsToDisplay(totals.cashValue)}
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/portfolio-summary-header.tsx
+++ b/src/components/organisms/portfolio-summary-header.tsx
@@ -1,5 +1,5 @@
 import { centsToDisplay } from "@/lib/money";
-import { StatStrip } from "@/components/molecules/stat-strip";
+import { StatStrip, type StatStripItem } from "@/components/molecules/stat-strip";
 import type { PortfolioSummary } from "@/queries/investments";
 
 interface PortfolioSummaryHeaderProps {
@@ -12,26 +12,40 @@ function signedDisplay(cents: number): string {
 }
 
 export function PortfolioSummaryHeader({ summary }: PortfolioSummaryHeaderProps) {
-  return (
-    <StatStrip
-      items={[
-        { label: "Total Portfolio", value: centsToDisplay(summary.totalValue) },
-        {
-          label: "Day Change",
-          value: summary.dayChange !== null ? signedDisplay(summary.dayChange) : "n/a",
-          valueClassName:
-            summary.dayChange !== null
-              ? summary.dayChange >= 0
-                ? "text-positive"
-                : "text-destructive"
-              : undefined,
-        },
-        {
-          label: "Total Gain/Loss",
-          value: signedDisplay(summary.totalGainLoss),
-          valueClassName: summary.totalGainLoss >= 0 ? "text-positive" : "text-destructive",
-        },
-      ]}
-    />
+  const items: StatStripItem[] = [
+    { label: "Total Portfolio", value: centsToDisplay(summary.totalValue) },
+  ];
+
+  // Only worth a column when there is a gap to explain. Showing a permanent
+  // "$0.00" cash tile would spend a quarter of the strip on nothing.
+  if (summary.cashValue > 0) {
+    items.push({
+      label: "Cash / Unallocated",
+      value: centsToDisplay(summary.cashValue),
+    });
+  }
+
+  items.push(
+    {
+      // Derived from holdings_history, so it can only ever describe the
+      // itemized part. The label says so rather than implying whole-portfolio.
+      label: "Day Change (holdings)",
+      value: summary.dayChange !== null ? signedDisplay(summary.dayChange) : "n/a",
+      valueClassName:
+        summary.dayChange !== null
+          ? summary.dayChange >= 0
+            ? "text-positive"
+            : "text-destructive"
+          : undefined,
+    },
+    {
+      // Spans only holdings that report a cost basis. Zero-basis positions
+      // would otherwise contribute their entire value as gain.
+      label: "Gain/Loss (with cost basis)",
+      value: signedDisplay(summary.totalGainLoss),
+      valueClassName: summary.totalGainLoss >= 0 ? "text-positive" : "text-destructive",
+    },
   );
+
+  return <StatStrip items={items} />;
 }

--- a/src/queries/investments.ts
+++ b/src/queries/investments.ts
@@ -2,16 +2,35 @@ import { eq, and, sql, desc, gte, lte, isNull, inArray } from "drizzle-orm";
 import { db as defaultDb, type LedgrDb } from "@/db";
 import { investmentHoldings, holdingsHistory, investmentTransactions, accounts } from "@/db/schema";
 import { scopedQuery } from "@/lib/scoped-query";
-import { encodeCursor, decodeCursor, sumCol } from "@/lib/query-helpers";
+import { encodeCursor, decodeCursor, sumCol, countRows } from "@/lib/query-helpers";
 import { todayDateString } from "@/lib/date-utils";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface PortfolioSummary {
+  /** What the accounts are actually worth: their balances, not the holdings sum. */
   totalValue: number;
+  /** The itemized part. */
+  holdingsValue: number;
+  /** totalValue - holdingsValue: real uninvested cash, or value a connector did not itemize. */
+  cashValue: number;
+  /** Covers only the holdings portion -- it is derived from holdings_history. */
   dayChange: number | null;
+  /** Covers only holdings that actually report a cost basis. */
   totalGainLoss: number;
   totalCostBasis: number;
+  /** Current value of the holdings the gain/loss figure describes, so the UI can state its scope. */
+  gainLossCoverage: number;
+}
+
+export interface AccountReconciliationRow {
+  accountId: string;
+  accountName: string;
+  balance: number;
+  holdingsValue: number;
+  cashValue: number;
+  /** False when the connector returned a balance but itemized nothing. */
+  hasHoldings: boolean;
 }
 
 export interface PortfolioPoint {
@@ -118,7 +137,17 @@ export async function getPortfolioSummary(
   accIds?: string[],
 ): Promise<PortfolioSummary> {
   const ids = await resolveAccIds(householdId, db, accIds);
-  if (ids.length === 0) return { totalValue: 0, dayChange: null, totalGainLoss: 0, totalCostBasis: 0 };
+  if (ids.length === 0) {
+    return {
+      totalValue: 0,
+      holdingsValue: 0,
+      cashValue: 0,
+      dayChange: null,
+      totalGainLoss: 0,
+      totalCostBasis: 0,
+      gainLossCoverage: 0,
+    };
+  }
 
   const holdings = await db
     .select({
@@ -128,12 +157,36 @@ export async function getPortfolioSummary(
     .from(investmentHoldings)
     .where(inArray(investmentHoldings.accountId, ids));
 
-  let totalValue = 0;
+  let holdingsValue = 0;
   let totalCostBasis = 0;
+  // Gain/loss must span the same set on both sides. Adding every holding to
+  // the value side while skipping null-basis ones on the cost side reports a
+  // holding's entire value as gain -- which is what inflated the total for
+  // zero-basis positions like ETH and BTC.
+  let gainLossCoverage = 0;
   for (const h of holdings) {
-    totalValue += h.currentValue ?? 0;
-    if (h.costBasis !== null) totalCostBasis += h.costBasis;
+    holdingsValue += h.currentValue ?? 0;
+    if (h.costBasis !== null) {
+      totalCostBasis += h.costBasis;
+      gainLossCoverage += h.currentValue ?? 0;
+    }
   }
+
+  // What the accounts are worth comes from their balances. Summing holdings
+  // instead silently drops anything the connector did not itemize.
+  const balanceRows = await db
+    .select({ id: accounts.id, currentBalance: accounts.currentBalance })
+    .from(accounts)
+    .where(inArray(accounts.id, ids));
+  const anyBalanceReported = balanceRows.some((r) => r.currentBalance !== null);
+  const balanceTotal = balanceRows.reduce((sum, r) => sum + (r.currentBalance ?? 0), 0);
+
+  // With no balance recorded anywhere, the holdings sum is the best figure we
+  // have -- falling back keeps accounts that predate balance capture working.
+  const totalValue = anyBalanceReported ? balanceTotal : holdingsValue;
+  // Clamped: a stale balance below the holdings sum would otherwise show
+  // negative cash, which is never a real state.
+  const cashValue = Math.max(0, totalValue - holdingsValue);
 
   const todayStr = today ?? todayDateString();
   const prevDate = new Date(todayStr + "T00:00:00");
@@ -169,10 +222,64 @@ export async function getPortfolioSummary(
 
   return {
     totalValue,
+    holdingsValue,
+    cashValue,
     dayChange,
-    totalGainLoss: totalValue - totalCostBasis,
+    totalGainLoss: gainLossCoverage - totalCostBasis,
     totalCostBasis,
+    gainLossCoverage,
   };
+}
+
+/**
+ * Per-account balance-versus-holdings reconciliation.
+ *
+ * Investments derives its headline from holdings alone, so an account that
+ * reports a balance but itemizes only part of it loses the difference with
+ * nothing on screen to explain the shortfall (#88). This exposes the gap per
+ * account so it can be shown as cash/unallocated, and flags accounts that
+ * itemized nothing at all -- a connector gap, not a cash position.
+ */
+export async function getAccountReconciliation(
+  householdId: string,
+  db: LedgrDb = defaultDb,
+  accIds?: string[],
+): Promise<AccountReconciliationRow[]> {
+  const ids = await resolveAccIds(householdId, db, accIds);
+  if (ids.length === 0) return [];
+
+  const accountRows = await db
+    .select({ id: accounts.id, name: accounts.name, currentBalance: accounts.currentBalance })
+    .from(accounts)
+    .where(inArray(accounts.id, ids));
+
+  const holdingRows = await db
+    .select({
+      accountId: investmentHoldings.accountId,
+      value: sumCol(investmentHoldings.currentValue),
+      count: countRows(),
+    })
+    .from(investmentHoldings)
+    .where(inArray(investmentHoldings.accountId, ids))
+    .groupBy(investmentHoldings.accountId);
+
+  const byAccount = new Map(holdingRows.map((r) => [r.accountId, r]));
+
+  return accountRows
+    .map((a) => {
+      const h = byAccount.get(a.id);
+      const holdingsValue = h?.value ?? 0;
+      const balance = a.currentBalance ?? holdingsValue;
+      return {
+        accountId: a.id,
+        accountName: a.name,
+        balance,
+        holdingsValue,
+        cashValue: Math.max(0, balance - holdingsValue),
+        hasHoldings: (h?.count ?? 0) > 0,
+      };
+    })
+    .sort((x, y) => y.balance - x.balance);
 }
 
 export async function getPortfolioHistory(

--- a/tests/integration/investment-queries.test.ts
+++ b/tests/integration/investment-queries.test.ts
@@ -13,6 +13,7 @@ import {
   getHoldings,
   getPortfolioHistory,
   getInvestmentTransactions,
+  getAccountReconciliation,
 } from "@/queries/investments";
 import type { LedgrDb } from "@/db";
 
@@ -35,16 +36,120 @@ describe("investment queries", () => {
   });
 
   describe("getPortfolioSummary", () => {
-    it("returns totals from holdings", async () => {
+    it("returns totals from holdings when the account carries no balance", async () => {
       await insertInvestmentHolding(db, accountId, { currentValue: 150000, costBasis: 120000 });
       await insertInvestmentHolding(db, accountId, { currentValue: 200000, costBasis: 180000, ticker: "VOO", plaidSecurityId: "sec-2" });
 
       const summary = await getPortfolioSummary(householdId, db);
       expect(summary.totalValue).toBe(350000);
+      expect(summary.holdingsValue).toBe(350000);
+      expect(summary.cashValue).toBe(0);
       expect(summary.totalCostBasis).toBe(300000);
       expect(summary.totalGainLoss).toBe(50000);
     });
 
+    it("takes the total from the account balance, not the holdings sum", async () => {
+      // The reported bug: an account reporting $14,274.92 with only $1,219.86
+      // of itemized holdings silently lost the difference.
+      const acc = await insertAccount(db, householdId, { type: "investment", currentBalance: 1427492 });
+      await insertInvestmentHolding(db, acc.accountId, { currentValue: 121986, costBasis: 100000 });
+
+      const summary = await getPortfolioSummary(householdId, db, undefined, [acc.accountId]);
+
+      expect(summary.totalValue).toBe(1427492);
+      expect(summary.holdingsValue).toBe(121986);
+      expect(summary.cashValue).toBe(1305506);
+    });
+
+    it("reports no cash when holdings account for the whole balance", async () => {
+      const acc = await insertAccount(db, householdId, { type: "investment", currentBalance: 7697 });
+      await insertInvestmentHolding(db, acc.accountId, { currentValue: 7697, costBasis: 5000 });
+
+      const summary = await getPortfolioSummary(householdId, db, undefined, [acc.accountId]);
+
+      expect(summary.cashValue).toBe(0);
+      expect(summary.totalValue).toBe(7697);
+    });
+
+    it("never reports negative cash when holdings exceed a stale balance", async () => {
+      const acc = await insertAccount(db, householdId, { type: "investment", currentBalance: 1000 });
+      await insertInvestmentHolding(db, acc.accountId, { currentValue: 5000, costBasis: 4000 });
+
+      const summary = await getPortfolioSummary(householdId, db, undefined, [acc.accountId]);
+
+      expect(summary.cashValue).toBe(0);
+    });
+
+    it("excludes holdings with no cost basis from gain/loss", async () => {
+      // Second bug in the same figure: totalValue counted every holding but
+      // totalCostBasis skipped null-basis ones, so their whole value read as
+      // gain. ETH and BTC carry no basis, which inflated the reported total.
+      const acc = await insertAccount(db, householdId, { type: "investment", currentBalance: 300000 });
+      await insertInvestmentHolding(db, acc.accountId, { currentValue: 100000, costBasis: 80000 });
+      await insertInvestmentHolding(db, acc.accountId, {
+        currentValue: 200000,
+        costBasis: null,
+        ticker: "ETH",
+        plaidSecurityId: "sec-eth",
+      });
+
+      const summary = await getPortfolioSummary(householdId, db, undefined, [acc.accountId]);
+
+      // Gain covers only the holding that has a basis: 100000 - 80000.
+      expect(summary.totalGainLoss).toBe(20000);
+      expect(summary.totalCostBasis).toBe(80000);
+      // ...and it says how much of the portfolio that figure describes.
+      expect(summary.gainLossCoverage).toBe(100000);
+      // The null-basis holding still counts toward what the portfolio is worth.
+      expect(summary.holdingsValue).toBe(300000);
+    });
+  });
+
+  describe("getAccountReconciliation", () => {
+    it("reports the gap between each account's balance and its holdings", async () => {
+      const acc = await insertAccount(db, householdId, {
+        type: "investment",
+        name: "Robinhood IRA",
+        currentBalance: 1427492,
+      });
+      await insertInvestmentHolding(db, acc.accountId, { currentValue: 121986, costBasis: 100000 });
+
+      const rows = await getAccountReconciliation(householdId, db);
+      const row = rows.find((r) => r.accountId === acc.accountId)!;
+
+      expect(row.accountName).toBe("Robinhood IRA");
+      expect(row.balance).toBe(1427492);
+      expect(row.holdingsValue).toBe(121986);
+      expect(row.cashValue).toBe(1305506);
+      expect(row.hasHoldings).toBe(true);
+    });
+
+    it("flags an account that reports a balance but no holdings at all", async () => {
+      const acc = await insertAccount(db, householdId, {
+        type: "investment",
+        name: "Unitemized",
+        currentBalance: 500000,
+      });
+
+      const rows = await getAccountReconciliation(householdId, db);
+      const row = rows.find((r) => r.accountId === acc.accountId)!;
+
+      expect(row.hasHoldings).toBe(false);
+      expect(row.holdingsValue).toBe(0);
+      expect(row.cashValue).toBe(500000);
+    });
+
+    it("does not return another household's investment accounts", async () => {
+      const theirs = await insertHousehold(db);
+      await insertAccount(db, theirs.householdId, { type: "investment", currentBalance: 999999 });
+
+      const rows = await getAccountReconciliation(householdId, db);
+
+      expect(rows.every((r) => r.balance !== 999999)).toBe(true);
+    });
+  });
+
+  describe("getPortfolioSummary day change", () => {
     it("returns dayChange from holdings_history", async () => {
       await insertHoldingsSnapshot(db, accountId, "2026-05-09", { value: 140000, plaidSecurityId: "sec-1" });
       await insertHoldingsSnapshot(db, accountId, "2026-05-10", { value: 150000, plaidSecurityId: "sec-1" });


### PR DESCRIPTION
Closes #88.

Mock reviewed before implementation: https://claude.ai/code/artifact/fdc0c027-fc9d-4a15-b607-fae87c1c95cd

## The missing money

`getPortfolioSummary` summed `investment_holdings` and never consulted the accounts' own balances, so anything a connector reported but did not itemize disappeared. On the reporting household that hid **$13,055 of one IRA** — the page showed $38,385.38 against $51,703.51 actually held, with nothing on screen hinting a number was missing.

| account | balance | holdings | gap |
|---|---:|---:|---:|
| Robinhood traditional IRA | $14,274.92 | $1,219.86 | **$13,055.06** |
| Robinhood individual ····1722 | $37,351.62 | $37,088.55 | $263.07 |
| Crypto ····9877 | $76.97 | $76.97 | — |

The $263.07 is almost certainly real uninvested cash — exactly the thing with nowhere to live. The IRA's $13,055.06 looks like a connector that did not itemize, which is why that row is *flagged* rather than quietly labelled cash.

## Changes

- **`totalValue` comes from account balances**, falling back to the holdings sum when no account reports one, so accounts predating balance capture keep working.
- **`cashValue`** is the remainder, **clamped at zero** — a stale balance below the holdings sum would otherwise show negative cash, which is never a real state.
- **`getAccountReconciliation()`** exposes the gap per account and flags accounts that itemized nothing.

## A second bug in the same figure

`totalValue` counted *every* holding while `totalCostBasis` skipped null-basis ones, so a holding with no cost basis contributed its **entire value as gain**. That is what inflated the reported +$8,500.19 — ETH and BTC carry no basis.

Gain/loss now spans the same set on both sides, and reports `gainLossCoverage` so the UI can state what it describes.

## Honest labels

- **"Day Change (holdings)"** — derived from `holdings_history`, so it can only ever describe the itemized part.
- **"Gain/Loss (with cost basis)"** — says which holdings it spans.
- The cash tile appears **only when there is a gap**, rather than spending a quarter of the strip on a permanent `$0.00`.

## Tests

8 new integration tests. The red phase was interrupted by an unrelated machine stall, so rather than assume, I verified they have teeth by restoring both old behaviours — **exactly the two behavioural tests fail**, and the other 13 pass either way:

```
× takes the total from the account balance, not the holdings sum
× excludes holdings with no cost basis from gain/loss
  Tests  2 failed | 13 passed (15)
```

Covered: balance-derived total, holdings fallback when no balance, zero cash when holdings match, no negative cash on a stale balance, gain/loss excluding null-basis holdings, per-account gap, the not-itemized flag, and household isolation.

Full suite: **781 passed / 115 files**. Typecheck, `eslint src tests`, and `pnpm build` clean.

## Not in scope

Asset Allocation still describes only the holdings portion, so its donut covers 74% of this portfolio as though it were all of it. Adding a cash slice is the natural follow-up; it needs a decision about whether unitemized balance should sit in the same visual bucket as genuine cash, which is a product call rather than a bug fix.

⚠️ `mutation (diff)` may report red — see #103. Compare against a `main` baseline before treating it as a finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)