### PR TITLE
Use the shadcn components we already have (charts, search fields, budget toggle)

### DIFF
--- a/src/components/atoms/cash-flow-bar-chart.tsx
+++ b/src/components/atoms/cash-flow-bar-chart.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts";
+import { ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
 import { centsToDisplay, centsToCompact } from "@/lib/money";
 import { formatMonthShort } from "@/lib/date-utils";
 import { INCOME_COLOR, SPENDING_COLOR, PRIMARY_COLOR } from "@/lib/chart-colors";
@@ -10,6 +18,12 @@ interface CashFlowBarChartProps {
   data: CashFlowRow[];
   showTrendline?: boolean;
 }
+
+const chartConfig = {
+  income: { label: "Income", color: INCOME_COLOR },
+  expenses: { label: "Spending", color: SPENDING_COLOR },
+  net: { label: "Net", color: PRIMARY_COLOR },
+} satisfies ChartConfig;
 
 export function CashFlowBarChart({ data, showTrendline = false }: CashFlowBarChartProps) {
   if (data.length === 0) {
@@ -21,7 +35,9 @@ export function CashFlowBarChart({ data, showTrendline = false }: CashFlowBarCha
   }
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    // Every caller sizes this chart with an explicit-height parent, so fill it
+    // rather than taking ChartContainer's default 16:9 aspect ratio.
+    <ChartContainer config={chartConfig} className="aspect-auto h-full w-full">
       <ComposedChart data={data} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
         <CartesianGrid vertical={false} stroke="var(--border)" />
         <XAxis
@@ -39,25 +55,28 @@ export function CashFlowBarChart({ data, showTrendline = false }: CashFlowBarCha
           tickLine={false}
           tickCount={4}
         />
-        <Tooltip
-          formatter={(v) => centsToDisplay(Number(v))}
-          labelFormatter={(label) => formatMonthShort(String(label))}
+        <ChartTooltip
           cursor={{ fill: "var(--muted)", opacity: 0.4 }}
+          content={
+            <ChartTooltipContent
+              labelFormatter={(label) => formatMonthShort(String(label))}
+              valueFormatter={(v) => centsToDisplay(Number(v))}
+            />
+          }
         />
-        <Legend iconType="circle" iconSize={8} wrapperStyle={{ fontSize: 12 }} />
-        <Bar dataKey="income" name="Income" fill={INCOME_COLOR} radius={[4, 4, 0, 0]} maxBarSize={24} />
-        <Bar dataKey="expenses" name="Spending" fill={SPENDING_COLOR} radius={[4, 4, 0, 0]} maxBarSize={24} />
+        <ChartLegend content={<ChartLegendContent />} />
+        <Bar dataKey="income" fill="var(--color-income)" radius={[4, 4, 0, 0]} maxBarSize={24} />
+        <Bar dataKey="expenses" fill="var(--color-expenses)" radius={[4, 4, 0, 0]} maxBarSize={24} />
         {showTrendline && (
           <Line
             type="monotone"
             dataKey="net"
-            name="Net"
-            stroke={PRIMARY_COLOR}
+            stroke="var(--color-net)"
             strokeWidth={2}
             dot={false}
           />
         )}
       </ComposedChart>
-    </ResponsiveContainer>
+    </ChartContainer>
   );
 }

--- a/src/components/atoms/net-worth-area-chart.tsx
+++ b/src/components/atoms/net-worth-area-chart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import {
   ComposedChart,
   Area,
@@ -7,12 +8,17 @@ import {
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip,
   ReferenceArea,
   ReferenceLine,
-  ResponsiveContainer,
-  Legend,
 } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
 import { centsToDisplay, centsToCompact, axisTickFormatter } from "@/lib/money";
 import { formatDateShort } from "@/lib/date-utils";
 import { INCOME_COLOR, EXPENSE_COLOR, POSITIVE_COLOR, UNCOVERED_COLOR } from "@/lib/chart-colors";
@@ -36,31 +42,26 @@ interface NetWorthAreaChartProps {
   seriesName?: string;
 }
 
-interface TooltipEntry {
-  name: string;
-  value: number;
-  color: string;
-}
-
 const AXIS_TICK = { fontSize: 11, fill: "var(--muted-foreground)" };
 
-function CustomTooltip({ active, payload, label }: { active?: boolean; payload?: TooltipEntry[]; label?: string }) {
-  if (!active || !payload?.length) return null;
-  // The split single-mode series leaves one key null on either side of the
-  // coverage boundary; Recharts still reports it, so drop the empty half
-  // rather than rendering the same date twice.
-  const entries = payload.filter((e) => e.value !== null && e.value !== undefined);
-  if (entries.length === 0) return null;
-  return (
-    <div className="rounded-md border bg-popover px-3 py-2 text-sm shadow-md">
-      <p className="font-medium">{formatDateShort(label ?? "")}</p>
-      {entries.map((entry: TooltipEntry) => (
-        <p key={entry.name} className="tabular-nums" style={{ color: entry.color }}>
-          {entry.name}: {centsToDisplay(entry.value)}
-        </p>
-      ))}
-    </div>
-  );
+const MULTI_CONFIG = {
+  netWorth: { label: "Net Worth", color: POSITIVE_COLOR },
+  assets: { label: "Assets", color: INCOME_COLOR },
+  liabilities: { label: "Liabilities", color: EXPENSE_COLOR },
+} satisfies ChartConfig;
+
+/**
+ * The split single-mode series leaves one key null on either side of the
+ * coverage boundary; Recharts still reports it, so drop the empty half rather
+ * than rendering the same date twice with a blank value.
+ */
+function DenseTooltipContent({
+  payload,
+  ...props
+}: React.ComponentProps<typeof ChartTooltipContent>) {
+  const entries = payload?.filter((e) => e.value !== null && e.value !== undefined);
+  if (!entries?.length) return null;
+  return <ChartTooltipContent {...props} payload={entries} />;
 }
 
 export function NetWorthAreaChart({ data, mode = "multi", seriesName = "Value" }: NetWorthAreaChartProps) {
@@ -95,8 +96,16 @@ export function NetWorthAreaChart({ data, mode = "multi", seriesName = "Value" }
       };
     });
 
+    const singleConfig: ChartConfig = {
+      covered: { label: seriesName, color: POSITIVE_COLOR },
+      partial: {
+        label: boundary.hasPartial ? "Tracked accounts only" : seriesName,
+        color: boundary.hasPartial ? UNCOVERED_COLOR : POSITIVE_COLOR,
+      },
+    };
+
     return (
-      <ResponsiveContainer width="100%" height="100%">
+      <ChartContainer config={singleConfig} className="aspect-auto h-full w-full">
         <ComposedChart data={split} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
           <defs>
             <linearGradient id="portfolioGradient" x1="0" y1="0" x2="0" y2="1">
@@ -118,7 +127,14 @@ export function NetWorthAreaChart({ data, mode = "multi", seriesName = "Value" }
             tickCount={4}
             domain={["auto", "auto"]}
           />
-          <Tooltip content={<CustomTooltip />} />
+          <ChartTooltip
+            content={
+              <DenseTooltipContent
+                labelFormatter={(label) => formatDateShort(String(label))}
+                valueFormatter={(v) => centsToDisplay(Number(v))}
+              />
+            }
+          />
           {boundary.hasPartial && boundary.date && (
             <ReferenceArea
               x1={points[0].date}
@@ -134,29 +150,27 @@ export function NetWorthAreaChart({ data, mode = "multi", seriesName = "Value" }
           <Area
             type="monotone"
             dataKey="covered"
-            name={seriesName}
             fill="url(#portfolioGradient)"
-            stroke={POSITIVE_COLOR}
+            stroke="var(--color-covered)"
             strokeWidth={2}
             connectNulls={false}
           />
           <Line
             type="monotone"
             dataKey="partial"
-            name={boundary.hasPartial ? "Tracked accounts only" : seriesName}
-            stroke={boundary.hasPartial ? UNCOVERED_COLOR : POSITIVE_COLOR}
+            stroke="var(--color-partial)"
             strokeWidth={boundary.hasPartial ? 1.75 : 2}
             strokeDasharray={boundary.hasPartial ? "5 4" : undefined}
             dot={false}
             connectNulls={false}
           />
         </ComposedChart>
-      </ResponsiveContainer>
+      </ChartContainer>
     );
   }
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    <ChartContainer config={MULTI_CONFIG} className="aspect-auto h-full w-full">
       <ComposedChart data={data as unknown as ChartDataPoint[]} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
         <defs>
           <linearGradient id="netWorthGradient" x1="0" y1="0" x2="0" y2="1">
@@ -175,21 +189,27 @@ export function NetWorthAreaChart({ data, mode = "multi", seriesName = "Value" }
           tickCount={4}
           domain={["auto", "auto"]}
         />
-        <Tooltip content={<CustomTooltip />} />
+        <ChartTooltip
+          content={
+            <DenseTooltipContent
+              labelFormatter={(label) => formatDateShort(String(label))}
+              valueFormatter={(v) => centsToDisplay(Number(v))}
+            />
+          }
+        />
         {/* Three series identified by colour alone, and only on hover, until
             this. A legend is not optional past one series. */}
-        <Legend wrapperStyle={{ fontSize: 12 }} />
+        <ChartLegend content={<ChartLegendContent />} />
         <Area
           type="monotone"
           dataKey="netWorth"
-          name="Net Worth"
           fill="url(#netWorthGradient)"
-          stroke={POSITIVE_COLOR}
+          stroke="var(--color-netWorth)"
           strokeWidth={2}
         />
-        <Line type="monotone" dataKey="assets" name="Assets" stroke={INCOME_COLOR} strokeWidth={1.5} dot={false} strokeDasharray="4 3" />
-        <Line type="monotone" dataKey="liabilities" name="Liabilities" stroke={EXPENSE_COLOR} strokeWidth={1.5} dot={false} />
+        <Line type="monotone" dataKey="assets" stroke="var(--color-assets)" strokeWidth={1.5} dot={false} strokeDasharray="4 3" />
+        <Line type="monotone" dataKey="liabilities" stroke="var(--color-liabilities)" strokeWidth={1.5} dot={false} />
       </ComposedChart>
-    </ResponsiveContainer>
+    </ChartContainer>
   );
 }

--- a/src/components/atoms/spending-chart.tsx
+++ b/src/components/atoms/spending-chart.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip } from "recharts";
+import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
 import { centsToDisplay } from "@/lib/money";
 import { activateOnKey } from "@/lib/a11y";
 import { CHART_COLORS } from "@/lib/chart-colors";
@@ -25,6 +31,10 @@ interface SpendingChartProps {
 // category either — it is the absence of one, and as the largest slice in most
 // households it was taking CHART_COLORS[0], the loudest blue, making "we do not
 // know" the visual hero of the chart.
+// In bar mode every row is the same series, so the row label names the measure
+// and the tooltip header carries the category.
+const BAR_CONFIG: ChartConfig = { value: { label: "Amount" } };
+
 function colorAt(item: SpendingChartItem, i: number): string {
   if (item.synthetic || item.id === null) return "var(--chart-neutral)";
   return CHART_COLORS[i % CHART_COLORS.length];
@@ -56,10 +66,17 @@ export function SpendingChart({ data, viewMode, onItemClick }: SpendingChartProp
   }
 
   if (viewMode === "donut") {
+    // Slices are user categories, so their names are the series keys — they
+    // carry spaces and ampersands and cannot be emitted as `--color-<key>`
+    // custom properties. The config names each slice; `Cell` keeps the colour.
+    const donutConfig: ChartConfig = Object.fromEntries(
+      chartData.map((item) => [item.name, { label: item.name }]),
+    );
+
     return (
       <div className="flex gap-3 h-full">
         <div className="w-2/5 shrink-0">
-          <ResponsiveContainer width="100%" height="100%">
+          <ChartContainer config={donutConfig} className="aspect-auto h-full w-full">
             <PieChart>
               <Pie
                 data={chartData}
@@ -76,9 +93,13 @@ export function SpendingChart({ data, viewMode, onItemClick }: SpendingChartProp
                   <Cell key={i} fill={colorAt(item, i)} />
                 ))}
               </Pie>
-              <Tooltip formatter={(v) => centsToDisplay(Number(v))} />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent hideLabel valueFormatter={(v) => centsToDisplay(Number(v))} />
+                }
+              />
             </PieChart>
-          </ResponsiveContainer>
+          </ChartContainer>
         </div>
         <div className="w-3/5 overflow-y-auto overflow-x-hidden">
           {chartData.map((row, i) => (
@@ -97,7 +118,7 @@ export function SpendingChart({ data, viewMode, onItemClick }: SpendingChartProp
   }
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    <ChartContainer config={BAR_CONFIG} className="aspect-auto h-full w-full">
       <BarChart data={chartData} layout="vertical" margin={{ left: 80 }}>
         <XAxis
           type="number"
@@ -105,7 +126,9 @@ export function SpendingChart({ data, viewMode, onItemClick }: SpendingChartProp
           tick={{ fontSize: 11 }}
         />
         <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={75} />
-        <Tooltip formatter={(v) => centsToDisplay(Number(v))} />
+        <ChartTooltip
+          content={<ChartTooltipContent valueFormatter={(v) => centsToDisplay(Number(v))} />}
+        />
         <Bar
           dataKey="value"
           onClick={(_, index) => handleClick(index)}
@@ -116,7 +139,7 @@ export function SpendingChart({ data, viewMode, onItemClick }: SpendingChartProp
           ))}
         </Bar>
       </BarChart>
-    </ResponsiveContainer>
+    </ChartContainer>
   );
 }
 

--- a/src/components/atoms/trend-line-chart.tsx
+++ b/src/components/atoms/trend-line-chart.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend, LabelList } from "recharts";
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, LabelList } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
 import { centsToDisplay } from "@/lib/money";
 import { formatMonthShort } from "@/lib/date-utils";
 
@@ -40,9 +48,16 @@ export function TrendLineChart({ data, categories: cats }: TrendLineChartProps) 
   }
 
   const lastIndex = data.length - 1;
+  // Categories are user data, so their names are the series keys. They carry
+  // spaces and ampersands, which would not survive being emitted as
+  // `--color-<key>` custom properties — so the config names the series and the
+  // stroke stays inline.
+  const chartConfig: ChartConfig = Object.fromEntries(
+    cats.map((cat) => [cat.name, { label: cat.name }]),
+  );
 
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    <ChartContainer config={chartConfig} className="aspect-auto h-full w-full">
       <LineChart data={data} margin={{ top: 5, right: LABEL_GUTTER, bottom: 5, left: 5 }}>
         <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
         <XAxis dataKey="period" tickFormatter={formatMonthShort} tick={{ fontSize: 11 }} />
@@ -51,8 +66,15 @@ export function TrendLineChart({ data, categories: cats }: TrendLineChartProps) 
           tick={{ fontSize: 11 }}
           width={60}
         />
-        <Tooltip formatter={(v) => centsToDisplay(Number(v))} labelFormatter={(l) => formatMonthShort(String(l))} />
-        <Legend />
+        <ChartTooltip
+          content={
+            <ChartTooltipContent
+              labelFormatter={(l) => formatMonthShort(String(l))}
+              valueFormatter={(v) => centsToDisplay(Number(v))}
+            />
+          }
+        />
+        <ChartLegend content={<ChartLegendContent />} />
         {cats.map((cat) => (
           <Line
             key={cat.name}
@@ -72,6 +94,6 @@ export function TrendLineChart({ data, categories: cats }: TrendLineChartProps) 
           </Line>
         ))}
       </LineChart>
-    </ResponsiveContainer>
+    </ChartContainer>
   );
 }

--- a/src/components/molecules/bill-search.tsx
+++ b/src/components/molecules/bill-search.tsx
@@ -3,7 +3,11 @@
 import { useCallback, useRef, useState } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { Search } from "lucide-react";
-import { Input } from "@/components/ui/input";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
 
 export function BillSearch() {
   const router = useRouter();
@@ -32,14 +36,15 @@ export function BillSearch() {
   }
 
   return (
-    <div className="relative w-[240px]">
-      <Search className="absolute left-2.5 top-2 h-4 w-4 text-muted-foreground" />
-      <Input
+    <InputGroup className="w-[240px]">
+      <InputGroupAddon>
+        <Search />
+      </InputGroupAddon>
+      <InputGroupInput
         placeholder="Search bills..."
         value={value}
         onChange={(e) => handleChange(e.target.value)}
-        className="pl-8 h-8"
       />
-    </div>
+    </InputGroup>
   );
 }

--- a/src/components/organisms/budget-page-header.tsx
+++ b/src/components/organisms/budget-page-header.tsx
@@ -4,9 +4,14 @@ import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Copy } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { BudgetMonthNav } from "@/components/molecules/budget-month-nav";
 import { updateBudgetType, copyBudgetFromMonth } from "@/actions/budgets";
-import { cn } from "@/lib/utils";
+
+const BUDGET_TYPES = [
+  { value: "category", label: "Category" },
+  { value: "flex", label: "Flex" },
+] as const;
 
 interface BudgetPageHeaderProps {
   month: string;
@@ -26,8 +31,12 @@ export function BudgetPageHeader({
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
 
-  function handleTypeToggle(type: "category" | "flex") {
-    if (!budgetId || type === budgetType) return;
+  // Base UI models a toggle group as an array even when only one item can be
+  // active, and hands back an empty array when the active item is clicked
+  // again. Ignoring anything that isn't a budget type keeps one option selected.
+  function handleTypeToggle(groupValue: string[]) {
+    const type = groupValue[0];
+    if (!budgetId || (type !== "category" && type !== "flex") || type === budgetType) return;
     startTransition(async () => {
       await updateBudgetType(budgetId, type);
       router.refresh();
@@ -49,32 +58,29 @@ export function BudgetPageHeader({
       </div>
       <div className="flex items-center gap-2">
         {budgetId && (
-          <div className="flex rounded-lg border p-0.5">
-            <button
-              onClick={() => handleTypeToggle("category")}
-              disabled={isPending}
-              className={cn(
-                "rounded-md px-3 py-1 text-xs font-medium transition-colors",
-                budgetType === "category"
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              Category
-            </button>
-            <button
-              onClick={() => handleTypeToggle("flex")}
-              disabled={isPending}
-              className={cn(
-                "rounded-md px-3 py-1 text-xs font-medium transition-colors",
-                budgetType === "flex"
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              Flex
-            </button>
-          </div>
+          <ToggleGroup
+            value={[budgetType]}
+            onValueChange={handleTypeToggle}
+            variant="outline"
+            size="sm"
+            spacing={1}
+            aria-label="Budget type"
+          >
+            {BUDGET_TYPES.map(({ value, label }) => (
+              <ToggleGroupItem
+                key={value}
+                value={value}
+                disabled={isPending}
+                // The shared toggle marks the active item with `bg-muted`, which
+                // is too close to the page ground to read as selected on a
+                // control whose whole job is showing which option is active.
+                // Same override the appearance toggle uses.
+                className="aria-pressed:bg-primary aria-pressed:text-primary-foreground aria-pressed:hover:bg-primary"
+              >
+                {label}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
         )}
         {hasPreviousMonthBudget && budgetId && (
           <Button

--- a/src/components/organisms/transaction-filters.tsx
+++ b/src/components/organisms/transaction-filters.tsx
@@ -18,6 +18,11 @@ import { cn } from "@/lib/utils";
 import { useSearchParamFilters } from "@/hooks/use-search-param-filters";
 import { useAmountFilter } from "@/hooks/use-amount-filter";
 import { Input } from "@/components/ui/input";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -313,16 +318,18 @@ export function TransactionFilters({ accounts, categories, resultCount }: Transa
     <div className="space-y-3">
       {/* Row 1: search + export */}
       <div className="flex items-center gap-2">
-        <div className="relative flex-1 sm:flex-none">
-          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
+        <InputGroup className="h-9 flex-1 sm:flex-none sm:w-[280px]">
+          <InputGroupAddon>
+            <Search />
+          </InputGroupAddon>
+          <InputGroupInput
             placeholder="Search transactions..."
             aria-label="Search transactions"
             value={searchValue}
             onChange={(e) => handleSearchChange(e.target.value)}
-            className="h-9 w-full pl-8 text-sm sm:w-[280px]"
+            className="text-sm"
           />
-        </div>
+        </InputGroup>
 
         <a
           href={`/api/export/transactions?${searchParams.toString()}`}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,0 +1,384 @@
+"use client"
+
+import * as React from "react"
+import { cn } from "@/lib/utils"
+import * as RechartsPrimitive from "recharts"
+import type { TooltipValueType } from "recharts"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+const INITIAL_DIMENSION = { width: 320, height: 200 } as const
+type TooltipNameType = number | string
+
+export type ChartConfig = Record<
+  string,
+  {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+>
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  initialDimension = INITIAL_DIMENSION,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"]
+  initialDimension?: {
+    width: number
+    height: number
+  }
+}) {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id ?? uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer
+          initialDimension={initialDimension}
+        >
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme ?? config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ??
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+  valueFormatter,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean
+    hideIndicator?: boolean
+    indicator?: "line" | "dot" | "dashed"
+    nameKey?: string
+    labelKey?: string
+    /**
+     * Formats the value only, leaving the indicator and series name intact.
+     * Recharts' `formatter` replaces the entire row, which drops both.
+     */
+    valueFormatter?: (value: TooltipValueType) => React.ReactNode
+  } & Omit<
+    RechartsPrimitive.DefaultTooltipContentProps<
+      TooltipValueType,
+      TooltipNameType
+    >,
+    "accessibilityLayer"
+  >) {
+  const { config } = useChart()
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null
+    }
+
+    const [item] = payload
+    const key = `${labelKey ?? item?.dataKey ?? item?.name ?? "value"}`
+    const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const value =
+      !labelKey && typeof label === "string"
+        ? (config[label]?.label ?? label)
+        : itemConfig?.label
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      )
+    }
+
+    if (!value) {
+      return null
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ])
+
+  if (!active || !payload?.length) {
+    return null
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot"
+
+  return (
+    <div
+      className={cn(
+        "grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+        className
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload
+          .filter((item) => item.type !== "none")
+          .map((item, index) => {
+            const key = `${nameKey ?? item.name ?? item.dataKey ?? "value"}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+            const indicatorColor = color ?? item.payload?.fill ?? item.color
+
+            return (
+              <div
+                key={index}
+                className={cn(
+                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                  indicator === "dot" && "items-center"
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            }
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center"
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label ?? item.name}
+                        </span>
+                      </div>
+                      {item.value != null && (
+                        <span className="font-mono font-medium text-foreground tabular-nums">
+                          {formatTooltipValue(item.value, valueFormatter)}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )
+          })}
+      </div>
+    </div>
+  )
+}
+
+const ChartLegend = RechartsPrimitive.Legend
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> & {
+  hideIcon?: boolean
+  nameKey?: string
+} & RechartsPrimitive.DefaultLegendContentProps) {
+  const { config } = useChart()
+
+  if (!payload?.length) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className
+      )}
+    >
+      {payload
+        .filter((item) => item.type !== "none")
+        .map((item, index) => {
+          const key = `${nameKey ?? item.dataKey ?? "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+          return (
+            <div
+              key={index}
+              className={cn(
+                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          )
+        })}
+    </div>
+  )
+}
+
+function formatTooltipValue(
+  value: TooltipValueType,
+  valueFormatter?: (value: TooltipValueType) => React.ReactNode
+) {
+  if (valueFormatter) return valueFormatter(value)
+  return typeof value === "number" ? value.toLocaleString() : String(value)
+}
+
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config ? config[configLabelKey] : config[key]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}


### PR DESCRIPTION
An audit of where the codebase hand-rolls UI that shadcn/ui already provides. The library turns out to be used well overall — 24 of 27 installed components have consumers, there is exactly one raw `<input>` and no raw `<select>` — so this PR takes only the three clearest gaps.

## 1. `chart` was never installed, and it was costing us a dark-mode bug

`spending-chart.tsx` passed Recharts' bare `<Tooltip>` in both donut and bar mode. That renders a hardcoded white box with dark text, which is unreadable against a dark background. `net-worth-area-chart.tsx` had already hand-rolled a `CustomTooltip` to route around the same problem, and CLAUDE.md has described the stack as "Recharts v3 (via shadcn Chart)" the whole time — the component itself was just missing.

All four charts now render inside `ChartContainer` with `ChartTooltip` / `ChartLegendContent`, and series labels come from `ChartConfig` rather than per-series `name` props, so legend and tooltip can't drift apart.

Two deliberate local edits to the generated `ui/chart.tsx`, both commented in the file:

- The shadcn CLI emits `import { cn } from "cn"` and tries to add an npm package by that name. Repointed at `@/lib/utils`.
- Added a `valueFormatter` prop. Every value this app charts is an integer cent count, and upstream renders values with `toLocaleString()` — `123,456` where `$1,234.56` belongs. Recharts' own `formatter` can't be used for this: it replaces the entire tooltip row, taking the colour indicator and series name with it.

Category-keyed charts keep inline colours on purpose. Category names are user data (`Groceries & Dining`), and those can't be emitted as `--color-<key>` custom properties.

The net worth chart keeps a five-line wrapper for the one thing `ChartTooltipContent` doesn't do: dropping the null half of the split coverage series, which would otherwise print the same date twice.

## 2. `input-group` was installed with zero consumers

`bill-search.tsx` and `transaction-filters.tsx` both positioned their magnifier by hand — a `relative` wrapper, an `absolute` icon, matching `pl-8` on the input. Now `InputGroup` / `InputGroupAddon` / `InputGroupInput`. Small a11y gain: the addon focuses the input when clicked, which the old `pointer-events-none` icon could not.

## 3. A segmented control built from raw buttons

`budget-page-header.tsx` built its Category/Flex switch from two `<button>`s in a bordered flex row, re-deriving selected-state styling. The same control is built from `ToggleGroup` in four other places (`appearance-toggle`, `date-range-selector`, `account-list`, `holdings-table`).

It takes the `aria-pressed:bg-primary` override that `appearance-toggle` documents — the shared `bg-muted` sits too close to the page ground to read as selected on a control whose only job is showing which option is active.

## Testing

`pnpm typecheck` and `pnpm lint` pass.

Charts have no automated coverage in this repo (vitest is `environment: "node"` and matches `*.test.ts` only), so I verified them with a throwaway jsdom harness — all four mount without throwing, legend labels resolve from `ChartConfig`, and the tooltip renders `$1,234.56` rather than `123,456`. The harness is not included; adding a jsdom project to vitest so component tests are possible at all is a separate call.

## Deliberately not in this PR

Two further findings from the audit, both of which shift pixels and want a mock first:

- Five popovers build option lists from raw `<button>`s inside `PopoverContent` (`transaction-filters` ×4, `report-filter-bar` ×2, `date-range-popover`). `DropdownMenu` would give roving arrow-key focus, typeahead and `role="menuitem"` — today those lists are Tab-only. This is the largest remaining a11y win.
- Three files hand-roll `<table>` (`bill-list`, `portfolio-reconciliation`, `widgets/account-balances`) while `ui/table.tsx` has six consumers. Needs care around cell padding and the `table-fixed` clipping fix from #159.

Not recommended: the ~20 hand-rolled `rounded-lg border` shells are *visually different* from this repo's `Card` (`rounded-xl bg-card ring-1 ring-foreground/10`, no border). Converting them is a redesign, not a refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
