### PR TITLE
fix(reports): stop the Spending tab crowning its own data-quality gaps

### DIFF
--- a/src/app/(dashboard)/reports/page.tsx
+++ b/src/app/(dashboard)/reports/page.tsx
@@ -82,12 +82,20 @@ export default async function ReportsPage({
   let sankeyData;
   let safeToSpendData;
   let cashFlowBarData;
+  let spendingTotalIncome;
 
   switch (tab) {
-    case "spending":
-      spendingData = await withHousehold(householdId, (tx) =>
-        getSpendingByCategory(householdId, filters, tx, compPeriod));
+    case "spending": {
+      // Income comes along for the share-of-income figure in the headline.
+      const [spending, income] = await Promise.all([
+        withHousehold(householdId, (tx) =>
+          getSpendingByCategory(householdId, filters, tx, compPeriod)),
+        withHousehold(householdId, (tx) => getIncomeVsExpense(householdId, filters, tx)),
+      ]);
+      spendingData = spending;
+      spendingTotalIncome = income.reduce((s, r) => s + r.income, 0);
       break;
+    }
     case "income-expense": {
       const [ie, ieCat] = await Promise.all([
         withHousehold(householdId, (tx) => getIncomeVsExpense(householdId, filters, tx)),
@@ -139,6 +147,7 @@ export default async function ReportsPage({
         cashFlowBarData={cashFlowBarData}
         safeToSpendData={safeToSpendData}
         comparisonLabel={compLabel}
+        spendingTotalIncome={spendingTotalIncome}
         dateFrom={dateFrom}
         dateTo={dateTo}
         accountIds={accountIds}

--- a/src/components/atoms/spending-chart.tsx
+++ b/src/components/atoms/spending-chart.tsx
@@ -19,13 +19,14 @@ interface SpendingChartProps {
   onItemClick?: (item: { id: string | null; name: string }) => void;
 }
 
-// The aggregated "Other" row (built below from categories past the top 8) is
-// not a real category — give it a fixed neutral color instead of cycling back
-// into CHART_COLORS, which would collide with an earlier slice's color. Real
-// uncategorized spend also carries a null id, so key off the synthetic flag
-// rather than the id to avoid recoloring legitimate rows.
+// Two rows take the neutral rather than a palette slot. "Other" (rolled up from
+// categories past the top 8) is not a real category, and cycling back into
+// CHART_COLORS would collide with an earlier slice. Uncategorized is not a
+// category either — it is the absence of one, and as the largest slice in most
+// households it was taking CHART_COLORS[0], the loudest blue, making "we do not
+// know" the visual hero of the chart.
 function colorAt(item: SpendingChartItem, i: number): string {
-  if (item.synthetic) return "var(--chart-neutral)";
+  if (item.synthetic || item.id === null) return "var(--chart-neutral)";
   return CHART_COLORS[i % CHART_COLORS.length];
 }
 

--- a/src/components/molecules/comparison-badge.tsx
+++ b/src/components/molecules/comparison-badge.tsx
@@ -1,4 +1,5 @@
 import { TrendingUp, TrendingDown, Minus } from "lucide-react";
+import { comparisonState } from "@/lib/comparison-state";
 
 interface ComparisonBadgeProps {
   current: number;
@@ -9,20 +10,25 @@ interface ComparisonBadgeProps {
 }
 
 export function ComparisonBadge({ current, previous, periodLabel, pill, invertColor }: ComparisonBadgeProps) {
-  if (previous === null || previous === 0) {
-    if (pill) {
-      return (
-        <span className="inline-flex items-center gap-1 text-xs text-muted-foreground rounded-full bg-muted px-2 py-0.5">
-          —
-        </span>
-      );
-    }
-    return null;
+  const state = comparisonState(current, previous);
+
+  // A category with no baseline row is new. It used to render as an empty cell,
+  // which read exactly like "no change".
+  if (state.kind === "new") {
+    return (
+      <span
+        className={`inline-flex items-center gap-1 text-xs text-muted-foreground${
+          pill ? " rounded-full bg-muted px-2 py-0.5" : ""
+        }`}
+      >
+        New
+      </span>
+    );
   }
 
-  const change = ((current - previous) / previous) * 100;
-  const isUp = change > 0;
-  const isFlat = Math.abs(change) < 0.5;
+  const change = state.percent;
+  const isUp = state.kind === "up";
+  const isFlat = state.kind === "flat";
 
   return (
     <span

--- a/src/components/molecules/date-range-popover.tsx
+++ b/src/components/molecules/date-range-popover.tsx
@@ -22,6 +22,12 @@ interface DateRangePopoverProps {
   active: boolean;
   /** Text shown after "Date:" on the trigger; null renders a bare "Date". */
   triggerValue: string | null;
+  /**
+   * The dates a named preset resolves to, shown in muted text beside it. A chip
+   * reading only "Last 3 months" never says which three months, and the
+   * resolved range appeared nowhere else on the page.
+   */
+  triggerDetail?: string | null;
   /** Current custom-range input values ("" when unset). */
   from: string;
   to: string;
@@ -42,6 +48,7 @@ export function DateRangePopover({
   selectedId,
   active,
   triggerValue,
+  triggerDetail,
   from,
   to,
   onSelectPreset,
@@ -66,6 +73,16 @@ export function DateRangePopover({
           <>
             <span className={cn("font-normal", active ? "opacity-70" : "text-muted-foreground")}>Date:</span>
             <span className="ml-1 max-w-[160px] truncate">{triggerValue}</span>
+            {triggerDetail && (
+              <span
+                className={cn(
+                  "ml-1.5 hidden truncate text-xs sm:inline",
+                  active ? "opacity-60" : "text-muted-foreground",
+                )}
+              >
+                {triggerDetail}
+              </span>
+            )}
           </>
         ) : (
           "Date"

--- a/src/components/organisms/report-filter-bar.tsx
+++ b/src/components/organisms/report-filter-bar.tsx
@@ -69,6 +69,15 @@ export function ReportFilterBar({ accounts, categories }: ReportFilterBarProps) 
     return null;
   })();
 
+  // A preset names a window without saying which one. Resolve it here so the
+  // chip prints the dates the report below it actually used.
+  const dateDetail = (() => {
+    if (!dateActive || !effectivePreset) return null;
+    const { from, to } = rangeToDateBounds(effectivePreset);
+    if (!from) return null;
+    return `${formatDateShort(from)} – ${formatDateShort(to)}`;
+  })();
+
   function handleDatePreset(id: string) {
     const { from, to } = rangeToDateBounds(id);
     updateFilters({ from, to, preset: id === "all" ? null : id });
@@ -95,6 +104,7 @@ export function ReportFilterBar({ accounts, categories }: ReportFilterBarProps) 
         selectedId={effectivePreset}
         active={dateActive}
         triggerValue={dateValue}
+        triggerDetail={dateDetail}
         from={fromParam ?? ""}
         to={toParam ?? ""}
         onSelectPreset={handleDatePreset}

--- a/src/components/organisms/report-spending.tsx
+++ b/src/components/organisms/report-spending.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { Wallet, Layers, Crown } from "lucide-react";
 import { CategoryIconTile } from "@/components/atoms/category-icon";
 import { ChartViewToggle } from "@/components/atoms/chart-view-toggle";
 import { SpendingChart } from "@/components/atoms/spending-chart";
-import { ReportSummaryBar, type SummaryItem } from "@/components/atoms/report-summary-bar";
 import { ComparisonBadge } from "@/components/molecules/comparison-badge";
 import { DrillDownSheet, type DrillDownFilter } from "@/components/organisms/drill-down-sheet";
 import {
@@ -19,6 +17,7 @@ import {
 import { centsToDisplay } from "@/lib/money";
 import { activateOnKey } from "@/lib/a11y";
 import { CHART_COLORS } from "@/lib/chart-colors";
+import { formatDateShort } from "@/lib/date-utils";
 import type { SpendingRow } from "@/queries/reports";
 
 interface ReportSpendingProps {
@@ -27,6 +26,8 @@ interface ReportSpendingProps {
   dateFrom: string;
   dateTo: string;
   accountIds?: string[];
+  /** Total income over the same range, for the share-of-income figure. */
+  totalIncome?: number;
 }
 
 export function ReportSpending({
@@ -35,8 +36,11 @@ export function ReportSpending({
   dateFrom,
   dateTo,
   accountIds,
+  totalIncome,
 }: ReportSpendingProps) {
-  const [view, setView] = useState<"donut" | "bar">("donut");
+  // Nine categories spanning three orders of magnitude is a size comparison,
+  // which bars read directly and a donut does not.
+  const [view, setView] = useState<"donut" | "bar">("bar");
   const [drillDown, setDrillDown] = useState<DrillDownFilter | null>(null);
 
   const chartData = data.map((r) => ({
@@ -46,14 +50,10 @@ export function ReportSpending({
   }));
 
   const totalSpent = data.reduce((s, r) => s + r.total, 0);
-  const topCategory = data.length > 0 ? data[0] : null;
-  const summaryItems: SummaryItem[] = [
-    { label: "Total Spent", value: totalSpent, color: "default", icon: Wallet },
-    { label: "Categories", value: data.length, format: "number", icon: Layers },
-    ...(topCategory
-      ? [{ label: `Top: ${topCategory.categoryName}`, value: topCategory.total, icon: Crown } as SummaryItem]
-      : []),
-  ];
+  const uncategorized = data.find((r) => r.categoryId === null)?.total ?? 0;
+  const categorized = totalSpent - uncategorized;
+  const shareOfIncome = totalIncome && totalIncome > 0 ? (totalSpent / totalIncome) * 100 : null;
+  const rangeLabel = `${formatDateShort(dateFrom)} – ${formatDateShort(dateTo)}`;
 
   function handleDrillDown(item: { id: string | null; name: string }) {
     // Keep the null: it means "uncategorized", not "every category".
@@ -66,7 +66,53 @@ export function ReportSpending({
 
   return (
     <div className="space-y-4">
-      <ReportSummaryBar items={summaryItems} />
+      {/* The old bar read Total Spent · Categories · Top: X. "Categories: 18" is
+          a number no decision turns on, and the crown landed on Uncategorized
+          whenever it was the largest line — a trophy for a data-quality gap.
+          What a reader needs instead is how much of the total is unaccounted
+          for, and what the total is measured against. */}
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="rounded-lg border p-4 lg:col-span-1">
+          <div className="text-xs text-muted-foreground">Total spent · {rangeLabel}</div>
+          <div className="mt-1 text-2xl font-semibold tabular-nums">{centsToDisplay(totalSpent)}</div>
+          {totalSpent > 0 && (
+            <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-1.5">
+                <span className="size-2 rounded-full" style={{ backgroundColor: CHART_COLORS[0] }} />
+                Categorized
+                <span className="tabular-nums text-foreground">{centsToDisplay(categorized)}</span>
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <span className="size-2 rounded-full" style={{ backgroundColor: "var(--chart-neutral)" }} />
+                Uncategorized
+                <span className="tabular-nums text-foreground">{centsToDisplay(uncategorized)}</span>
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-lg border p-4">
+          <div className="text-xs text-muted-foreground">Compared with</div>
+          <div className="mt-1 text-lg font-medium">
+            {compLabel ? compLabel.replace(/^vs\s+/, "") : "Nothing — showing all time"}
+          </div>
+          {compLabel && (
+            <div className="mt-1 text-xs text-muted-foreground">the preceding period, same length</div>
+          )}
+        </div>
+
+        <div className="rounded-lg border p-4">
+          <div className="text-xs text-muted-foreground">Share of income</div>
+          <div className="mt-1 text-lg font-medium tabular-nums">
+            {shareOfIncome === null ? "—" : `${shareOfIncome.toFixed(1)}%`}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {totalIncome && totalIncome > 0
+              ? `of ${centsToDisplay(totalIncome)} received`
+              : "no income recorded in this range"}
+          </div>
+        </div>
+      </div>
 
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-medium">Spending by Category</h3>
@@ -83,6 +129,7 @@ export function ReportSpending({
             <TableRow className="hover:bg-transparent text-muted-foreground">
               <TableHead className="h-auto px-3 py-2">Category</TableHead>
               <TableHead className="h-auto px-3 py-2 text-right">Amount</TableHead>
+              <TableHead className="h-auto px-3 py-2 text-right">% of total</TableHead>
               {compLabel && <TableHead className="h-auto px-3 py-2 text-right">Change</TableHead>}
             </TableRow>
           </TableHeader>
@@ -106,13 +153,20 @@ export function ReportSpending({
                   <div className="flex items-center gap-3">
                     <CategoryIconTile
                       name={row.categoryIcon}
+                      // Uncategorized takes the neutral here too, so the table
+                      // and the chart agree about what is and is not a category.
                       style={
-                        i < 8
+                        row.categoryId === null
                           ? {
-                              color: CHART_COLORS[i],
-                              backgroundColor: CHART_COLORS[i].replace(")", " / 0.12)"),
+                              color: "var(--chart-neutral)",
+                              backgroundColor: "color-mix(in oklab, var(--chart-neutral) 12%, transparent)",
                             }
-                          : undefined
+                          : i < 8
+                            ? {
+                                color: CHART_COLORS[i],
+                                backgroundColor: CHART_COLORS[i].replace(")", " / 0.12)"),
+                              }
+                            : undefined
                       }
                     />
                     <div className="min-w-0">
@@ -125,6 +179,9 @@ export function ReportSpending({
                 </TableCell>
                 <TableCell className="px-3 py-2 text-right tabular-nums font-medium">
                   {centsToDisplay(row.total)}
+                </TableCell>
+                <TableCell className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                  {totalSpent > 0 ? `${((row.total / totalSpent) * 100).toFixed(1)}%` : "—"}
                 </TableCell>
                 {compLabel && (
                   <TableCell className="px-3 py-2 text-right">

--- a/src/components/organisms/report-tabs.tsx
+++ b/src/components/organisms/report-tabs.tsx
@@ -46,6 +46,8 @@ interface ReportTabsProps {
   cashFlowBarData?: IncomeExpenseRow[];
   safeToSpendData?: SafeToSpendResult;
   comparisonLabel: string | null;
+  /** Income over the selected range — the Spending tab's share-of-income figure. */
+  spendingTotalIncome?: number;
   /**
    * The range the figures on screen were actually computed over. Passed down
    * rather than re-read from the URL, so a drill-down can never query a
@@ -69,6 +71,7 @@ export function ReportTabs({
   cashFlowBarData,
   safeToSpendData,
   comparisonLabel,
+  spendingTotalIncome,
   dateFrom,
   dateTo,
   accountIds,
@@ -109,6 +112,7 @@ export function ReportTabs({
           <ReportSpending
             data={spendingData}
             comparisonLabel={comparisonLabel}
+            totalIncome={spendingTotalIncome}
             dateFrom={dateFrom}
             dateTo={dateTo}
             accountIds={accountIds}

--- a/src/lib/comparison-state.test.ts
+++ b/src/lib/comparison-state.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "vitest";
+import { comparisonState } from "./comparison-state";
+
+describe("comparisonState", () => {
+  test("a category absent from the baseline is new, not unchanged", () => {
+    // Both used to render as an empty cell, so "we have never seen this before"
+    // and "it did not move" looked identical in the Change column.
+    expect(comparisonState(5_000, null)).toEqual({ kind: "new" });
+  });
+
+  test("a baseline of zero is also new — there was nothing to grow from", () => {
+    expect(comparisonState(5_000, 0)).toEqual({ kind: "new" });
+  });
+
+  test("spending that went up", () => {
+    expect(comparisonState(150_00, 100_00)).toEqual({ kind: "up", percent: 50 });
+  });
+
+  test("spending that came down", () => {
+    expect(comparisonState(50_00, 100_00)).toEqual({ kind: "down", percent: -50 });
+  });
+
+  test("a move under half a percent reads as flat", () => {
+    expect(comparisonState(100_30, 100_00)).toEqual({ kind: "flat", percent: 0.3 });
+    expect(comparisonState(100_00, 100_00)).toEqual({ kind: "flat", percent: 0 });
+  });
+
+  test("half a percent is a move, not flat", () => {
+    expect(comparisonState(100_50, 100_00).kind).toBe("up");
+  });
+
+  test("a category that spent nothing this period against a real baseline", () => {
+    expect(comparisonState(0, 100_00)).toEqual({ kind: "down", percent: -100 });
+  });
+});

--- a/src/lib/comparison-state.ts
+++ b/src/lib/comparison-state.ts
@@ -1,0 +1,24 @@
+export type ComparisonState =
+  | { kind: "new" }
+  | { kind: "flat"; percent: number }
+  | { kind: "up"; percent: number }
+  | { kind: "down"; percent: number };
+
+/** Below this, a move is noise rather than a trend. */
+const FLAT_THRESHOLD_PERCENT = 0.5;
+
+/**
+ * How this period compares with the baseline.
+ *
+ * A missing or zero baseline is reported as `new` rather than folded in with
+ * "no change": the Change column used to render an empty cell for both, so a
+ * category appearing for the first time was indistinguishable from one that had
+ * not moved.
+ */
+export function comparisonState(current: number, previous: number | null): ComparisonState {
+  if (previous === null || previous === 0) return { kind: "new" };
+
+  const percent = ((current - previous) / previous) * 100;
+  if (Math.abs(percent) < FLAT_THRESHOLD_PERCENT) return { kind: "flat", percent };
+  return { kind: percent > 0 ? "up" : "down", percent };
+}

--- a/src/lib/mcp/tools/reports.ts
+++ b/src/lib/mcp/tools/reports.ts
@@ -39,8 +39,11 @@ export function registerReportTools(server: McpServer, householdId: string) {
           groupId: r.groupId,
           totalCents: r.total,
           totalDisplay: centsToDisplay(r.total),
+          // null means the category has no baseline row at all — new, rather
+          // than unchanged. Reporting it as 0 would let a consumer compute a
+          // change against a period the category was not in.
           prevTotalCents: r.prevTotal,
-          prevTotalDisplay: centsToDisplay(r.prevTotal),
+          prevTotalDisplay: r.prevTotal === null ? null : centsToDisplay(r.prevTotal),
         })),
       );
     },

--- a/src/queries/reports.ts
+++ b/src/queries/reports.ts
@@ -37,7 +37,12 @@ export interface SpendingRow {
   groupId: string | null;
   categoryIcon: string | null;
   total: number;
-  prevTotal: number;
+  /**
+   * The same category's spending in the comparison period, or `null` when the
+   * category has no baseline row — it is new, which is not the same as
+   * unchanged. `null` also when no comparison period was requested.
+   */
+  prevTotal: number | null;
 }
 
 export interface IncomeExpenseRow {
@@ -66,7 +71,7 @@ export async function getSpendingByCategory(
   const currentSpending = await aggregateSpending(householdId, filters, db);
   const enriched = await enrichSpendingMap(currentSpending, db);
 
-  let prevMap = new Map<string, number>();
+  let prevMap: Map<string, number> | null = null;
   if (comparisonPeriod) {
     prevMap = await aggregateSpending(householdId, { ...filters, ...comparisonPeriod }, db);
   }
@@ -78,7 +83,7 @@ export async function getSpendingByCategory(
     groupId: row.groupId,
     categoryIcon: row.categoryIcon,
     total: row.value,
-    prevTotal: prevMap.get(row.id ?? "uncategorized") ?? 0,
+    prevTotal: prevMap?.get(row.id ?? "uncategorized") ?? null,
   }));
 }
 

--- a/tests/integration/report-drill-down.test.ts
+++ b/tests/integration/report-drill-down.test.ts
@@ -181,3 +181,32 @@ describe("an income drill-down explains its own figure", () => {
     expect(drill.rows.map((r) => r.name).sort()).toEqual(["Bonus", "Salary"]);
   });
 });
+
+describe("a category's comparison against the baseline", () => {
+  test("a category absent from the baseline reports no previous figure, not zero", async () => {
+    // Food spends in both periods; Salary's category is irrelevant here — what
+    // matters is that a category with no baseline row is distinguishable from
+    // one that spent nothing, which `?? 0` made impossible.
+    await insertTransaction(db, householdId, accountId, { date: "2026-03-05", normalizedAmount: -5000, amount: 5000, categoryId: foodCatId, name: "Grocery" });
+    await insertTransaction(db, householdId, accountId, { date: "2026-02-10", normalizedAmount: -2000, amount: 2000, categoryId: foodCatId, name: "Grocery last period" });
+    await insertTransaction(db, householdId, accountId, { date: "2026-03-06", normalizedAmount: -3000, amount: 3000, categoryId: null, name: "First ever uncategorized" });
+    const { getSpendingByCategory } = await import("../../src/queries/reports");
+
+    const rows = await getSpendingByCategory(householdId, RANGE, db, {
+      dateFrom: "2026-02-01",
+      dateTo: "2026-02-28",
+    });
+
+    expect(rows.find((r) => r.categoryName === "Food")?.prevTotal).toBe(2000);
+    expect(rows.find((r) => r.categoryId === null)?.prevTotal).toBeNull();
+  });
+
+  test("without a comparison period nothing claims a previous figure", async () => {
+    await insertTransaction(db, householdId, accountId, { date: "2026-03-05", normalizedAmount: -5000, amount: 5000, categoryId: foodCatId, name: "Grocery" });
+    const { getSpendingByCategory } = await import("../../src/queries/reports");
+
+    const rows = await getSpendingByCategory(householdId, RANGE, db);
+
+    expect(rows.every((r) => r.prevTotal === null)).toBe(true);
+  });
+});


### PR DESCRIPTION
The **information design** third of #147, built to your [Spending tab mock](https://claude.ai/code/artifact/9ed146ee-85de-4a73-8075-7c39fcca43d5). Completes the issue.

**Stacked on #153 → #152 → #151 → #150.**

## The summary bar celebrated the wrong things

`Total Spent · Categories · Top: X`. "Categories: 18" is a number no decision turns on, and `topCategory = data[0]` took the largest row blindly — so whenever Uncategorized was largest, which is the usual case, the page put a **crown on the spending it had failed to identify**.

Three tiles replace it, per the mock:

| | |
|---|---|
| **Total spent · Jun 2 – Sep 2** | the figure, split into `● Categorized` / `● Uncategorized` |
| **Compared with** | `Mar 2 – Jun 2` · the preceding period, same length |
| **Share of income** | `73.8%` of $23,100.00 received |

The split states the unaccounted-for share instead of decorating it.

## Uncategorized was the loudest colour on the page

It drew `CHART_COLORS[0]`, the most saturated blue. It takes `--chart-neutral` now — the treatment the synthetic "Other" slice already had — in the chart and in the table's category tile. Uncategorized is not a category, it's the absence of one, and shouldn't look like the hero.

**Bar is the default view.** Nine categories spanning three orders of magnitude is a size comparison; bars read it directly.

## A blank Change cell meant two different things

`prevTotal` defaulted to `0` for a category with no baseline row, and `ComparisonBadge` rendered nothing for zero — so *"this category is new"* and *"this category didn't move"* were the same empty cell.

`prevTotal` is `number | null` now (null when there's no baseline row, and null throughout when no comparison period was requested), and the badge renders **New**. The MCP tool reports null rather than 0 for the same reason: a consumer shouldn't be able to compute a change against a period the category wasn't in.

## The resolved range appeared nowhere

The chip said "Last 3 months" and the actual dates were on no part of the page. It prints them: `Date: Last 3 months  Jun 2 – Sep 2`.

Also added a **% of total** column, so a row's share is readable without dividing by the headline.

## Tests

- `src/lib/comparison-state.test.ts` — 7 tests: a null baseline is new, a zero baseline is new, up / down / flat, the half-percent boundary, and a category that spent nothing against a real baseline (−100%, not "new").
- `tests/integration/report-drill-down.test.ts` — 2 added: a category absent from the baseline reports `null` while one present reports its figure; with no comparison period nothing claims a previous figure.

Full suite: 1095 passed, 1 failed — the pre-existing `investment-queries` date rot.

## Verification

Inserted a temporary uncategorized charge and a charge in a category with no baseline, then read the live page:

- Uncategorized — `$3,200.00 · 18.8% · New`, bar fill `var(--chart-neutral)`
- Property Tax — `$450.00 · 2.6% · New`
- Headline — `$17,055.33`, split `$13,855.33` categorized / `$3,200.00` uncategorized, `73.8%` of `$23,100.00`

Rows removed afterwards.

## Not built

The mock also proposes a **"Data issues in this range"** panel (uncategorized count with a link to categorize, categories that net positive and so vanish from spending, transfers miscategorized as spending). That's a new feature rather than information design and sits outside what #147 lists — worth its own issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)