### PR TITLE
Add a command palette over transactions, accounts and pages

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { getHouseholdId } from "@/lib/auth/session";
+import { withHousehold } from "@/lib/household-context";
+import { getTransactions } from "@/queries/transactions";
+import { getAccounts } from "@/queries/accounts";
+import { accountDisplayName } from "@/lib/account-name";
+
+/**
+ * Backs the command palette. Deliberately small: it answers "where is this
+ * thing" for the two entities people look one up by — a transaction and an
+ * account — rather than trying to be a second Transactions page.
+ */
+
+const MAX_TRANSACTIONS = 6;
+const MAX_ACCOUNTS = 4;
+/** Below this, results are mostly noise and the query is still being typed. */
+const MIN_QUERY_LENGTH = 2;
+
+export interface SearchResults {
+  transactions: {
+    id: string;
+    name: string;
+    date: string;
+    normalizedAmount: number;
+    currency: string;
+    categoryName: string | null;
+  }[];
+  accounts: { id: string; name: string; type: string }[];
+}
+
+export async function GET(request: Request) {
+  const householdId = await getHouseholdId();
+  const query = new URL(request.url).searchParams.get("q")?.trim() ?? "";
+
+  if (query.length < MIN_QUERY_LENGTH) {
+    return NextResponse.json({ transactions: [], accounts: [] } satisfies SearchResults);
+  }
+
+  const [page, allAccounts] = await Promise.all([
+    withHousehold(householdId, (tx) =>
+      getTransactions(householdId, { search: query }, undefined, undefined, tx),
+    ),
+    getAccounts(householdId),
+  ]);
+
+  const needle = query.toLowerCase();
+
+  return NextResponse.json({
+    transactions: page.rows.slice(0, MAX_TRANSACTIONS).map((t) => ({
+      id: t.id,
+      name: t.merchantName ?? t.name,
+      date: t.date,
+      normalizedAmount: t.normalizedAmount,
+      currency: t.currency,
+      categoryName: t.categoryName ?? null,
+    })),
+    accounts: allAccounts
+      .filter((a) => !a.isHidden)
+      // Matched against the display name, so what the user typed lines up with
+      // what they saw on screen — the stored name can carry a duplicated mask.
+      .filter((a) => accountDisplayName(a.name).toLowerCase().includes(needle))
+      .slice(0, MAX_ACCOUNTS)
+      .map((a) => ({ id: a.id, name: accountDisplayName(a.name), type: a.type })),
+  } satisfies SearchResults);
+}

--- a/src/components/molecules/command-palette-trigger.tsx
+++ b/src/components/molecules/command-palette-trigger.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, useEffect, useSyncExternalStore } from "react";
+import { Search } from "lucide-react";
+import { CommandPalette } from "@/components/organisms/command-palette";
+
+/** Platform is fixed for the life of the page, so there is nothing to notify. */
+function noopSubscribe() {
+  return () => {};
+}
+
+function detectMac() {
+  return /Mac|iPhone|iPad/.test(navigator.userAgent);
+}
+
+/** Matches the common case, so the first paint rarely shows the wrong key. */
+function assumeMacOnServer() {
+  return true;
+}
+
+/**
+ * Opens the command palette.
+ *
+ * The button matters as much as the shortcut: a palette reachable only by ⌘K
+ * is invisible to anyone who does not already know it exists, which is most
+ * people the first time. The shortcut is printed on the button so it teaches
+ * itself.
+ */
+export function CommandPaletteTrigger() {
+  const [open, setOpen] = useState(false);
+
+  // Read through an external store rather than an effect: the platform never
+  // changes, so there is nothing to subscribe to, and the server snapshot keeps
+  // hydration consistent without writing state from inside an effect.
+  const isMac = useSyncExternalStore(noopSubscribe, detectMac, assumeMacOnServer);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      // metaKey on macOS, ctrlKey elsewhere — binding only one strands half of
+      // the users on a shortcut their keyboard cannot produce.
+      if (e.key.toLowerCase() === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex w-full items-center gap-2 rounded-md border border-sidebar-border bg-sidebar-accent/40 px-2.5 py-1.5 text-left text-sm text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring"
+      >
+        <Search className="size-3.5 shrink-0" />
+        <span className="flex-1 truncate">Search…</span>
+        <kbd className="shrink-0 rounded border border-sidebar-border px-1 py-0.5 font-sans text-[10px] text-sidebar-foreground/50">
+          {isMac ? "⌘" : "Ctrl "}K
+        </kbd>
+      </button>
+      <CommandPalette open={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/src/components/organisms/command-palette.tsx
+++ b/src/components/organisms/command-palette.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
+import {
+  LayoutDashboard,
+  Building2,
+  ArrowLeftRight,
+  TrendingUp,
+  Wallet,
+  BarChart3,
+  Receipt,
+  Upload,
+  Settings,
+  Tag,
+} from "lucide-react";
+import {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+import { AmountDisplay } from "@/components/atoms/amount-display";
+import { formatDateShort } from "@/lib/date-utils";
+import type { SearchResults } from "@/app/api/search/route";
+
+const PAGES = [
+  { href: "/", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/accounts", label: "Accounts", icon: Building2 },
+  { href: "/transactions", label: "Transactions", icon: ArrowLeftRight },
+  { href: "/rules", label: "Rules", icon: Tag },
+  { href: "/investments", label: "Investments", icon: TrendingUp },
+  { href: "/budgets", label: "Budgets", icon: Wallet },
+  { href: "/bills", label: "Bills", icon: Receipt },
+  { href: "/reports", label: "Reports", icon: BarChart3 },
+  { href: "/import", label: "Import", icon: Upload },
+  { href: "/settings", label: "Settings", icon: Settings },
+];
+
+const EMPTY: SearchResults = { transactions: [], accounts: [] };
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResults>(EMPTY);
+  const [searching, setSearching] = useState(false);
+
+  // Debounced so typing does not fire a query per keystroke. The ref holds the
+  // latest request so a slow earlier response cannot overwrite a newer one.
+  const latestRequest = useRef(0);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const trimmed = query.trim();
+    // Nothing to fetch yet. The short-query and closed states are *derived*
+    // below rather than written back here — clearing state from inside an
+    // effect is what triggers cascading renders.
+    if (trimmed.length < 2) return;
+
+    const requestId = ++latestRequest.current;
+    const timer = setTimeout(async () => {
+      setSearching(true);
+      try {
+        const res = await fetch(`/api/search?q=${encodeURIComponent(trimmed)}`);
+        const data: SearchResults = await res.json();
+        if (requestId === latestRequest.current) setResults(data);
+      } catch {
+        // A failed lookup should leave the palette usable for navigation
+        // rather than tearing it down.
+        if (requestId === latestRequest.current) setResults(EMPTY);
+      } finally {
+        if (requestId === latestRequest.current) setSearching(false);
+      }
+    }, 200);
+
+    return () => clearTimeout(timer);
+  }, [query, open]);
+
+  // Reset on close in the handler rather than an effect, so the palette never
+  // opens showing a stale search and no state is written from inside an effect.
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (!next) {
+        setQuery("");
+        setResults(EMPTY);
+      }
+      onOpenChange(next);
+    },
+    [onOpenChange],
+  );
+
+  const go = useCallback(
+    (href: string) => {
+      handleOpenChange(false);
+      router.push(href);
+    },
+    [handleOpenChange, router],
+  );
+
+  const needle = query.trim().toLowerCase();
+
+  // Derived, not stored: a query too short to search shows nothing regardless
+  // of what the last completed search returned.
+  const visible = needle.length < 2 ? EMPTY : results;
+  const hasResults = visible.transactions.length > 0 || visible.accounts.length > 0;
+  const matchingPages = needle
+    ? PAGES.filter((p) => p.label.toLowerCase().includes(needle))
+    : PAGES;
+
+  // If a query matches nothing anywhere, offer every page rather than an empty
+  // dialog — the palette should never be a dead end you have to escape out of.
+  const pages = !hasResults && matchingPages.length === 0 ? PAGES : matchingPages;
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={handleOpenChange}
+      title="Search"
+      description="Search transactions and accounts, or jump to a page."
+    >
+      {/*
+        cmdk's own filtering is off: the transaction and account rows are
+        already filtered server-side for this exact query, and letting cmdk
+        filter them again by visible label would drop rows that matched on a
+        field the label does not show. Pages are filtered explicitly below
+        instead, so the behaviour is the same for every group.
+      */}
+      <Command shouldFilter={false}>
+        <CommandInput
+          placeholder="Search transactions and accounts, or jump to a page…"
+          value={query}
+          onValueChange={setQuery}
+        />
+        <CommandList>
+        <CommandEmpty>
+          {searching ? "Searching…" : query.trim().length < 2 ? "Type to search." : "No matches."}
+        </CommandEmpty>
+
+        {visible.transactions.length > 0 && (
+          <CommandGroup heading="Transactions">
+            {visible.transactions.map((t) => (
+              <CommandItem
+                key={t.id}
+                value={`txn-${t.id}`}
+                onSelect={() => go(`/transactions?txn=${t.id}`)}
+              >
+                <span className="flex-1 truncate">{t.name}</span>
+                <span className="ml-2 shrink-0 text-xs text-muted-foreground">
+                  {formatDateShort(t.date)}
+                  {t.categoryName ? ` · ${t.categoryName}` : ""}
+                </span>
+                <AmountDisplay
+                  amount={t.normalizedAmount}
+                  currency={t.currency}
+                  className="ml-3 shrink-0"
+                />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {visible.accounts.length > 0 && (
+          <CommandGroup heading="Accounts">
+            {visible.accounts.map((a) => (
+              <CommandItem key={a.id} value={`acct-${a.id}`} onSelect={() => go("/accounts")}>
+                <Building2 />
+                <span className="truncate">{a.name}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+          {pages.length > 0 && (
+          <CommandGroup heading={hasResults ? "Go to" : "Pages"}>
+            {pages.map((page) => (
+              <CommandItem key={page.href} value={page.label} onSelect={() => go(page.href)}>
+                <page.icon />
+                <span>{page.label}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+          )}
+        </CommandList>
+      </Command>
+    </CommandDialog>
+  );
+}

--- a/src/components/organisms/sidebar-nav.tsx
+++ b/src/components/organisms/sidebar-nav.tsx
@@ -17,6 +17,7 @@ import {
   Settings,
 } from "lucide-react";
 import { authClient } from "@/lib/auth/client";
+import { CommandPaletteTrigger } from "@/components/molecules/command-palette-trigger";
 import {
   Sidebar,
   SidebarContent,
@@ -85,13 +86,14 @@ export function SidebarNav({ userName, userEmail }: SidebarNavProps) {
 
   return (
     <Sidebar variant="inset" collapsible="offcanvas">
-      <SidebarHeader className="px-4 py-4">
+      <SidebarHeader className="px-4 py-4 gap-3">
         <Link href="/" className="flex items-center gap-2 text-lg font-bold tracking-tight">
           <span className="flex size-5 items-center justify-center rounded-md bg-positive text-[11px] font-extrabold text-background">
             L
           </span>
           Ledgr
         </Link>
+        <CommandPaletteTrigger />
       </SidebarHeader>
 
       <SidebarContent>


### PR DESCRIPTION
No palette, on an app whose navigation is ten sidebar links — while `components/ui/command.tsx` already shipped and was already used by the category pill and the chat input. The dependency and the primitive were both paid for.

## Search, not a nav shortcut

Type a merchant name and get its transactions with date, category and amount, and open one directly. `/api/search` is deliberately small: it answers *"where is this thing"* for the two entities people look one up by, rather than becoming a second Transactions page.

Accounts match on their **display name**, so what the user typed lines up with what they saw on screen — the stored name can still carry a duplicated mask.

## The button matters as much as the shortcut

A palette reachable only by ⌘K is invisible to anyone who doesn't already know it exists, which is most people the first time. The trigger sits in the sidebar with the shortcut printed on it, so it teaches itself. It binds **both `metaKey` and `ctrlKey`** rather than stranding non-macOS users on a chord their keyboard cannot produce.

## Two decisions worth explaining

**cmdk's own filtering is off.** The transaction and account rows are already filtered server-side for the exact query; letting cmdk filter them again by visible label would drop rows that matched on a field the label doesn't show. Pages are filtered explicitly so every group behaves the same.

**The palette is never a dead end.** When a query matches nothing anywhere, the full page list comes back rather than an empty dialog you have to escape out of. I caught this because my own code comment claimed pages "stay available mid-search" while the filtering actually hid them — the comment was right about the intent, the code wasn't.

## React 19 details

Both surfaced by the `set-state-in-effect` lint rule rather than guessed at:

- Requests de-duplicate through a ref, so a slow earlier response cannot overwrite a newer one.
- Neither the short-query reset nor the platform check writes state from inside an effect — the first is *derived*, the second reads through `useSyncExternalStore`.

## Verification

- 524 unit tests pass
- `tsc --noEmit` and `eslint src/` clean (0 errors)
- Verified in the browser: both the button and ⌘K open it; searching a merchant returns its transactions with correct dates, categories and amounts

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
