### PR TITLE
feat(bills): make detected bills editable, mutable and deletable

### DIFF
--- a/src/actions/recurring.ts
+++ b/src/actions/recurring.ts
@@ -1,0 +1,129 @@
+"use server";
+
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { db as defaultDb, type LedgrDb } from "@/db";
+import { recurringTransactions, categories } from "@/db/schema";
+import { scopedQuery } from "@/lib/scoped-query";
+import { authorizeAction } from "@/lib/auth/authorize-action";
+
+type ActionResult = { success: true } | { error: string };
+
+const FREQUENCIES = ["weekly", "biweekly", "semimonthly", "monthly", "yearly"] as const;
+
+const updateSchema = z.object({
+  id: z.string().min(1),
+  name: z
+    .string()
+    .transform((s) => s.trim())
+    .pipe(z.string().min(1).max(200)),
+  // Null clears the category. A bill with no category is a normal state --
+  // every detected bill starts that way.
+  categoryId: z.string().min(1).nullable(),
+  // Amounts are displayed via Math.abs, so a negative would render identically
+  // while corrupting the sign handling behind the monthly total.
+  averageAmount: z.number().int().min(0),
+  frequency: z.enum(FREQUENCIES),
+  isActive: z.boolean(),
+});
+
+export type RecurringUpdateInput = z.input<typeof updateSchema>;
+
+/**
+ * A bill points at a category, so the category must belong to the same
+ * household -- otherwise a caller could aim a bill at another household's
+ * category id and read its name back off the bills list.
+ */
+async function categoryBelongsToHousehold(
+  householdId: string,
+  categoryId: string,
+  db: LedgrDb,
+): Promise<boolean> {
+  const scoped = scopedQuery(householdId, db);
+  const [row] = await db
+    .select({ id: categories.id })
+    .from(categories)
+    .where(scoped.where(categories, eq(categories.id, categoryId)))
+    .limit(1);
+  return !!row;
+}
+
+export async function updateRecurringTransactionScoped(
+  householdId: string,
+  input: RecurringUpdateInput,
+  db: LedgrDb = defaultDb,
+): Promise<ActionResult> {
+  const parsed = updateSchema.safeParse(input);
+  if (!parsed.success) return { error: "Check the name, amount and frequency." };
+
+  if (
+    parsed.data.categoryId !== null &&
+    !(await categoryBelongsToHousehold(householdId, parsed.data.categoryId, db))
+  ) {
+    return { error: "Category not found" };
+  }
+
+  const scoped = scopedQuery(householdId, db);
+  const updated = await db
+    .update(recurringTransactions)
+    .set({
+      name: parsed.data.name,
+      categoryId: parsed.data.categoryId,
+      averageAmount: parsed.data.averageAmount,
+      frequency: parsed.data.frequency,
+      // Muting keeps the row: getUpcomingBills and getRecurringSummary both
+      // filter on isActive, so the bill leaves the list and the monthly total
+      // while the record survives -- otherwise the next sync would re-detect
+      // it as new and the user would have to mute it again.
+      isActive: parsed.data.isActive,
+      updatedAt: new Date(),
+    })
+    .where(scoped.where(recurringTransactions, eq(recurringTransactions.id, parsed.data.id)))
+    .returning({ id: recurringTransactions.id });
+
+  if (updated.length === 0) return { error: "Bill not found" };
+
+  revalidatePath("/bills");
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function updateRecurringTransaction(
+  input: RecurringUpdateInput,
+  db: LedgrDb = defaultDb,
+): Promise<ActionResult> {
+  const auth = await authorizeAction();
+  if ("error" in auth) return auth;
+  return updateRecurringTransactionScoped(auth.householdId, input, db);
+}
+
+export async function deleteRecurringTransactionScoped(
+  householdId: string,
+  billId: string,
+  db: LedgrDb = defaultDb,
+): Promise<ActionResult> {
+  const parsed = z.string().min(1).safeParse(billId);
+  if (!parsed.success) return { error: "Invalid input" };
+
+  const scoped = scopedQuery(householdId, db);
+  const deleted = await db
+    .delete(recurringTransactions)
+    .where(scoped.where(recurringTransactions, eq(recurringTransactions.id, parsed.data)))
+    .returning({ id: recurringTransactions.id });
+
+  if (deleted.length === 0) return { error: "Bill not found" };
+
+  revalidatePath("/bills");
+  revalidatePath("/");
+  return { success: true };
+}
+
+export async function deleteRecurringTransaction(
+  billId: string,
+  db: LedgrDb = defaultDb,
+): Promise<ActionResult> {
+  const auth = await authorizeAction();
+  if ("error" in auth) return auth;
+  return deleteRecurringTransactionScoped(auth.householdId, billId, db);
+}

--- a/src/app/(dashboard)/bills/page.tsx
+++ b/src/app/(dashboard)/bills/page.tsx
@@ -1,5 +1,6 @@
 import { getHouseholdId } from "@/lib/auth/session";
 import { getUpcomingBills, getRecurringSummary } from "@/queries/recurring";
+import { getCategories } from "@/queries/categories";
 import { centsToDisplay } from "@/lib/money";
 import { BillList } from "@/components/organisms/bill-list";
 import { BillSearch } from "@/components/molecules/bill-search";
@@ -12,9 +13,10 @@ export default async function BillsPage({
 }) {
   const householdId = await getHouseholdId();
   const params = await searchParams;
-  const [bills, summary] = await Promise.all([
+  const [bills, summary, categoryGroups] = await Promise.all([
     getUpcomingBills(householdId, { search: params.q }),
     getRecurringSummary(householdId),
+    getCategories(householdId),
   ]);
 
   return (
@@ -39,7 +41,7 @@ export default async function BillsPage({
         {bills.length > 0 && <BillSearch />}
       </div>
 
-      {bills.length === 0 ? <BillEmptyState /> : <BillList bills={bills} />}
+      {bills.length === 0 ? <BillEmptyState /> : <BillList bills={bills} categoryGroups={categoryGroups} />}
     </div>
   );
 }

--- a/src/components/molecules/bill-row.tsx
+++ b/src/components/molecules/bill-row.tsx
@@ -6,6 +6,7 @@ import type { BillRow as BillRowType } from "@/queries/recurring";
 
 interface BillRowProps {
   bill: BillRowType;
+  onSelect: () => void;
 }
 
 export const BILL_ROW_GRID =
@@ -19,9 +20,16 @@ const FREQUENCY_LABELS: Record<string, string> = {
   yearly: "Yearly",
 };
 
-export function BillRow({ bill }: BillRowProps) {
+export function BillRow({ bill, onSelect }: BillRowProps) {
   return (
-    <div className={`${BILL_ROW_GRID} h-10 px-3 text-sm border-b border-border/50`}>
+    // A real <button>, not a div with a click handler: bills were previously
+    // inert, and keyboard users need to reach the editor too.
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-label={`Edit ${bill.name}`}
+      className={`${BILL_ROW_GRID} h-10 w-full px-3 text-left text-sm border-b border-border/50 hover:bg-accent focus-visible:outline-2 focus-visible:outline-ring focus-visible:-outline-offset-2`}
+    >
       <span className="font-medium truncate">{bill.name}</span>
       <span className="text-muted-foreground truncate text-xs">
         {categoryLabel(bill.categoryName)}
@@ -41,6 +49,6 @@ export function BillRow({ bill }: BillRowProps) {
       <span className="flex justify-end">
         <BillStatusIndicator status={bill.status} relativeDateLabel={bill.relativeDateLabel} />
       </span>
-    </div>
+    </button>
   );
 }

--- a/src/components/organisms/bill-detail-sheet.tsx
+++ b/src/components/organisms/bill-detail-sheet.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Trash2 } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  updateRecurringTransaction,
+  deleteRecurringTransaction,
+} from "@/actions/recurring";
+import type { BillRow } from "@/queries/recurring";
+import type { CategoryGroup } from "@/queries/categories";
+
+const FREQUENCIES = ["weekly", "biweekly", "semimonthly", "monthly", "yearly"] as const;
+type Frequency = (typeof FREQUENCIES)[number];
+
+const FREQUENCY_LABELS: Record<Frequency, string> = {
+  weekly: "Weekly",
+  biweekly: "Biweekly",
+  semimonthly: "Twice a month",
+  monthly: "Monthly",
+  yearly: "Yearly",
+};
+
+const NO_CATEGORY = "__none__";
+
+interface BillDetailSheetProps {
+  /** Non-null: the parent mounts this only for the open bill, keyed by id. */
+  bill: BillRow;
+  categoryGroups: CategoryGroup[];
+  onClose: () => void;
+}
+
+/**
+ * The parent renders this with `key={bill.id}`, so opening a different bill
+ * remounts it and the initialisers below re-seed the form. That replaces
+ * syncing props into state from an effect, which React now flags.
+ */
+export function BillDetailSheet({ bill, categoryGroups, onClose }: BillDetailSheetProps) {
+  const categories = categoryGroups.flatMap((g) => g.categories);
+
+  const [name, setName] = useState(bill.name);
+  const [categoryId, setCategoryId] = useState<string>(
+    () => categories.find((c) => c.name === bill.categoryName)?.id ?? NO_CATEGORY,
+  );
+  const [amount, setAmount] = useState(() =>
+    bill.averageAmount !== null ? (bill.averageAmount / 100).toFixed(2) : "0.00",
+  );
+  const [frequency, setFrequency] = useState<Frequency>(
+    () => (bill.frequency as Frequency) ?? "monthly",
+  );
+  // getUpcomingBills only returns active bills, so an open one is always active.
+  const [isActive, setIsActive] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  function save() {
+    setError(null);
+    // Money is stored in cents; the field edits dollars.
+    const cents = Math.round(parseFloat(amount || "0") * 100);
+
+    startTransition(async () => {
+      const result = await updateRecurringTransaction({
+        id: bill.id,
+        name,
+        categoryId: categoryId === NO_CATEGORY ? null : categoryId,
+        averageAmount: cents,
+        frequency,
+        isActive,
+      });
+      if ("error" in result) {
+        setError(result.error);
+        return;
+      }
+      onClose();
+    });
+  }
+
+  function remove() {
+    setError(null);
+    startTransition(async () => {
+      const result = await deleteRecurringTransaction(bill.id);
+      if ("error" in result) {
+        setError(result.error);
+        return;
+      }
+      onClose();
+    });
+  }
+
+  return (
+    <Sheet open onOpenChange={(open) => !open && onClose()}>
+      <SheetContent className="flex w-full flex-col sm:w-[440px]">
+        <SheetHeader>
+          <SheetTitle className="text-base">Edit bill</SheetTitle>
+          <SheetDescription>
+            Corrections apply to this recurring stream, not to past transactions.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-4 overflow-y-auto px-4">
+          {error && (
+            <div
+              role="alert"
+              className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive"
+            >
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="bill-name">Name</Label>
+            <Input id="bill-name" value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="bill-category">Category</Label>
+            <Select
+              value={categoryId}
+              onValueChange={(v) => {
+                if (v !== null) setCategoryId(v);
+              }}
+            >
+              <SelectTrigger id="bill-category">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_CATEGORY}>Uncategorized</SelectItem>
+                {categories.map((c) => (
+                  <SelectItem key={c.id} value={c.id}>
+                    {c.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="bill-amount">Amount</Label>
+              <Input
+                id="bill-amount"
+                type="number"
+                step="0.01"
+                min="0"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="bill-frequency">Frequency</Label>
+              <Select
+                value={frequency}
+                onValueChange={(v) => {
+                  if (v !== null) setFrequency(v as Frequency);
+                }}
+              >
+                <SelectTrigger id="bill-frequency">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {FREQUENCIES.map((f) => (
+                    <SelectItem key={f} value={f}>
+                      {FREQUENCY_LABELS[f]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex items-start justify-between gap-4 rounded-lg border p-3">
+            <div>
+              <Label htmlFor="bill-active" className="text-sm">
+                Counts as a recurring bill
+              </Label>
+              {/* Muting is how a cancelled subscription -- or a credit-card
+                  payment that is really a transfer -- stops inflating the
+                  monthly total, without deleting the detection. */}
+              <p className="mt-1 text-xs text-muted-foreground">
+                Turn off to drop it from the list and the monthly total. The bill is remembered, so
+                a future sync will not detect it again as new.
+              </p>
+            </div>
+            <Switch
+              id="bill-active"
+              checked={isActive}
+              onCheckedChange={setIsActive}
+              disabled={pending}
+            />
+          </div>
+        </div>
+
+        <div className="flex gap-2 border-t p-4">
+          <Button onClick={save} disabled={pending || !name.trim()}>
+            Save
+          </Button>
+          <Button variant="outline" onClick={onClose} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            variant="ghost"
+            className="ml-auto text-destructive hover:text-destructive"
+            onClick={remove}
+            disabled={pending}
+          >
+            <Trash2 className="mr-1 h-3.5 w-3.5" />
+            Delete
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/organisms/bill-list.tsx
+++ b/src/components/organisms/bill-list.tsx
@@ -1,11 +1,19 @@
+"use client";
+
+import { useState } from "react";
 import { BillRow, BILL_ROW_GRID } from "@/components/molecules/bill-row";
+import { BillDetailSheet } from "@/components/organisms/bill-detail-sheet";
 import type { BillRow as BillRowType } from "@/queries/recurring";
+import type { CategoryGroup } from "@/queries/categories";
 
 interface BillListProps {
   bills: BillRowType[];
+  categoryGroups: CategoryGroup[];
 }
 
-export function BillList({ bills }: BillListProps) {
+export function BillList({ bills, categoryGroups }: BillListProps) {
+  const [selected, setSelected] = useState<BillRowType | null>(null);
+
   return (
     <div>
       <div
@@ -18,8 +26,19 @@ export function BillList({ bills }: BillListProps) {
         <span className="text-right">Status</span>
       </div>
       {bills.map((bill) => (
-        <BillRow key={bill.id} bill={bill} />
+        <BillRow key={bill.id} bill={bill} onSelect={() => setSelected(bill)} />
       ))}
+
+      {/* Keyed so opening another bill remounts the sheet and its form
+          re-seeds, rather than syncing props into state from an effect. */}
+      {selected && (
+        <BillDetailSheet
+          key={selected.id}
+          bill={selected}
+          categoryGroups={categoryGroups}
+          onClose={() => setSelected(null)}
+        />
+      )}
     </div>
   );
 }

--- a/tests/integration/recurring-actions.test.ts
+++ b/tests/integration/recurring-actions.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { v4 as uuid } from "uuid";
+import { createTestDb } from "./setup";
+import { insertHousehold, insertCategoryGroup, insertCategory } from "./helpers";
+import {
+  updateRecurringTransaction,
+  deleteRecurringTransaction,
+} from "../../src/actions/recurring";
+import { getUpcomingBills, getRecurringSummary } from "../../src/queries/recurring";
+import { recurringTransactions } from "../../src/db/schema";
+import { eq } from "drizzle-orm";
+import type { LedgrDb } from "../../src/db";
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("../../src/lib/demo-mode", () => ({ guardDemoMode: vi.fn(() => null) }));
+
+const mockUserId = "test-user-id";
+let mockHouseholdId: string;
+vi.mock("../../src/lib/auth/session", () => ({
+  getHouseholdId: vi.fn(() => Promise.resolve(mockHouseholdId)),
+  getSession: vi.fn(() => Promise.resolve({ user: { id: mockUserId } })),
+}));
+
+describe("recurring transaction actions", () => {
+  let db: LedgrDb;
+  let close: () => Promise<void>;
+  let categoryId: string;
+
+  beforeAll(async () => {
+    ({ db, close } = await createTestDb());
+    const hh = await insertHousehold(db);
+    mockHouseholdId = hh.householdId;
+    const { groupId } = await insertCategoryGroup(db, hh.householdId);
+    ({ categoryId } = await insertCategory(db, hh.householdId, groupId, { name: "Subscriptions" }));
+  });
+
+  afterAll(async () => {
+    await close();
+  });
+
+  async function insertBill(
+    householdId: string,
+    overrides: Partial<typeof recurringTransactions.$inferInsert> = {},
+  ) {
+    const id = uuid();
+    await db.insert(recurringTransactions).values({
+      id,
+      householdId,
+      name: "Twitterapi.io",
+      averageAmount: 1333,
+      lastAmount: 1333,
+      frequency: "monthly",
+      lastDate: "2026-08-01",
+      nextDate: "2026-09-01",
+      isActive: true,
+      isIncome: false,
+      ...overrides,
+    });
+    return id;
+  }
+
+  describe("updateRecurringTransaction", () => {
+    it("updates name, category, amount and frequency together", async () => {
+      const id = await insertBill(mockHouseholdId);
+
+      const result = await updateRecurringTransaction(
+        {
+          id,
+          name: "Twitter API",
+          categoryId,
+          averageAmount: 1500,
+          frequency: "yearly",
+          isActive: true,
+        },
+        db,
+      );
+
+      expect(result).toMatchObject({ success: true });
+      const [row] = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.id, id));
+      expect(row!.name).toBe("Twitter API");
+      expect(row!.categoryId).toBe(categoryId);
+      expect(row!.averageAmount).toBe(1500);
+      expect(row!.frequency).toBe("yearly");
+    });
+
+    it("trims the name and rejects one that is only whitespace", async () => {
+      const id = await insertBill(mockHouseholdId);
+
+      const ok = await updateRecurringTransaction(
+        { id, name: "  Spotify  ", categoryId: null, averageAmount: 1333, frequency: "monthly", isActive: true },
+        db,
+      );
+      expect(ok).toMatchObject({ success: true });
+      const [row] = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.id, id));
+      expect(row!.name).toBe("Spotify");
+
+      const bad = await updateRecurringTransaction(
+        { id, name: "   ", categoryId: null, averageAmount: 1333, frequency: "monthly", isActive: true },
+        db,
+      );
+      expect(bad).toMatchObject({ error: expect.any(String) });
+    });
+
+    it("rejects a negative amount", async () => {
+      // averageAmount is displayed via Math.abs, so a negative would render
+      // identically while corrupting the monthly total's sign handling.
+      const id = await insertBill(mockHouseholdId);
+
+      const result = await updateRecurringTransaction(
+        { id, name: "Twitterapi.io", categoryId: null, averageAmount: -500, frequency: "monthly", isActive: true },
+        db,
+      );
+
+      expect(result).toMatchObject({ error: expect.any(String) });
+    });
+
+    it("clears the category when passed null", async () => {
+      const id = await insertBill(mockHouseholdId, { categoryId });
+
+      await updateRecurringTransaction(
+        { id, name: "Twitterapi.io", categoryId: null, averageAmount: 1333, frequency: "monthly", isActive: true },
+        db,
+      );
+
+      const [row] = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.id, id));
+      expect(row!.categoryId).toBeNull();
+    });
+
+    it("rejects a category belonging to another household", async () => {
+      const id = await insertBill(mockHouseholdId);
+      const other = await insertHousehold(db);
+      const { groupId } = await insertCategoryGroup(db, other.householdId);
+      const foreign = await insertCategory(db, other.householdId, groupId, { name: "Foreign" });
+
+      const result = await updateRecurringTransaction(
+        {
+          id,
+          name: "Twitterapi.io",
+          categoryId: foreign.categoryId,
+          averageAmount: 1333,
+          frequency: "monthly",
+          isActive: true,
+        },
+        db,
+      );
+
+      expect(result).toMatchObject({ error: expect.any(String) });
+      const [row] = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.id, id));
+      expect(row!.categoryId).toBeNull();
+    });
+
+    it("will not update a bill belonging to another household", async () => {
+      const other = await insertHousehold(db);
+      const foreignId = await insertBill(other.householdId, { name: "Theirs" });
+
+      const result = await updateRecurringTransaction(
+        { id: foreignId, name: "Hijacked", categoryId: null, averageAmount: 1, frequency: "monthly", isActive: true },
+        db,
+      );
+
+      expect(result).toMatchObject({ error: expect.any(String) });
+      const [row] = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.id, foreignId));
+      expect(row!.name).toBe("Theirs");
+    });
+  });
+
+  describe("muting", () => {
+    it("drops a muted bill from the list and the monthly total", async () => {
+      const hh = await insertHousehold(db);
+      mockHouseholdId = hh.householdId;
+      const id = await insertBill(hh.householdId, { averageAmount: 5000, frequency: "monthly" });
+
+      const before = await getRecurringSummary(hh.householdId, db);
+      expect(before.monthlyExpenses).toBe(5000);
+      expect(await getUpcomingBills(hh.householdId, {}, db)).toHaveLength(1);
+
+      await updateRecurringTransaction(
+        { id, name: "Twitterapi.io", categoryId: null, averageAmount: 5000, frequency: "monthly", isActive: false },
+        db,
+      );
+
+      // The record survives -- a later sync must not re-detect it as new --
+      // but it stops counting as a recurring expense.
+      const after = await getRecurringSummary(hh.householdId, db);
+      expect(after.monthlyExpenses).toBe(0);
+      expect(await getUpcomingBills(hh.householdId, {}, db)).toHaveLength(0);
+      const [row] = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.id, id));
+      expect(row).toBeDefined();
+      expect(row!.isActive).toBe(false);
+    });
+  });
+
+  describe("deleteRecurringTransaction", () => {
+    it("removes the bill", async () => {
+      const hh = await insertHousehold(db);
+      mockHouseholdId = hh.householdId;
+      const id = await insertBill(hh.householdId);
+
+      const result = await deleteRecurringTransaction(id, db);
+
+      expect(result).toMatchObject({ success: true });
+      const rows = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.id, id));
+      expect(rows).toHaveLength(0);
+    });
+
+    it("will not delete a bill belonging to another household", async () => {
+      const hh = await insertHousehold(db);
+      mockHouseholdId = hh.householdId;
+      const other = await insertHousehold(db);
+      const foreignId = await insertBill(other.householdId, { name: "Survives" });
+
+      const result = await deleteRecurringTransaction(foreignId, db);
+
+      expect(result).toMatchObject({ error: expect.any(String) });
+      const rows = await db
+        .select()
+        .from(recurringTransactions)
+        .where(eq(recurringTransactions.id, foreignId));
+      expect(rows).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #90.

Mock reviewed before implementation: https://claude.ai/code/artifact/013b74b5-8b4d-4fa9-a982-52a13a2a3d59

## The problem

There was no `src/actions/recurring.ts`, bill rows were plain `div`s, and the only interactive control on the page was the search box. Every detected bill was stuck as detected — a false positive, a wrong amount, a wrong frequency, or a credit-card payment counted as an expense all just sat there. The `$808.79/mo` headline was arithmetically correct and built entirely from rows nobody could touch.

## What this adds

- **`updateRecurringTransaction`** — name, category, amount, frequency, active state. Scoped + authorized variants, following `actions/merchants.ts`.
- **`deleteRecurringTransaction`** — for a genuine false positive.
- **Rows are real `<button>`s** opening a detail sheet. They were inert, so keyboard users had no route to the editor at all.

## Muting is the load-bearing one

Setting `is_active = false` works because `getUpcomingBills` and `getRecurringSummary` **already filter on it** — so the bill leaves both the list and the monthly total with no query changes.

Deleting would also remove it, but the next sync would re-detect the same stream as new and the user would have to act again. Keeping the row is what makes the decision stick. That is how a cancelled subscription — and "Applecard Gsbank Payment", a credit-card payment that is really a transfer — both stop inflating the monthly figure.

## Guards, all tested

- **Name** is trimmed and required.
- **Amount must be non-negative.** It is rendered through `Math.abs`, so a negative would look identical on screen while corrupting the sign handling behind the monthly total — invisible corruption is the kind worth blocking at the door.
- **Target category must belong to the household**, or a caller could aim a bill at another household's category id and read its name back off the bills list.

Plus household isolation on both update and delete.

## One React detail

The sheet is mounted with `key={bill.id}`, so opening a different bill remounts it and the form re-seeds from `useState` initialisers. My first version synced props into state from a `useEffect`, which `react-hooks/set-state-in-effect` correctly rejected — the keyed remount is the idiomatic form and needs no effect at all.

## Deliberately not included

#90 asks for a bill to be markable as a **transfer**. `recurring_transactions` has `is_active` and `is_income` but nothing for transfer, so a real label needs a schema migration.

Muting already delivers the outcome the issue describes — *"so it stops counting as a recurring expense"* — without one. And with another agent working this repo concurrently, an ordered migration file is precisely the change most likely to collide. Deferring it seemed better than rushing it; happy to add the column as a follow-up if you want the semantic distinction between "cancelled" and "not an expense".

## Tests

9 integration tests: combined field update, name trimming and whitespace rejection, negative-amount rejection, clearing a category, cross-household category rejection, cross-household update rejection, muting removing the bill from both the list and the monthly total while the row survives, delete, and cross-household delete rejection.

Full suite: **881 passed / 121 files**. Typecheck, `eslint src tests`, and `pnpm build` clean.

## Note for #93

This PR leaves `BILL_ROW_GRID` alone — the 500px of fixed columns that overflows at 390px, and the missing table semantics, are #93's subject. Splitting them keeps each reviewable; #93 will rework the same markup.

⚠️ `mutation (diff)` may report red — see #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)