### PR TITLE
ci: install pnpm standalone so jobs stop racing on a shared $HOME

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,16 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 11.5.2
+          # Self-hosted runners share one $HOME, so the default install path
+          # (~/setup-pnpm/node_modules) is shared by every job on the box. Two
+          # jobs from different refs starting together race on it and leave it
+          # half-removed, after which every later job fails at setup — first as
+          # `ENOTEMPTY ... rmdir`, then permanently as `self-installer exits
+          # with code 254`, before a single test runs.
+          #
+          # `standalone` fetches a self-contained pnpm binary instead, skipping
+          # the node_modules layout that races. See #125.
+          standalone: true
 
       # No `cache: pnpm` on purpose. The runner is self-hosted, so the pnpm
       # store already persists in $HOME between jobs — actions/cache would
@@ -69,6 +79,16 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 11.5.2
+          # Self-hosted runners share one $HOME, so the default install path
+          # (~/setup-pnpm/node_modules) is shared by every job on the box. Two
+          # jobs from different refs starting together race on it and leave it
+          # half-removed, after which every later job fails at setup — first as
+          # `ENOTEMPTY ... rmdir`, then permanently as `self-installer exits
+          # with code 254`, before a single test runs.
+          #
+          # `standalone` fetches a self-contained pnpm binary instead, skipping
+          # the node_modules layout that races. See #125.
+          standalone: true
 
       # No `cache: pnpm` — see the test job for why.
       - uses: actions/setup-node@v7


### PR DESCRIPTION
Fixes the first of the two flake sources in #125, which is now hard-blocking rather than intermittent.

## What happens

`pnpm/action-setup` installs into `~/setup-pnpm/node_modules`, which on a self-hosted runner is shared by **every job on the box**. Two jobs from different refs starting close together race on it and leave it half-removed.

The workflow's `concurrency` group is keyed on `github.ref` — so it correctly serialises runs for one branch and does nothing across branches, which is exactly the case that collides.

Observed here across three runs, degrading as it went:

```
ENOTEMPTY: directory not empty, rmdir
  '~/setup-pnpm/node_modules/.bin/store/v11/files/03'
```

then, once the directory was left corrupt, permanently:

```
Something went wrong, self-installer exits with code 254
```

Both fail **before a single test runs**, and both show up as a red X on whichever PR was unlucky.

## Why re-running isn't the answer

PR #129 hit the first error, then hit the second on re-run. The corrupt directory doesn't clear itself, so this is no longer a flake you can retry past — it's a broken runner state that will fail every job until the path is repaired or avoided.

## The fix

`standalone: true` fetches a self-contained pnpm binary instead of building the `node_modules` layout, so there's no shared mutable directory to race on. Applied to both jobs.

This doesn't change the reasoning behind the existing "no `cache: pnpm`" comment — the pnpm **store** still persists in `$HOME` between jobs, which is what that comment is about. Only the installer changes.

## Validation

This PR validates itself: a change to `ci.yml` runs under the changed `ci.yml`, so a green `typecheck · lint · test` here *is* the evidence that the standalone installer works on these runners.

Refs #125 (leaves the post-teardown `57P01` half of that issue open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
