### PR TITLE
fix(ui): forward ToggleGroup's orientation to the primitive

### DIFF
--- a/src/components/ui/toggle-group.test.tsx
+++ b/src/components/ui/toggle-group.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Arrow-key movement in a ToggleGroup comes from Base UI's composite, which
+ * reads `orientation` off the primitive. Our wrapper takes `orientation` as its
+ * own prop, so it is one destructure away from being spent on the data
+ * attribute and never reaching the composite — which is exactly what happened:
+ * a vertical group answered to Left/Right instead of Up/Down.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ToggleGroup, ToggleGroupItem } from "./toggle-group";
+
+function renderGroup(orientation: "horizontal" | "vertical") {
+  render(
+    <ToggleGroup value={["a"]} onValueChange={() => {}} orientation={orientation} aria-label="Test">
+      <ToggleGroupItem value="a">A</ToggleGroupItem>
+      <ToggleGroupItem value="b">B</ToggleGroupItem>
+      <ToggleGroupItem value="c">C</ToggleGroupItem>
+    </ToggleGroup>,
+  );
+  return ["A", "B", "C"].map((n) => screen.getByRole("button", { name: n }));
+}
+
+async function movesFocus(items: HTMLElement[], key: string) {
+  items[0].focus();
+  fireEvent.keyDown(items[0], { key });
+  try {
+    await waitFor(() => expect(document.activeElement).toBe(items[1]), { timeout: 300 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("ToggleGroup keyboard navigation", () => {
+  it("is a single tab stop, not one per item", () => {
+    const items = renderGroup("horizontal");
+    expect(items.filter((el) => (el as HTMLButtonElement).tabIndex === 0)).toHaveLength(1);
+  });
+
+  it("moves a vertical group with ArrowDown", async () => {
+    expect(await movesFocus(renderGroup("vertical"), "ArrowDown")).toBe(true);
+  });
+
+  it("does not move a vertical group with ArrowRight", async () => {
+    expect(await movesFocus(renderGroup("vertical"), "ArrowRight")).toBe(false);
+  });
+
+  it("moves a horizontal group with ArrowRight", async () => {
+    expect(await movesFocus(renderGroup("horizontal"), "ArrowRight")).toBe(true);
+  });
+});

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -39,6 +39,10 @@ function ToggleGroup({
       data-variant={variant}
       data-size={size}
       data-spacing={spacing}
+      // Base UI drives arrow-key movement from this, so it has to reach the
+      // primitive and not just the data attribute the styles read. Without it
+      // a vertical group still answered to Left/Right instead of Up/Down.
+      orientation={orientation}
       data-orientation={orientation}
       style={{ "--gap": spacing } as React.CSSProperties}
       className={cn(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+    // `.tsx` files are component tests; each one declares
+    // `@vitest-environment jsdom` in its own docblock, so the default node
+    // environment still applies to everything else.
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx", "tests/**/*.test.ts"],
     exclude: ["e2e/**", "node_modules/**"],
     globalSetup: ["./tests/global-setup.ts"],
     testTimeout: 30_000,


### PR DESCRIPTION
A bug in #165, found by finally running the keyboard check that PR shipped without.

## What is wrong

`ToggleGroup` takes `orientation` as its own prop, destructures it, and spends it on `data-orientation` and the class list. It never reaches `ToggleGroupPrimitive`. Base UI's composite drives arrow-key movement from the real prop, so it kept its horizontal default.

The vertical date-preset group added in #165 is the first caller to notice. It renders as a column but moves with Left/Right, and Up/Down does nothing:

```
ArrowDown  → focus did not move
ArrowRight → focus moved
```

The four pre-existing callers (`appearance-toggle`, `date-range-selector`, `account-list`, `holdings-table`) are all horizontal, which is why this survived until a vertical group existed.

Fix is one line: pass `orientation` to the primitive as well as the data attribute.

## How this got in

#165 shipped the keyboard behaviour unverified, and I said so in its description — CI cannot see it, since there were no component tests. I also said I could not verify it without Chrome remote debugging. That was wrong: Base UI's roving focus is plain JS and jsdom drives it fine. Five green checks and a reviewed mock did not catch a control navigating along the wrong axis.

## The regression test

`src/components/ui/toggle-group.test.tsx` pins all four directions — vertical moves on ArrowDown and *not* on ArrowRight, horizontal moves on ArrowRight, and the group is a single tab stop.

Getting it to run at all needed vitest to accept `.tsx`:

- `include` now covers `src/**/*.test.tsx`.
- A component test declares `@vitest-environment jsdom` in its own docblock, so the `node` default still applies to every other file.

No projects, no workspace, no CI change. This also closes the "component tests are not currently possible" gap recorded in `AGENTS.md` — worth a follow-up to reword that line once this lands.

## Not the same bug

`size` on Card, Avatar, Select, Switch and AlertDialog, and `align` on InputGroup, follow the same destructure-to-data-attribute shape. Those are styling-only props shadcn expresses that way deliberately. `orientation` is the one that changes what the primitive *does*, which is what made it a bug. Checked, no other instances.

## Testing

`pnpm typecheck`, `pnpm lint`, and the new test under the project's real vitest config all pass (4/4).

Still not verified in a browser. The test drives Base UI's focus management directly, which is where the bug was, but a pass through the Reports date picker would confirm it end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
