### PR TITLE
Group accounts by type with reconciling subtotals; total the unfiltered transaction list

### DIFF
--- a/src/app/(dashboard)/transactions/page.tsx
+++ b/src/app/(dashboard)/transactions/page.tsx
@@ -30,9 +30,10 @@ export default async function TransactionsPage({
     withHousehold(householdId, (tx) => getTransactions(householdId, filters, undefined, undefined, tx)),
     getCategories(householdId),
     getAccounts(householdId),
-    hasAnyFilters
-      ? withHousehold(householdId, (tx) => getTransactionSummary(householdId, filters, tx))
-      : Promise.resolve(null),
+    // Always summarised, not only when a filter is applied. The unfiltered view
+    // is the one people land on, and it was the only view of the ledger with no
+    // arithmetic on it at all — per-day subtotals, and nothing for the whole.
+    withHousehold(householdId, (tx) => getTransactionSummary(householdId, filters, tx)),
     withHousehold(householdId, (tx) => getTransactionSummary(householdId, { reviewed: false }, tx)),
   ]);
   const accountOptions = allAccounts.map((a) => ({ id: a.id, name: a.name }));

--- a/src/components/atoms/balance-display.tsx
+++ b/src/components/atoms/balance-display.tsx
@@ -5,6 +5,7 @@ interface BalanceDisplayProps {
   amount: number | null;
   currency?: string;
   size?: "sm" | "md" | "lg";
+  className?: string;
 }
 
 const sizeClasses = {
@@ -17,10 +18,11 @@ export function BalanceDisplay({
   amount,
   currency = "USD",
   size = "md",
+  className,
 }: BalanceDisplayProps) {
   if (amount === null) {
     return (
-      <span className={cn("text-muted-foreground", sizeClasses[size])}>
+      <span className={cn("text-muted-foreground", sizeClasses[size], className)}>
         —
       </span>
     );
@@ -30,7 +32,8 @@ export function BalanceDisplay({
     <span
       className={cn(
         sizeClasses[size],
-        amount < 0 && "text-destructive"
+        amount < 0 && "text-destructive",
+        className
       )}
     >
       {centsToDisplay(amount, currency)}

--- a/src/components/molecules/account-card.tsx
+++ b/src/components/molecules/account-card.tsx
@@ -10,20 +10,29 @@ import type { AccountRow } from "@/queries/accounts";
 
 interface AccountCardProps {
   account: AccountRow;
+  /**
+   * Shown when the list is grouped by type, where the institution is the one
+   * piece of context the grouping takes away. Omitted under institution
+   * grouping, which already states it in the card header.
+   */
+  institutionName?: string;
   onEdit: (account: AccountRow) => void;
 }
 
-export function AccountCard({ account, onEdit }: AccountCardProps) {
+export function AccountCard({ account, institutionName, onEdit }: AccountCardProps) {
   return (
     <div className="group/card flex items-center justify-between px-4 py-3 hover:bg-muted/50 transition-colors">
       <div className="flex items-center gap-3 min-w-0">
         <AccountTypeIcon type={account.type as AccountType} />
         <div className="min-w-0">
           <span className="text-sm font-medium truncate block">{accountDisplayName(account.name)}</span>
-          {account.officialName && account.officialName !== account.name && (
-            <p className="text-xs text-muted-foreground truncate">
-              {account.officialName}
-            </p>
+          {institutionName ? (
+            <p className="text-xs text-muted-foreground truncate">{institutionName}</p>
+          ) : (
+            account.officialName &&
+            account.officialName !== account.name && (
+              <p className="text-xs text-muted-foreground truncate">{account.officialName}</p>
+            )
           )}
         </div>
       </div>

--- a/src/components/molecules/institution-header.tsx
+++ b/src/components/molecules/institution-header.tsx
@@ -21,6 +21,7 @@ import {
   AlertDialogMedia,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { formatRelativeTime } from "@/lib/relative-time";
 import { EntityAvatar } from "@/components/molecules/entity-avatar";
 import { StatusBadge } from "@/components/atoms/status-badge";
 import { SyncStatusBadge, type SyncStatus } from "@/components/atoms/sync-status-badge";
@@ -40,17 +41,6 @@ interface InstitutionHeaderProps {
   onDisconnect?: () => void;
   reconnectButton?: ReactNode;
   reAuthError?: string | null;
-}
-
-function formatRelativeTime(date: Date | string): string {
-  const diff = Date.now() - new Date(date).getTime();
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "just now";
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }
 
 export function InstitutionHeader({

--- a/src/components/organisms/account-list.tsx
+++ b/src/components/organisms/account-list.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { RefreshCw } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { BalanceDisplay } from "@/components/atoms/balance-display";
+import { formatRelativeTime } from "@/lib/relative-time";
+import { groupAccountsByType } from "@/lib/group-accounts-by-type";
 import { AccountCard } from "@/components/molecules/account-card";
 import { InstitutionHeader } from "@/components/molecules/institution-header";
 import { PlaidLinkFlow } from "./plaid-link-flow";
@@ -17,6 +21,8 @@ import { disconnectSimplefinConnection } from "@/actions/simplefin";
 import type { InstitutionGroup, AccountRow } from "@/queries/accounts";
 import type { SyncStatus } from "@/components/atoms/sync-status-badge";
 
+type GroupBy = "type" | "institution";
+
 interface SyncState {
   status: SyncStatus;
   error?: string;
@@ -27,6 +33,7 @@ interface AccountListProps {
 }
 
 export function AccountList({ groups }: AccountListProps) {
+  const [groupBy, setGroupBy] = useState<GroupBy>("type");
   const [editingAccount, setEditingAccount] = useState<AccountRow | null>(null);
   const [syncStates, setSyncStates] = useState<Map<string, SyncState>>(new Map());
   const [reAuthingConnectionId, setReAuthingConnectionId] = useState<string | null>(null);
@@ -36,6 +43,35 @@ export function AccountList({ groups }: AccountListProps) {
   const connectionIds = groups
     .map((g) => g.connectionId)
     .filter((id): id is string => id !== null);
+
+  // Flattened once, carrying the institution down so a type-grouped row can
+  // still say which bank an account sits at.
+  const typeGroups = useMemo(
+    () =>
+      groupAccountsByType(
+        groups.flatMap((g) =>
+          g.accounts.map((a) => ({ ...a, institutionName: g.institutionName })),
+        ),
+      ),
+    [groups],
+  );
+
+  // The toolbar reports one figure for the whole page, so it takes the most
+  // recent sync rather than an arbitrary connection's.
+  const freshestSync = useMemo(() => {
+    const times = groups
+      .map((g) => g.lastSyncedAt)
+      .filter((d): d is Date => d != null)
+      .map((d) => new Date(d).getTime());
+    return times.length > 0 ? new Date(Math.max(...times)) : null;
+  }, [groups]);
+
+  const handleGroupByChange = useCallback((value: string[]) => {
+    // Base UI hands back an empty array when the active item is clicked again;
+    // ignoring it keeps one grouping always selected.
+    const next = value[0];
+    if (next === "type" || next === "institution") setGroupBy(next);
+  }, []);
 
   const handleSync = useCallback(async (connectionId: string) => {
     setSyncStates((prev) => {
@@ -101,8 +137,32 @@ export function AccountList({ groups }: AccountListProps) {
 
   return (
     <>
-      {connectionIds.length > 0 && (
-        <div className="flex justify-end">
+      {/* One toolbar row: the grouping choice and the sync action, anchored to
+          each other instead of floating in the gap above the first card. */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <ToggleGroup
+          value={[groupBy]}
+          onValueChange={handleGroupByChange}
+          variant="outline"
+          spacing={1}
+          size="sm"
+          aria-label="Group accounts by"
+        >
+          <ToggleGroupItem
+            value="type"
+            className="aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:hover:bg-primary"
+          >
+            By type
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            value="institution"
+            className="aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:hover:bg-primary"
+          >
+            By institution
+          </ToggleGroupItem>
+        </ToggleGroup>
+
+        {connectionIds.length > 0 && (
           <Button
             variant="ghost"
             size="sm"
@@ -110,11 +170,41 @@ export function AccountList({ groups }: AccountListProps) {
             disabled={isSyncing || reAuthingConnectionId !== null}
           >
             <RefreshCw className="size-3.5 mr-1" />
-            Sync All
+            Sync all
+            {freshestSync && (
+              <span className="ml-1 font-normal text-muted-foreground">
+                · {formatRelativeTime(freshestSync)}
+              </span>
+            )}
           </Button>
+        )}
+      </div>
+
+      {groupBy === "type" && (
+        <div className="space-y-4">
+          {typeGroups.map((group) => (
+            <Card key={group.key} className="gap-0 py-0 overflow-hidden">
+              <div className="flex items-center justify-between bg-muted px-4 py-2.5">
+                <h3 className="text-sm font-semibold">{group.label}</h3>
+                <BalanceDisplay amount={group.subtotal} size="sm" className="font-semibold" />
+              </div>
+              <Separator />
+              <div>
+                {group.accounts.map((account) => (
+                  <AccountCard
+                    key={account.id}
+                    account={account}
+                    institutionName={account.institutionName}
+                    onEdit={setEditingAccount}
+                  />
+                ))}
+              </div>
+            </Card>
+          ))}
         </div>
       )}
 
+      {groupBy === "institution" && (
       <div className="space-y-6">
         {groups.map((group) => {
           const state = getSyncState(group.connectionId);
@@ -170,6 +260,7 @@ export function AccountList({ groups }: AccountListProps) {
           );
         })}
       </div>
+      )}
 
       <EditAccountDialog
         account={editingAccount}

--- a/src/lib/group-accounts-by-type.test.ts
+++ b/src/lib/group-accounts-by-type.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { groupAccountsByType, type GroupableAccount } from "./group-accounts-by-type";
+import type { AccountType } from "@/db/schema/accounts";
+
+function acct(
+  id: string,
+  type: AccountType,
+  currentBalance: number | null,
+  extra: Partial<GroupableAccount> = {},
+): GroupableAccount {
+  return {
+    id,
+    name: id,
+    type,
+    currentBalance,
+    isHidden: false,
+    institutionName: "Bank",
+    ...extra,
+  };
+}
+
+describe("groupAccountsByType", () => {
+  it("returns groups in a fixed order regardless of input order", () => {
+    const groups = groupAccountsByType([
+      acct("card", "credit", -1000),
+      acct("brokerage", "investment", 5000),
+      acct("chk", "checking", 2000),
+    ]);
+    expect(groups.map((g) => g.key)).toEqual(["cash", "investment", "credit"]);
+  });
+
+  it("omits groups with no accounts rather than rendering empty sections", () => {
+    const groups = groupAccountsByType([acct("chk", "checking", 100)]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].key).toBe("cash");
+  });
+
+  it("returns nothing for no accounts", () => {
+    expect(groupAccountsByType([])).toEqual([]);
+  });
+
+  it("sums each group's subtotal", () => {
+    const groups = groupAccountsByType([
+      acct("chk1", "checking", 2000),
+      acct("chk2", "checking", 500),
+      acct("card", "credit", -1000),
+    ]);
+    expect(groups.find((g) => g.key === "cash")!.subtotal).toBe(2500);
+    expect(groups.find((g) => g.key === "credit")!.subtotal).toBe(-1000);
+  });
+
+  it("treats a null balance as zero in the subtotal but still lists the account", () => {
+    // A manual account with no balance yet should not vanish from the list.
+    const groups = groupAccountsByType([acct("chk", "checking", null), acct("chk2", "checking", 300)]);
+    expect(groups[0].subtotal).toBe(300);
+    expect(groups[0].accounts).toHaveLength(2);
+  });
+
+  it("excludes hidden accounts entirely", () => {
+    // getAccountSummary filters hidden accounts before totalling, so including
+    // them here would make the group subtotals disagree with the page header.
+    const groups = groupAccountsByType([
+      acct("visible", "checking", 1000),
+      acct("hidden", "checking", 9999, { isHidden: true }),
+    ]);
+    expect(groups[0].accounts.map((a) => a.id)).toEqual(["visible"]);
+    expect(groups[0].subtotal).toBe(1000);
+  });
+
+  it("sorts accounts within a group by balance, largest first", () => {
+    const groups = groupAccountsByType([
+      acct("small", "checking", 100),
+      acct("big", "checking", 5000),
+      acct("mid", "checking", 900),
+    ]);
+    expect(groups[0].accounts.map((a) => a.id)).toEqual(["big", "mid", "small"]);
+  });
+
+  it("sorts debts by size of debt, largest first", () => {
+    // Liabilities are negative, so a naive descending sort would put the
+    // smallest debt at the top. Largest obligation should lead.
+    const groups = groupAccountsByType([
+      acct("small", "credit", -100),
+      acct("big", "credit", -5000),
+    ]);
+    expect(groups[0].accounts.map((a) => a.id)).toEqual(["big", "small"]);
+  });
+
+  describe("subtotals reconcile to the page header", () => {
+    // The header states Assets / Debts / Net Worth. If the groups do not foot
+    // to those figures the page contradicts itself, which is the whole reason
+    // this grouping exists.
+    const accounts = [
+      acct("chk", "checking", 119520),
+      acct("sav", "savings", 50000),
+      acct("brk", "investment", 3838538),
+      acct("card1", "credit", -320534),
+      acct("card2", "credit", -104893),
+      acct("loan", "loan", -1500000),
+      acct("hidden", "checking", 999999, { isHidden: true }),
+    ];
+
+    it("assets sum to the sum of asset-group subtotals", () => {
+      const groups = groupAccountsByType(accounts);
+      const assets = groups.filter((g) => g.side === "asset").reduce((s, g) => s + g.subtotal, 0);
+      expect(assets).toBe(119520 + 50000 + 3838538);
+    });
+
+    it("debts sum to the sum of liability-group subtotals", () => {
+      const groups = groupAccountsByType(accounts);
+      const debts = groups.filter((g) => g.side === "liability").reduce((s, g) => s + g.subtotal, 0);
+      expect(debts).toBe(-320534 - 104893 - 1500000);
+    });
+
+    it("all subtotals together equal net worth", () => {
+      const groups = groupAccountsByType(accounts);
+      const net = groups.reduce((s, g) => s + g.subtotal, 0);
+      expect(net).toBe(119520 + 50000 + 3838538 - 320534 - 104893 - 1500000);
+    });
+  });
+
+  it("labels each group and marks which side of the balance sheet it is on", () => {
+    const groups = groupAccountsByType([acct("chk", "checking", 1), acct("card", "credit", -1)]);
+    expect(groups.find((g) => g.key === "cash")).toMatchObject({ label: "Cash", side: "asset" });
+    expect(groups.find((g) => g.key === "credit")).toMatchObject({
+      label: "Credit cards",
+      side: "liability",
+    });
+  });
+
+  it("folds savings in with checking under Cash", () => {
+    // Users think of these as one pool; splitting them makes the page longer
+    // without answering a question anyone asked.
+    const groups = groupAccountsByType([acct("chk", "checking", 100), acct("sav", "savings", 200)]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].subtotal).toBe(300);
+  });
+});

--- a/src/lib/group-accounts-by-type.ts
+++ b/src/lib/group-accounts-by-type.ts
@@ -1,0 +1,103 @@
+import type { AccountType } from "@/db/schema/accounts";
+import { classifyAccountType } from "@/lib/account-utils";
+
+/**
+ * Regroups accounts by what they are rather than who holds them.
+ *
+ * The Accounts page header states Assets / Debts / Net Worth, but the list
+ * beneath it is organised by institution — so a bank holding both a current
+ * account and a credit card sums to a group total that means nothing, and the
+ * debts are scattered across separate cards. Grouping by type gives every
+ * subtotal a meaning and lets them foot to the header.
+ *
+ * Hidden accounts are dropped here because `getAccountSummary` drops them
+ * before totalling; including them would make the groups disagree with the
+ * figures printed directly above them.
+ */
+
+export interface GroupableAccount {
+  id: string;
+  name: string;
+  type: AccountType;
+  currentBalance: number | null;
+  isHidden: boolean | null;
+  institutionName: string;
+}
+
+export type AccountGroupKey = "cash" | "investment" | "credit" | "loan" | "other";
+
+export interface AccountTypeGroup<T extends GroupableAccount = GroupableAccount> {
+  key: AccountGroupKey;
+  label: string;
+  side: "asset" | "liability";
+  subtotal: number;
+  accounts: T[];
+}
+
+/** Checking and savings read as one pool of spendable money, so they share a group. */
+const GROUP_OF: Record<AccountType, AccountGroupKey> = {
+  checking: "cash",
+  savings: "cash",
+  investment: "investment",
+  credit: "credit",
+  loan: "loan",
+  other: "other",
+};
+
+/** Assets first, then debts — the order the header states them in. */
+const GROUP_ORDER: { key: AccountGroupKey; label: string }[] = [
+  { key: "cash", label: "Cash" },
+  { key: "investment", label: "Investments" },
+  { key: "other", label: "Other assets" },
+  { key: "credit", label: "Credit cards" },
+  { key: "loan", label: "Loans" },
+];
+
+/** One representative type per group, enough to ask which side of the sheet it is on. */
+const REPRESENTATIVE_TYPE: Record<AccountGroupKey, AccountType> = {
+  cash: "checking",
+  investment: "investment",
+  credit: "credit",
+  loan: "loan",
+  other: "other",
+};
+
+export function groupAccountsByType<T extends GroupableAccount>(
+  accounts: T[],
+): AccountTypeGroup<T>[] {
+  const buckets = new Map<AccountGroupKey, T[]>();
+
+  for (const account of accounts) {
+    if (account.isHidden) continue;
+    const key = GROUP_OF[account.type] ?? "other";
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(account);
+    else buckets.set(key, [account]);
+  }
+
+  const groups: AccountTypeGroup<T>[] = [];
+
+  for (const { key, label } of GROUP_ORDER) {
+    const bucket = buckets.get(key);
+    // An empty section is noise — a household with no loans should not be told
+    // it has no loans on every visit. A missing key is the only empty case: a
+    // bucket is created by its first push, so it is never present-but-empty.
+    if (!bucket) continue;
+
+    const side = classifyAccountType(REPRESENTATIVE_TYPE[key]);
+
+    groups.push({
+      key,
+      label,
+      side,
+      subtotal: bucket.reduce((sum, a) => sum + (a.currentBalance ?? 0), 0),
+      // Sorted by magnitude so the largest holding — or the largest debt, which
+      // is the most negative number — leads its group.
+      accounts: [...bucket].sort(
+        (a, b) => Math.abs(b.currentBalance ?? 0) - Math.abs(a.currentBalance ?? 0),
+      ),
+    });
+  }
+
+  return groups;
+}

--- a/src/lib/relative-time.test.ts
+++ b/src/lib/relative-time.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { formatRelativeTime } from "./relative-time";
+
+const NOW = new Date("2026-08-30T12:00:00Z");
+
+function ago(ms: number) {
+  return new Date(NOW.getTime() - ms);
+}
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function at(now: Date) {
+  vi.useFakeTimers();
+  vi.setSystemTime(now);
+}
+
+describe("formatRelativeTime", () => {
+  it.each([
+    [0, "just now"],
+    [30 * SECOND, "just now"],
+    [59 * SECOND, "just now"],
+  ])("renders %dms as %s", (offset, expected) => {
+    at(NOW);
+    expect(formatRelativeTime(ago(offset))).toBe(expected);
+  });
+
+  describe("boundaries between units", () => {
+    // Each unit's first and last value, so an off-by-one in a threshold shows up
+    // as a wrong unit rather than a plausible-looking number.
+    it.each([
+      [1 * MINUTE, "1m ago"],
+      [59 * MINUTE, "59m ago"],
+      [1 * HOUR, "1h ago"],
+      [23 * HOUR + 59 * MINUTE, "23h ago"],
+      [1 * DAY, "1d ago"],
+      [6 * DAY, "6d ago"],
+      [365 * DAY, "365d ago"],
+    ])("renders %dms as %s", (offset, expected) => {
+      at(NOW);
+      expect(formatRelativeTime(ago(offset))).toBe(expected);
+    });
+  });
+
+  it("accepts an ISO string as well as a Date", () => {
+    at(NOW);
+    expect(formatRelativeTime(ago(2 * HOUR).toISOString())).toBe("2h ago");
+  });
+
+  it("truncates rather than rounds", () => {
+    // 90 minutes is 1h, not 2h — reporting a sync as more recent or more stale
+    // than it is undermines the point of showing it.
+    at(NOW);
+    expect(formatRelativeTime(ago(90 * MINUTE))).toBe("1h ago");
+  });
+
+  it("treats a future timestamp as just now rather than a negative age", () => {
+    // Clock skew between the server and the browser can put a sync timestamp
+    // slightly ahead; "-1m ago" would read as a bug.
+    at(NOW);
+    expect(formatRelativeTime(new Date(NOW.getTime() + 5 * MINUTE))).toBe("just now");
+  });
+});

--- a/src/lib/relative-time.ts
+++ b/src/lib/relative-time.ts
@@ -1,0 +1,17 @@
+/**
+ * Short relative time for sync timestamps ("3m ago", "6h ago").
+ *
+ * Lifted out of institution-header.tsx so the accounts toolbar can report the
+ * freshest sync across all connections in the same wording the per-institution
+ * rows use — two phrasings for the same fact on one page read as two facts.
+ */
+export function formatRelativeTime(date: Date | string): string {
+  const diff = Date.now() - new Date(date).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
     exclude: ["e2e/**", "node_modules/**"],
     globalSetup: ["./tests/global-setup.ts"],
     testTimeout: 30_000,
+    // Integration hooks do strictly more work than the tests they set up:
+    // `createTestDb()` in beforeEach provisions a fresh Postgres schema and
+    // replays migrations. Vitest's hook default is 10s, so the heaviest step
+    // had a budget 3x tighter than the assertions it feeds — and under any
+    // runner contention it blew that budget and failed whole files with
+    // "Hook timed out in 10000ms" rather than a real assertion.
+    hookTimeout: 30_000,
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
Second cluster from the UI review.

## #109 — Accounts grouped by type

The header states Assets / Debts / Net Worth; the list beneath was organised by institution. A bank holding both a current account and a credit card summed to a group total that meant nothing, and the debts were scattered across three cards.

Adds a **By type / By institution** toggle, defaulting to type. Institution grouping stays — its per-connection sync status and reconnect flows have no equivalent in the type view.

`groupAccountsByType` is a pure function whose central test is the reconciliation: asset subtotals must sum to Assets, liability subtotals to Debts, all of them to Net Worth. It drops hidden accounts for the same reason `getAccountSummary` does — otherwise the groups disagree with the figures printed directly above them.

Two details worth noting: checking and savings fold into one **Cash** group because people read them as one pool; and accounts sort by *magnitude*, so the largest debt leads its group — liabilities are negative and a naive descending sort inverts them.

Also closes **A3**: `Sync All` floated in the gap between the stat strip and the first card, attached to nothing and duplicating the per-institution timestamps without carrying an aggregate. It now sits in the toolbar with the grouping control and reports the freshest sync across all connections.

### This immediately surfaced a real inconsistency

With subtotals visible, the **Investments** group totals **$56,305.65** while the dashboard Investments widget reports **$38,385.38** — a **$17,920.27** gap. The accounts page sums account *balances*; the widget sums *holdings*. That is #88, and larger than the figure that issue cites. Not fixed here; commented on #88.

## #108 — mostly already built

I filed #108 saying the filter bar shows no state and nothing totals the list. Checking it in the browser, most of that was already there and I had judged it from a screenshot of the *unfiltered* page:

- the dropdowns do show their value (`Category: Uncategorized`)
- applied filters already render as removable chips with a `Clear all`
- `FilterSummaryBar` already reports count / expenses / credits / net

What was actually missing is narrow: the summary was gated behind `hasAnyFilters`, so the default view — the one people land on — was the only view of the ledger with no arithmetic on it at all. That gate is now dropped. I've corrected the issue text rather than leaving the original claim standing.

## Also here: a CI fix, because this branch's first run went red

The first run of this PR failed six integration files — and so had `main` itself, at my #118 merge. Worth being precise about it, because it was not a code defect:

- All six fail on `Error: Hook timed out in 10000ms`, never on an assertion.
- The same six pass locally: **120 files, 865 tests, all green.**
- Re-running `main`'s failed job on an idle runner went **green with no code change**.

Root cause: `vitest.config.ts` raised `testTimeout` to 30s but never set `hookTimeout`, leaving hooks on Vitest's 10s default. That is backwards for this suite — `createTestDb()` in `beforeEach` provisions a fresh Postgres schema and replays migrations for *every test*, so the hooks do strictly more work than the tests they feed. `dashboard-queries.test.ts` alone takes ~49s locally for 19 tests. Any contention pushes setup past 10s, and because it is a hook, the whole file fails regardless of what it was asserting.

`hookTimeout: 30_000` now matches `testTimeout`. This doesn't hide a slow suite; it stops a slow *setup* being reported as a broken *test*.

The contention itself was partly my doing: #118's non-blocking `mutation (diff)` job was still running on the same self-hosted runner when I merged, and main's CI queued behind it. Worth waiting for that job before merging even though it's `continue-on-error: true`.

## Verification

- Full suite green locally: **120 files, 865 tests** (26 new: `groupAccountsByType`, `formatRelativeTime`)
- Mutation on the two new lib files: **100% of covered mutants killed, 0 survivors**. It found one more unreachable branch — `bucket.length === 0`, which can never be true since a bucket is created by its first push — removed rather than tested around
- `tsc --noEmit` and `eslint src/` clean
- Walked both groupings and both themes in the browser; a11y tree shows real `<h3>` group headings and a `pressed` state on the toggle; console clean

Closes #109. Refs #108, refs #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
