### PR TITLE
fix(transactions): collapse the filter bar on mobile, give account a column (#108)

### DIFF
--- a/src/app/(dashboard)/transactions/page.tsx
+++ b/src/app/(dashboard)/transactions/page.tsx
@@ -45,7 +45,11 @@ export default async function TransactionsPage({
         <ReviewEntryButton unreviewedCount={unreviewedSummary.count} />
       </div>
 
-      <FilterBar accounts={accountOptions} categories={allCategories} />
+      <FilterBar
+        accounts={accountOptions}
+        categories={allCategories}
+        resultCount={summary?.count ?? 0}
+      />
 
       {summary && (
         <FilterSummaryBar

--- a/src/components/molecules/filter-summary-bar.tsx
+++ b/src/components/molecules/filter-summary-bar.tsx
@@ -1,4 +1,4 @@
-import { centsToDisplay } from "@/lib/money";
+import { centsToDisplay, centsToSignedDisplay } from "@/lib/money";
 
 interface FilterSummaryBarProps {
   count: number;
@@ -13,17 +13,38 @@ export function FilterSummaryBar({
   totalIncome,
   net,
 }: FilterSummaryBarProps) {
+  const label = `${count} transaction${count !== 1 ? "s" : ""}`;
+  // Math.abs() here used to swallow the minus, so a net of -$248 read as
+  // "$248" — a loss shown as a gain to anyone not reading the color.
+  const netText = centsToSignedDisplay(net);
+
   return (
-    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 px-2 py-1.5 text-sm text-muted-foreground">
-      <span>{count} transaction{count !== 1 ? "s" : ""}</span>
-      <span className="text-border">|</span>
-      <span>Expenses: <span className="tabular-nums">{centsToDisplay(totalExpense)}</span></span>
-      <span className="text-border">|</span>
-      <span className="text-positive">Credits: <span className="tabular-nums">+{centsToDisplay(totalIncome)}</span></span>
-      <span className="text-border">|</span>
-      <span className={net >= 0 ? "text-positive" : ""}>
-        Net: <span className="tabular-nums">{net >= 0 ? "+" : ""}{centsToDisplay(Math.abs(net))}</span>
-      </span>
-    </div>
+    <>
+      {/*
+        Below sm the four figures and three separators wrap to two lines, which
+        puts Net — the number the strip exists for — last, on the second line.
+        One line instead, net first; expenses and credits return at sm, where
+        the full strip fits on one line anyway.
+      */}
+      <div className="flex items-center gap-x-2 px-2 py-1.5 text-sm text-muted-foreground sm:hidden">
+        <span className={net >= 0 ? "text-positive" : ""}>
+          Net <span className="tabular-nums">{netText}</span>
+        </span>
+        <span className="text-border">·</span>
+        <span className="truncate">{label}</span>
+      </div>
+
+      <div className="hidden flex-wrap items-center gap-x-4 gap-y-1 px-2 py-1.5 text-sm text-muted-foreground sm:flex">
+        <span>{label}</span>
+        <span className="text-border">|</span>
+        <span>Expenses: <span className="tabular-nums">{centsToDisplay(totalExpense)}</span></span>
+        <span className="text-border">|</span>
+        <span className="text-positive">Credits: <span className="tabular-nums">+{centsToDisplay(totalIncome)}</span></span>
+        <span className="text-border">|</span>
+        <span className={net >= 0 ? "text-positive" : ""}>
+          Net: <span className="tabular-nums">{netText}</span>
+        </span>
+      </div>
+    </>
   );
 }

--- a/src/components/molecules/mobile-filter-sheet.tsx
+++ b/src/components/molecules/mobile-filter-sheet.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { Check, ChevronDown, SlidersHorizontal } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+
+export interface FilterSheetOption {
+  id: string;
+  label: string;
+  /** Renders the label muted and italic — used for "Uncategorized". */
+  muted?: boolean;
+}
+
+export interface FilterSheetGroup {
+  heading?: string;
+  options: FilterSheetOption[];
+}
+
+export interface FilterSheetSection {
+  key: string;
+  label: string;
+  icon: LucideIcon;
+  /** The applied value, or null when this filter is unset. */
+  value: string | null;
+  /** Shown in place of the value when the filter is unset ("All accounts"). */
+  placeholder: string;
+  groups?: FilterSheetGroup[];
+  /** Id of the selected option; "" when the filter is unset. */
+  selectedId?: string;
+  onSelect?: (id: string) => void;
+  /** Rendered under the options — a custom date range, the amount inputs. */
+  extra?: ReactNode;
+}
+
+interface MobileFilterSheetProps {
+  sections: FilterSheetSection[];
+  activeCount: number;
+  reviewed: boolean;
+  onReviewedChange: (next: boolean) => void;
+  onClearAll: () => void;
+  /** Row count under the filters as they currently stand. */
+  resultCount: number;
+}
+
+/**
+ * The filter bar's mobile form: a single Filters button opening a bottom sheet.
+ *
+ * Rows expand inline rather than opening the popovers the desktop pills use.
+ * That is partly a mobile-ergonomics call — a full-width list beats a 220px
+ * popover on a 390px screen — and partly to keep a popover from being nested
+ * inside this dialog, where two competing focus traps is a fight worth not
+ * having.
+ */
+export function MobileFilterSheet({
+  sections,
+  activeCount,
+  reviewed,
+  onReviewedChange,
+  onClearAll,
+  resultCount,
+}: MobileFilterSheetProps) {
+  const [open, setOpen] = useState(false);
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+
+  // Collapse the open row when the sheet closes, so reopening starts at the
+  // list of filters rather than wherever the last visit left off.
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) setExpandedKey(null);
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetTrigger
+        render={
+          <Button
+            variant={activeCount > 0 ? "default" : "outline"}
+            size="sm"
+            className="h-8 shrink-0 text-xs"
+          />
+        }
+      >
+        <SlidersHorizontal className="mr-1 h-3.5 w-3.5" />
+        Filters
+        {activeCount > 0 && (
+          <span className="ml-1.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary-foreground px-1 text-[10px] font-medium tabular-nums text-primary">
+            {activeCount}
+          </span>
+        )}
+      </SheetTrigger>
+
+      <SheetContent
+        side="bottom"
+        showCloseButton={false}
+        className="max-h-[85svh] gap-0 rounded-t-xl p-0"
+      >
+        <SheetHeader className="px-4 pb-3">
+          <SheetTitle className="text-sm">Filters</SheetTitle>
+        </SheetHeader>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {sections.map((section) => {
+            const Icon = section.icon;
+            const expanded = expandedKey === section.key;
+            return (
+              <div key={section.key} className="border-t">
+                <button
+                  type="button"
+                  aria-expanded={expanded}
+                  aria-controls={`filter-panel-${section.key}`}
+                  onClick={() => setExpandedKey(expanded ? null : section.key)}
+                  className="flex w-full items-center gap-2 px-4 py-3 text-left text-sm"
+                >
+                  <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  {section.label}
+                  <span
+                    className={cn(
+                      "ml-auto min-w-0 truncate text-xs",
+                      section.value ? "text-foreground" : "text-muted-foreground",
+                    )}
+                  >
+                    {section.value ?? section.placeholder}
+                  </span>
+                  <ChevronDown
+                    className={cn(
+                      "h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform",
+                      expanded && "rotate-180",
+                    )}
+                  />
+                </button>
+
+                {expanded && (
+                  <div id={`filter-panel-${section.key}`} className="px-2 pb-3">
+                    {section.groups?.map((group, i) => (
+                      <div key={group.heading ?? i} role="radiogroup" aria-label={section.label}>
+                        {group.heading && (
+                          <p className="px-2 pt-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                            {group.heading}
+                          </p>
+                        )}
+                        {group.options.map((option) => {
+                          const checked = section.selectedId === option.id;
+                          return (
+                            <button
+                              key={option.id}
+                              type="button"
+                              role="radio"
+                              aria-checked={checked}
+                              onClick={() => section.onSelect?.(option.id)}
+                              className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm hover:bg-muted"
+                            >
+                              <span className={cn("min-w-0 truncate", option.muted && "italic text-muted-foreground")}>
+                                {option.label}
+                              </span>
+                              {checked && <Check className="ml-auto h-3.5 w-3.5 shrink-0" />}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ))}
+                    {section.extra}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+
+          {/* Reviewed is a toggle, not a list, so it gets a row of its own. */}
+          <div className="flex items-center gap-2 border-t px-4 py-3 text-sm">
+            <label htmlFor="filter-reviewed" className="flex-1">
+              Reviewed only
+            </label>
+            <Switch
+              id="filter-reviewed"
+              checked={reviewed}
+              onCheckedChange={onReviewedChange}
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 border-t p-3">
+          <Button variant="outline" size="sm" className="h-9" onClick={onClearAll}>
+            Clear all
+          </Button>
+          <SheetClose render={<Button size="sm" className="ml-auto h-9" />}>
+            Show {resultCount} transaction{resultCount !== 1 ? "s" : ""}
+          </SheetClose>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/molecules/transaction-row.tsx
+++ b/src/components/molecules/transaction-row.tsx
@@ -12,8 +12,18 @@ import type { TransactionRow as TxnRow } from "@/queries/transactions";
 import type { CategoryGroup } from "@/queries/categories";
 import { cn } from "@/lib/utils";
 
+// Account is a column only at lg and up. The breakpoint is on the viewport but
+// the grid lives inside the content area, which is a 256px sidebar narrower —
+// at md the six tracks leave the description almost no width at all. Below lg
+// the account stays an inline suffix on the description (sm-lg), and below sm
+// it is dropped entirely; see the spans in the row body.
+//
+// The category track is bounded rather than `auto` wherever the account column
+// exists: every row is its own grid, so an `auto` track resolves per row and
+// the 1fr description absorbs the difference, which left the account starting
+// at a different x on every line.
 export const TRANSACTION_GRID_COLS =
-  "grid-cols-[24px_minmax(0,1fr)_auto_80px] sm:grid-cols-[24px_32px_minmax(0,1fr)_auto_100px]" as const;
+  "grid-cols-[24px_minmax(0,1fr)_auto_80px] sm:grid-cols-[24px_32px_minmax(0,1fr)_auto_100px] lg:grid-cols-[24px_32px_minmax(0,1fr)_128px_minmax(0,150px)_100px]" as const;
 
 interface TransactionRowProps {
   transaction: TxnRow;
@@ -96,13 +106,19 @@ export const TransactionRow = memo(function TransactionRow({
               ({txn.originalName})
             </span>
           )}
-          <span className="hidden sm:inline text-[10px] text-muted-foreground shrink-0 max-w-[100px] truncate">
+          <span className="hidden sm:inline lg:hidden text-[10px] text-muted-foreground shrink-0 max-w-[100px] truncate">
             {txn.accountName && accountDisplayName(txn.accountName)}
           </span>
         </div>
       </div>
 
-      <div onClick={handleCheckboxClick}>
+      <div className="hidden min-w-0 pr-2 text-xs text-muted-foreground lg:block">
+        <span className="block truncate">
+          {txn.accountName && accountDisplayName(txn.accountName)}
+        </span>
+      </div>
+
+      <div className="min-w-0" onClick={handleCheckboxClick}>
         <CategoryPill
           key={`${txn.id}-cat-${txn.categoryId}`}
           transactionId={txn.id}

--- a/src/components/organisms/portfolio-summary-header.tsx
+++ b/src/components/organisms/portfolio-summary-header.tsx
@@ -1,14 +1,9 @@
-import { centsToDisplay } from "@/lib/money";
+import { centsToDisplay, centsToSignedDisplay } from "@/lib/money";
 import { StatStrip, type StatStripItem } from "@/components/molecules/stat-strip";
 import type { PortfolioSummary } from "@/queries/investments";
 
 interface PortfolioSummaryHeaderProps {
   summary: PortfolioSummary;
-}
-
-function signedDisplay(cents: number): string {
-  const display = centsToDisplay(Math.abs(cents));
-  return cents < 0 ? `-${display}` : `+${display}`;
 }
 
 export function PortfolioSummaryHeader({ summary }: PortfolioSummaryHeaderProps) {
@@ -30,7 +25,7 @@ export function PortfolioSummaryHeader({ summary }: PortfolioSummaryHeaderProps)
       // Derived from holdings_history, so it can only ever describe the
       // itemized part. The label says so rather than implying whole-portfolio.
       label: "Day Change (holdings)",
-      value: summary.dayChange !== null ? signedDisplay(summary.dayChange) : "n/a",
+      value: summary.dayChange !== null ? centsToSignedDisplay(summary.dayChange) : "n/a",
       valueClassName:
         summary.dayChange !== null
           ? summary.dayChange >= 0
@@ -42,7 +37,7 @@ export function PortfolioSummaryHeader({ summary }: PortfolioSummaryHeaderProps)
       // Spans only holdings that report a cost basis. Zero-basis positions
       // would otherwise contribute their entire value as gain.
       label: "Gain/Loss (with cost basis)",
-      value: signedDisplay(summary.totalGainLoss),
+      value: centsToSignedDisplay(summary.totalGainLoss),
       valueClassName: summary.totalGainLoss >= 0 ? "text-positive" : "text-destructive",
     },
   );

--- a/src/components/organisms/transaction-filters.tsx
+++ b/src/components/organisms/transaction-filters.tsx
@@ -12,6 +12,7 @@ import {
   Check,
   ChevronDown,
   BadgeCheck,
+  CalendarDays,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSearchParamFilters } from "@/hooks/use-search-param-filters";
@@ -32,26 +33,32 @@ import {
   DateRangePopover,
   type DatePresetOption,
 } from "@/components/molecules/date-range-popover";
+import {
+  MobileFilterSheet,
+  type FilterSheetSection,
+} from "@/components/molecules/mobile-filter-sheet";
 import { DATE_PRESETS, dateRangeForPreset, matchDatePreset, type DatePresetId } from "@/lib/date-presets";
-import { formatDateShort } from "@/lib/date-utils";
+import {
+  TYPE_LABELS,
+  buildFilterChips,
+  describeAccountFilter,
+  describeAmountFilter,
+  describeCategoryFilter,
+  describeDateFilter,
+  describeTypeFilter,
+  type AccountOption,
+  type FilterChip,
+  type FilterChipKey,
+} from "@/lib/transaction-filter-chips";
 import { UNCATEGORIZED } from "@/lib/labels";
 import type { CategoryGroup } from "@/queries/categories";
-
-interface AccountOption {
-  id: string;
-  name: string;
-}
 
 interface TransactionFiltersProps {
   accounts: AccountOption[];
   categories: CategoryGroup[];
+  /** Rows matching the current filters — shown on the mobile sheet's apply button. */
+  resultCount: number;
 }
-
-const TYPE_LABELS: Record<string, string> = {
-  expense: "Expenses",
-  credits: "Credits",
-  transfer: "Transfers",
-};
 
 // "All time" clears from/to; the rest map to date-presets ranges.
 const DATE_OPTIONS: DatePresetOption[] = [
@@ -72,7 +79,7 @@ function triggerLabel(label: string, value: string | null, active: boolean): Rea
   );
 }
 
-export function TransactionFilters({ accounts, categories }: TransactionFiltersProps) {
+export function TransactionFilters({ accounts, categories, resultCount }: TransactionFiltersProps) {
   const { updateFilter, updateFilters, clearFilters, hasFilters, searchParams } =
     useSearchParamFilters();
 
@@ -110,42 +117,19 @@ export function TransactionFilters({ accounts, categories }: TransactionFiltersP
   const dateMatch = matchDatePreset(fromParam, toParam);
   const dateActive = dateMatch !== null;
   const dateSelectedId = dateActive ? (dateMatch === "custom" ? null : dateMatch) : "all";
-  const dateValue = (() => {
-    if (dateMatch === null) return null;
-    if (dateMatch !== "custom") return DATE_PRESETS.find((p) => p.id === dateMatch)?.label ?? null;
-    if (fromParam && toParam) return `${formatDateShort(fromParam)} - ${formatDateShort(toParam)}`;
-    if (fromParam) return `From ${formatDateShort(fromParam)}`;
-    if (toParam) return `Until ${formatDateShort(toParam)}`;
-    return null;
-  })();
+  const dateValue = describeDateFilter(fromParam, toParam);
 
   const accountId = searchParams.get("account");
-  const accountValue = accountId
-    ? accounts.find((a) => a.id === accountId)?.name ?? null
-    : null;
+  const accountValue = describeAccountFilter(accountId, accounts);
 
   const categoryId = searchParams.get("category");
-  const categoryValue = (() => {
-    if (!categoryId) return null;
-    if (categoryId === "uncategorized") return UNCATEGORIZED;
-    for (const group of categories) {
-      const cat = group.categories.find((c) => c.id === categoryId);
-      if (cat) return cat.name;
-    }
-    return null;
-  })();
+  const categoryValue = describeCategoryFilter(categoryId, categories);
 
   const typeId = searchParams.get("type");
-  const typeValue = typeId ? TYPE_LABELS[typeId] ?? null : null;
+  const typeValue = describeTypeFilter(typeId);
 
   const amountActive = !!(searchParams.get("amountMin") || searchParams.get("amountMax"));
-  const amountValue = (() => {
-    const { minDisplay: min, maxDisplay: max } = amount;
-    if (min && max) return `$${min} - $${max}`;
-    if (min) return `≥ $${min}`;
-    if (max) return `≤ $${max}`;
-    return null;
-  })();
+  const amountValue = describeAmountFilter(amount.minDisplay, amount.maxDisplay);
 
   const reviewedActive = searchParams.get("reviewed") === "true";
 
@@ -160,26 +144,170 @@ export function TransactionFilters({ accounts, categories }: TransactionFiltersP
   }
 
   // ---- applied-filter chips ----
-  const chips: { key: string; label: string; onRemove: () => void }[] = [];
-  if (dateActive)
-    chips.push({ key: "date", label: `Date: ${dateValue}`, onRemove: () => updateFilters({ from: null, to: null }) });
-  if (accountValue)
-    chips.push({ key: "account", label: `Account: ${accountValue}`, onRemove: () => updateFilter("account", null) });
-  if (categoryValue)
-    chips.push({ key: "category", label: `Category: ${categoryValue}`, onRemove: () => updateFilter("category", null) });
-  if (typeValue)
-    chips.push({ key: "type", label: typeValue, onRemove: () => updateFilter("type", null) });
-  if (amountActive)
-    chips.push({
+  const chips = buildFilterChips({
+    from: fromParam,
+    to: toParam,
+    accountId,
+    categoryId,
+    typeId,
+    amountMinDisplay: amount.minDisplay,
+    amountMaxDisplay: amount.maxDisplay,
+    reviewed: reviewedActive,
+    accounts,
+    categories,
+  });
+
+  const removeChip: Record<FilterChipKey, () => void> = {
+    date: () => updateFilters({ from: null, to: null }),
+    account: () => updateFilter("account", null),
+    category: () => updateFilter("category", null),
+    type: () => updateFilter("type", null),
+    amount: () => {
+      amount.reset();
+      updateFilters({ amountMin: null, amountMax: null });
+    },
+    reviewed: () => updateFilter("reviewed", null),
+  };
+
+  function renderChip(chip: FilterChip) {
+    const text = chip.label ? `${chip.label}: ${chip.value}` : chip.value;
+    return (
+      <Badge key={chip.key} variant="secondary" className="shrink-0 gap-1 pr-1 font-normal">
+        {chip.label && <span className="text-muted-foreground">{chip.label}:</span>}
+        {chip.value}
+        <button
+          type="button"
+          aria-label={`Remove ${text} filter`}
+          onClick={removeChip[chip.key]}
+          className="ml-0.5 rounded-full p-0.5 text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </Badge>
+    );
+  }
+
+  // ---- the same filters, as rows for the mobile sheet ----
+  const amountInputs = (
+    <div className="flex items-center gap-1.5 px-2 pt-2">
+      <Input
+        type="text"
+        inputMode="decimal"
+        placeholder="Min $"
+        aria-label="Minimum amount"
+        value={amount.minDisplay}
+        onChange={(e) => amount.handleMinChange(e.target.value)}
+        onBlur={() => amount.handleBlur("amountMin")}
+        className="h-9 text-sm"
+      />
+      <span className="text-xs text-muted-foreground">to</span>
+      <Input
+        type="text"
+        inputMode="decimal"
+        placeholder="Max $"
+        aria-label="Maximum amount"
+        value={amount.maxDisplay}
+        onChange={(e) => amount.handleMaxChange(e.target.value)}
+        onBlur={() => amount.handleBlur("amountMax")}
+        className="h-9 text-sm"
+      />
+    </div>
+  );
+
+  const sheetSections: FilterSheetSection[] = [
+    {
+      key: "date",
+      label: "Date",
+      icon: CalendarDays,
+      value: dateValue,
+      placeholder: "All time",
+      groups: [{ options: DATE_OPTIONS.map((o) => ({ id: o.id, label: o.label })) }],
+      selectedId: dateSelectedId ?? "",
+      onSelect: handleDatePreset,
+      extra: (
+        <div className="flex items-center gap-1.5 px-2 pt-2">
+          <Input
+            type="date"
+            aria-label="From date"
+            value={fromParam ?? ""}
+            onChange={(e) => updateFilter("from", e.target.value || null)}
+            className="h-9 flex-1 text-sm"
+          />
+          <span className="text-xs text-muted-foreground">to</span>
+          <Input
+            type="date"
+            aria-label="To date"
+            value={toParam ?? ""}
+            onChange={(e) => updateFilter("to", e.target.value || null)}
+            className="h-9 flex-1 text-sm"
+          />
+        </div>
+      ),
+    },
+    {
+      key: "account",
+      label: "Account",
+      icon: Landmark,
+      value: accountValue,
+      placeholder: "All accounts",
+      groups: [
+        {
+          options: [
+            { id: "", label: "All accounts" },
+            ...accounts.map((a) => ({ id: a.id, label: a.name })),
+          ],
+        },
+      ],
+      selectedId: accountId ?? "",
+      onSelect: (id) => updateFilter("account", id || null),
+    },
+    {
+      key: "category",
+      label: "Category",
+      icon: Tags,
+      value: categoryValue,
+      placeholder: "All categories",
+      groups: [
+        {
+          options: [
+            { id: "", label: "All categories" },
+            { id: "uncategorized", label: UNCATEGORIZED, muted: true },
+          ],
+        },
+        ...categories.map((group) => ({
+          heading: group.name,
+          options: group.categories.map((cat) => ({ id: cat.id, label: cat.name })),
+        })),
+      ],
+      selectedId: categoryId ?? "",
+      onSelect: (id) => updateFilter("category", id || null),
+    },
+    {
+      key: "type",
+      label: "Type",
+      icon: ArrowLeftRight,
+      value: typeValue,
+      placeholder: "All types",
+      groups: [
+        {
+          options: [
+            { id: "", label: "All types" },
+            ...Object.entries(TYPE_LABELS).map(([id, label]) => ({ id, label })),
+          ],
+        },
+      ],
+      selectedId: typeId ?? "",
+      onSelect: (id) => updateFilter("type", id || null),
+    },
+    {
       key: "amount",
-      label: `Amount: ${amountValue}`,
-      onRemove: () => {
-        amount.reset();
-        updateFilters({ amountMin: null, amountMax: null });
-      },
-    });
-  if (reviewedActive)
-    chips.push({ key: "reviewed", label: "Reviewed", onRemove: () => updateFilter("reviewed", null) });
+      label: "Amount",
+      icon: DollarSign,
+      value: amountValue,
+      placeholder: "Any",
+      extra: amountInputs,
+    },
+  ];
 
   return (
     <div className="space-y-3">
@@ -207,8 +335,27 @@ export function TransactionFilters({ accounts, categories }: TransactionFiltersP
         </a>
       </div>
 
-      {/* Row 2: filter pills */}
-      <div className="flex flex-wrap items-center gap-2">
+      {/*
+        Row 2, below sm: one Filters button and the applied chips share a single
+        scrolling row. Six wrapping pills plus a chips row cost up to three rows
+        of a 390px screen before the ledger starts; this costs one, applied or
+        not. The negative margin lets chips scroll to the screen edge rather
+        than stopping short at the layout's px-4.
+      */}
+      <div className="-mx-4 flex items-center gap-2 overflow-x-auto px-4 pb-0.5 [scrollbar-width:none] sm:hidden [&::-webkit-scrollbar]:hidden">
+        <MobileFilterSheet
+          sections={sheetSections}
+          activeCount={chips.length}
+          reviewed={reviewedActive}
+          onReviewedChange={(next) => updateFilter("reviewed", next ? "true" : null)}
+          onClearAll={handleClearAll}
+          resultCount={resultCount}
+        />
+        {chips.map(renderChip)}
+      </div>
+
+      {/* Row 2, sm and up: the filter pills, unchanged */}
+      <div className="hidden flex-wrap items-center gap-2 sm:flex">
         {/* Date */}
         <DateRangePopover
           presets={DATE_OPTIONS}
@@ -309,7 +456,6 @@ export function TransactionFilters({ accounts, categories }: TransactionFiltersP
                           setCategoryOpen(false);
                         }}
                       >
-                        {cat.icon ? `${cat.icon} ` : ""}
                         {cat.name}
                         {categoryId === cat.id && <Check className="ml-auto h-3.5 w-3.5" />}
                       </CommandItem>
@@ -405,22 +551,10 @@ export function TransactionFilters({ accounts, categories }: TransactionFiltersP
         </Button>
       </div>
 
-      {/* Row 3: applied-filter chips */}
+      {/* Row 3, sm and up: applied-filter chips. Below sm they ride in row 2. */}
       {hasFilters && chips.length > 0 && (
-        <div className="flex flex-wrap items-center gap-1.5">
-          {chips.map((chip) => (
-            <Badge key={chip.key} variant="secondary" className="gap-1 pr-1 font-normal">
-              {chip.label}
-              <button
-                type="button"
-                aria-label={`Remove ${chip.label} filter`}
-                onClick={chip.onRemove}
-                className="ml-0.5 rounded-full p-0.5 text-muted-foreground hover:bg-foreground/10 hover:text-foreground"
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </Badge>
-          ))}
+        <div className="hidden flex-wrap items-center gap-1.5 sm:flex">
+          {chips.map(renderChip)}
           <Button variant="ghost" size="xs" onClick={handleClearAll} className="text-xs text-muted-foreground">
             Clear all
           </Button>

--- a/src/components/organisms/transaction-list.tsx
+++ b/src/components/organisms/transaction-list.tsx
@@ -130,6 +130,7 @@ export function TransactionList({
             />
           </div>
           <span>Description</span>
+          <span className="hidden lg:block">Account</span>
           <span>Category</span>
           <span className="text-right">Amount</span>
         </div>

--- a/src/lib/money.test.ts
+++ b/src/lib/money.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { test, fc } from "@fast-check/vitest";
 import {
   centsToDisplay,
+  centsToSignedDisplay,
   centsToCompact,
   displayToCents,
   plaidAmountToCents,
@@ -12,6 +13,21 @@ import {
 } from "./money";
 
 describe("money utilities", () => {
+  describe("centsToSignedDisplay", () => {
+    it("writes both signs, so a delta never reads as a quantity", () => {
+      expect(centsToSignedDisplay(1250)).toBe("+$12.50");
+      expect(centsToSignedDisplay(-1250)).toBe("-$12.50");
+    });
+
+    it("treats zero as non-negative", () => {
+      expect(centsToSignedDisplay(0)).toBe("+$0.00");
+    });
+
+    it("signs the amount, not the currency symbol", () => {
+      expect(centsToSignedDisplay(-1250, "EUR")).toBe("-€12.50");
+    });
+  });
+
   describe("centsToCompact", () => {
     it("abbreviates thousands and millions", () => {
       expect(centsToCompact(12830412)).toBe("$128.3K");

--- a/src/lib/money.ts
+++ b/src/lib/money.ts
@@ -7,6 +7,18 @@ export function centsToDisplay(cents: number, currency = "USD"): string {
   }).format(cents / 100);
 }
 
+/**
+ * A signed amount, always carrying its sign: "+$12.50", "-$12.50", "+$0.00".
+ *
+ * Intl already renders a minus for negatives, but never a plus for positives.
+ * Where a figure is a delta rather than a quantity — a net, a gain/loss — the
+ * leading "+" is what makes it read as one, so both signs are written here.
+ */
+export function centsToSignedDisplay(cents: number, currency = "USD"): string {
+  const display = centsToDisplay(Math.abs(cents), currency);
+  return cents < 0 ? `-${display}` : `+${display}`;
+}
+
 export function displayToCents(display: number): number {
   return Math.round(display * 100);
 }

--- a/src/lib/transaction-filter-chips.test.ts
+++ b/src/lib/transaction-filter-chips.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFilterChips,
+  describeAmountFilter,
+  describeCategoryFilter,
+  describeDateFilter,
+  type ChipInput,
+} from "./transaction-filter-chips";
+import { dateRangeForPreset } from "./date-presets";
+import type { CategoryGroup } from "@/queries/categories";
+
+const CATEGORIES: CategoryGroup[] = [
+  {
+    id: "g1",
+    name: "Food",
+    categories: [
+      { id: "c1", name: "Groceries", icon: "🛒" },
+      { id: "c2", name: "Restaurants", icon: null },
+    ],
+  },
+] as unknown as CategoryGroup[];
+
+const ACCOUNTS = [
+  { id: "a1", name: "Checking-1135" },
+  { id: "a2", name: "Robinhood individual (1722)" },
+];
+
+/** A no-filters-applied baseline each test narrows from. */
+const EMPTY: ChipInput = {
+  from: null,
+  to: null,
+  accountId: null,
+  categoryId: null,
+  typeId: null,
+  amountMinDisplay: "",
+  amountMaxDisplay: "",
+  reviewed: false,
+  accounts: ACCOUNTS,
+  categories: CATEGORIES,
+};
+
+describe("describeDateFilter", () => {
+  it("names the preset when the range matches one", () => {
+    const { from, to } = dateRangeForPreset("30d");
+    expect(describeDateFilter(from, to)).toBe("Last 30 days");
+  });
+
+  it("renders both endpoints for a custom range", () => {
+    expect(describeDateFilter("2026-03-04", "2026-04-09")).toBe("Mar 4 - Apr 9");
+  });
+
+  it("renders an open-ended range from one endpoint", () => {
+    expect(describeDateFilter("2026-03-04", null)).toBe("From Mar 4");
+    expect(describeDateFilter(null, "2026-04-09")).toBe("Until Apr 9");
+  });
+
+  it("is null when no date filter is applied", () => {
+    expect(describeDateFilter(null, null)).toBeNull();
+  });
+});
+
+describe("describeCategoryFilter", () => {
+  it("resolves an id nested inside a group", () => {
+    expect(describeCategoryFilter("c2", CATEGORIES)).toBe("Restaurants");
+  });
+
+  it("names the uncategorized pseudo-filter", () => {
+    expect(describeCategoryFilter("uncategorized", CATEGORIES)).toBe("Uncategorized");
+  });
+
+  it("is null for an id that resolves to no category", () => {
+    expect(describeCategoryFilter("gone", CATEGORIES)).toBeNull();
+  });
+});
+
+describe("describeAmountFilter", () => {
+  it("renders a bounded range, and each half-open bound", () => {
+    expect(describeAmountFilter("10", "50")).toBe("$10 - $50");
+    expect(describeAmountFilter("10", "")).toBe("≥ $10");
+    expect(describeAmountFilter("", "50")).toBe("≤ $50");
+  });
+
+  it("is null when neither bound is set", () => {
+    expect(describeAmountFilter("", "")).toBeNull();
+  });
+});
+
+describe("buildFilterChips", () => {
+  it("is empty when nothing is applied", () => {
+    expect(buildFilterChips(EMPTY)).toEqual([]);
+  });
+
+  it("carries a label and value per applied filter", () => {
+    const chips = buildFilterChips({
+      ...EMPTY,
+      accountId: "a2",
+      categoryId: "c1",
+    });
+    expect(chips).toEqual([
+      { key: "account", label: "Account", value: "Robinhood individual (1722)" },
+      { key: "category", label: "Category", value: "Groceries" },
+    ]);
+  });
+
+  it("gives the type chip no label — its value already names the filter", () => {
+    expect(buildFilterChips({ ...EMPTY, typeId: "expense" })).toEqual([
+      { key: "type", label: null, value: "Expenses" },
+    ]);
+  });
+
+  it("skips filters whose value cannot be resolved", () => {
+    // A stale account id in the URL must not produce a chip with no value —
+    // an "Account:" chip naming nothing is worse than no chip at all.
+    expect(buildFilterChips({ ...EMPTY, accountId: "deleted" })).toEqual([]);
+  });
+
+  it("counts the reviewed toggle, which has no value of its own", () => {
+    expect(buildFilterChips({ ...EMPTY, reviewed: true })).toEqual([
+      { key: "reviewed", label: null, value: "Reviewed" },
+    ]);
+  });
+
+  it("orders chips the same way the filter controls are ordered", () => {
+    const chips = buildFilterChips({
+      ...EMPTY,
+      from: "2026-03-04",
+      to: "2026-04-09",
+      accountId: "a1",
+      categoryId: "c1",
+      typeId: "credits",
+      amountMinDisplay: "10",
+      reviewed: true,
+    });
+    expect(chips.map((c) => c.key)).toEqual([
+      "date",
+      "account",
+      "category",
+      "type",
+      "amount",
+      "reviewed",
+    ]);
+  });
+});

--- a/src/lib/transaction-filter-chips.ts
+++ b/src/lib/transaction-filter-chips.ts
@@ -1,0 +1,135 @@
+/**
+ * Display values for the transactions filter bar.
+ *
+ * The bar renders the same applied-filter state three ways — as the value on a
+ * desktop pill ("Category: Groceries"), as a removable chip, and as the current
+ * value on a row of the mobile filter sheet — so the branchy part (which of a
+ * range's endpoints are set, whether an id still resolves) lives here rather
+ * than three times in the component.
+ *
+ * Everything here is pure: ids in, strings out. The URL params stay the source
+ * of truth, and the component owns what removing a chip does.
+ */
+
+import { formatDateShort } from "@/lib/date-utils";
+import { DATE_PRESETS, matchDatePreset } from "@/lib/date-presets";
+import { UNCATEGORIZED } from "@/lib/labels";
+import type { CategoryGroup } from "@/queries/categories";
+
+export const TYPE_LABELS: Record<string, string> = {
+  expense: "Expenses",
+  credits: "Credits",
+  transfer: "Transfers",
+};
+
+export type FilterChipKey =
+  | "date"
+  | "account"
+  | "category"
+  | "type"
+  | "amount"
+  | "reviewed";
+
+export interface FilterChip {
+  key: FilterChipKey;
+  /** The filter's name, or null when the value already names it ("Expenses"). */
+  label: string | null;
+  value: string;
+}
+
+export interface AccountOption {
+  id: string;
+  name: string;
+}
+
+export interface ChipInput {
+  from: string | null;
+  to: string | null;
+  accountId: string | null;
+  categoryId: string | null;
+  typeId: string | null;
+  /** Amount bounds as the user typed them, not cents — the inputs are the source. */
+  amountMinDisplay: string;
+  amountMaxDisplay: string;
+  reviewed: boolean;
+  accounts: AccountOption[];
+  categories: CategoryGroup[];
+}
+
+/** "Last 30 days", "Mar 4 - Apr 9", "From Mar 4", or null when unfiltered. */
+export function describeDateFilter(from: string | null, to: string | null): string | null {
+  const match = matchDatePreset(from, to);
+  if (match === null) return null;
+  if (match !== "custom") return DATE_PRESETS.find((p) => p.id === match)?.label ?? null;
+  if (from && to) return `${formatDateShort(from)} - ${formatDateShort(to)}`;
+  if (from) return `From ${formatDateShort(from)}`;
+  if (to) return `Until ${formatDateShort(to)}`;
+  return null;
+}
+
+/** The account's name, or null when the id names no account we hold. */
+export function describeAccountFilter(
+  accountId: string | null,
+  accounts: AccountOption[],
+): string | null {
+  if (!accountId) return null;
+  return accounts.find((a) => a.id === accountId)?.name ?? null;
+}
+
+/** The category's name, or null when the id resolves to nothing. */
+export function describeCategoryFilter(
+  categoryId: string | null,
+  categories: CategoryGroup[],
+): string | null {
+  if (!categoryId) return null;
+  if (categoryId === "uncategorized") return UNCATEGORIZED;
+  for (const group of categories) {
+    const cat = group.categories.find((c) => c.id === categoryId);
+    if (cat) return cat.name;
+  }
+  return null;
+}
+
+/** "Expenses" / "Credits" / "Transfers", or null for an unknown type param. */
+export function describeTypeFilter(typeId: string | null): string | null {
+  if (!typeId) return null;
+  return TYPE_LABELS[typeId] ?? null;
+}
+
+/** "$10 - $50", "≥ $10", "≤ $50", or null when neither bound is set. */
+export function describeAmountFilter(min: string, max: string): string | null {
+  if (min && max) return `$${min} - $${max}`;
+  if (min) return `≥ $${min}`;
+  if (max) return `≤ $${max}`;
+  return null;
+}
+
+/**
+ * One chip per applied filter, in the order the controls themselves appear.
+ *
+ * A filter whose value no longer resolves — a stale account id left in the URL
+ * after the account was removed — contributes no chip: a chip reading
+ * "Account:" and nothing else is worse than showing no chip at all.
+ */
+export function buildFilterChips(input: ChipInput): FilterChip[] {
+  const chips: FilterChip[] = [];
+
+  const date = describeDateFilter(input.from, input.to);
+  if (date) chips.push({ key: "date", label: "Date", value: date });
+
+  const account = describeAccountFilter(input.accountId, input.accounts);
+  if (account) chips.push({ key: "account", label: "Account", value: account });
+
+  const category = describeCategoryFilter(input.categoryId, input.categories);
+  if (category) chips.push({ key: "category", label: "Category", value: category });
+
+  const type = describeTypeFilter(input.typeId);
+  if (type) chips.push({ key: "type", label: null, value: type });
+
+  const amount = describeAmountFilter(input.amountMinDisplay, input.amountMaxDisplay);
+  if (amount) chips.push({ key: "amount", label: "Amount", value: amount });
+
+  if (input.reviewed) chips.push({ key: "reviewed", label: null, value: "Reviewed" });
+
+  return chips;
+}


### PR DESCRIPTION
Closes #108.

Your correction on the issue established that the pills, chips and summary bar were already built — this is the remainder: what that bar costs on a phone, plus the account column (T4).

## What changed

**Filter bar, below `sm`.** Six pills wrapped to two rows and the chips took a third, so up to ~100px of a 390px screen went to filter chrome before the first transaction. They collapse to one `Filters` button carrying an active count, sharing a single horizontally-scrolling row with the applied chips — one row whether nothing is filtered or everything is. The button opens a bottom sheet whose rows expand inline rather than opening the desktop popovers; that keeps a Base UI popover from nesting inside a Base UI dialog and having two focus traps argue. **At `sm` and up the pills are untouched.**

**Account column.** It was a 10px suffix capped at 100px, so `Robinhood individual (1722)` truncated to `Robinhood indi…` — cutting exactly the digits that tell two accounts apart. Now its own column with a header at `lg` and up.

`lg`, not `md`: the breakpoint is on the viewport but the grid sits in a content area a 256px sidebar narrower. At 768px the six tracks left the description no width at all and merchant names disappeared entirely — caught in the browser, not by any test. Between `sm` and `lg` the inline suffix stays, so no band regresses.

The category track is bounded wherever the account column exists. Every row is its own grid, so an `auto` track resolves per row and the `1fr` description absorbs the difference — which had the account column starting at a different x on every line.

**Totals strip.** One line with net leading below `sm`, which is the acceptance criterion already written on the issue.

## Bugs found while verifying

- `FilterSummaryBar` took `Math.abs(net)` and only ever prefixed `+`, so a net of −$24,805.90 rendered as `$24,805.90` — a loss shown as a gain to anyone not reading the colour. `portfolio-summary-header`'s local `signedDisplay` already did this correctly, so it moves to `money.ts` as `centsToSignedDisplay` and both call sites use it.
- `categories.icon` holds a Lucide icon name, not an emoji, so interpolating it printed `banknote Salary`. That was already true of the desktop category popover; both now render the name alone.

## Tests

The chip and filter-value derivation moves to a pure `lib/transaction-filter-chips.ts`, so the branchy part — which endpoints of a range are set, whether an id still resolves — is stated once instead of three times and is testable without a database. 15 tests there, 3 more on `centsToSignedDisplay`.

Colocated and DB-free, so unlike the files in #103 this is actually reachable by the mutation gate.

## Verification

Typecheck, lint, and 952/953 tests pass. Screenshots taken at 390 / 768 / 1024 / 1280px against the seeded demo household.

The one failing test, `investment-queries > returns dayChange from holdings_history`, fails identically on clean `main` — it pins a hardcoded date, the rot `CLAUDE.md` warns about. Not touched here.

## Not in scope

Converting the ledger from a CSS grid to a real `<table>`, the way Bills got in #128. Bigger change, wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)