### PR TITLE
Fix four leaks in the categorization pipeline (171 uncategorized -> 3)

### DIFF
--- a/src/components/molecules/transaction-metadata.tsx
+++ b/src/components/molecules/transaction-metadata.tsx
@@ -15,7 +15,9 @@ interface TransactionMetadataProps {
 const SOURCE_LABELS: Record<string, string> = {
   manual: "Manual",
   ai: "AI",
+  ai_low_confidence: "AI (unsure)",
   rule: "Rule",
+  merchant_default: "Merchant",
   plaid: "Plaid",
   pfc: "Plaid (PFC)",
 };

--- a/src/db/schema/transactions.ts
+++ b/src/db/schema/transactions.ts
@@ -6,7 +6,19 @@ import { merchants } from "./merchants";
 import { categories } from "./categories";
 import { recurringTransactions } from "./recurring";
 
-export const CATEGORY_SOURCES = ["rule", "merchant_default", "pfc", "ai", "manual"] as const;
+// `ai_low_confidence` is a real AI assignment, just one the model was unsure
+// of. An uncategorized row has to be edited by hand anyway, so a best guess is
+// strictly better than nothing — it is recorded under its own source so the
+// review queue can surface it and a later tier can safely overwrite it, which
+// a plain `ai` assignment is not meant to allow.
+export const CATEGORY_SOURCES = [
+  "rule",
+  "merchant_default",
+  "pfc",
+  "ai",
+  "ai_low_confidence",
+  "manual",
+] as const;
 export type CategorySource = (typeof CATEGORY_SOURCES)[number];
 
 export const transactions = pgTable(

--- a/src/db/seed/demo.ts
+++ b/src/db/seed/demo.ts
@@ -397,7 +397,7 @@ export async function seedDemoHousehold(db: LedgrDb = defaultDb): Promise<void> 
           currency: "USD",
           pending: false,
           reviewed: true,
-          categorySource: CATEGORY_SOURCES[txnIndex % 5],
+          categorySource: CATEGORY_SOURCES[txnIndex % CATEGORY_SOURCES.length],
           createdAt: now,
           updatedAt: now,
         });
@@ -439,7 +439,7 @@ export async function seedDemoHousehold(db: LedgrDb = defaultDb): Promise<void> 
           currency: "USD",
           pending: false,
           reviewed: txnIndex % 4 !== 0,
-          categorySource: CATEGORY_SOURCES[txnIndex % 5],
+          categorySource: CATEGORY_SOURCES[txnIndex % CATEGORY_SOURCES.length],
           createdAt: now,
           updatedAt: now,
         });

--- a/src/lib/ai/categorize.test.ts
+++ b/src/lib/ai/categorize.test.ts
@@ -10,7 +10,7 @@ describe("buildCategorizationPrompt", () => {
 
   test("includes all categories with IDs", () => {
     const prompt = buildCategorizationPrompt(
-      [{ id: "txn-1", description: "STARBUCKS #123", amount: -550 }],
+      [{ id: "txn-1", description: "STARBUCKS #123", normalizedAmount: -550 }],
       categories,
       [],
     );
@@ -21,12 +21,48 @@ describe("buildCategorizationPrompt", () => {
 
   test("includes transaction details", () => {
     const prompt = buildCategorizationPrompt(
-      [{ id: "txn-1", description: "STARBUCKS #123", amount: -550 }],
+      [{ id: "txn-1", description: "STARBUCKS #123", normalizedAmount: -550 }],
       categories,
       [],
     );
     expect(prompt).toContain("txn-1");
     expect(prompt).toContain("STARBUCKS #123");
+  });
+});
+
+describe("buildCategorizationPrompt expense/income labelling", () => {
+  const categories = [{ id: "cat-1", name: "Coffee", groupName: "Food & Drink" }];
+
+  // Regression: the prompt used to read the raw `amount` column with Plaid's
+  // positive-is-debit rule. SimpleFIN stores negative-is-debit, so every
+  // SimpleFIN expense was announced to the model as income — and the default
+  // taxonomy's only generic bucket is "Other Income", so unknown expenses
+  // landed there and counted as income in reports.
+  test("labels a negative normalized amount as an expense", () => {
+    const prompt = buildCategorizationPrompt(
+      [{ id: "txn-1", description: "SEVEN-ELEVEN", normalizedAmount: -209 }],
+      categories,
+      [],
+    );
+    expect(prompt).toContain("$2.09 (expense)");
+  });
+
+  test("labels a positive normalized amount as income", () => {
+    const prompt = buildCategorizationPrompt(
+      [{ id: "txn-2", description: "IRS TREAS TAX REF", normalizedAmount: 158100 }],
+      categories,
+      [],
+    );
+    expect(prompt).toContain("$1581.00 (income)");
+  });
+
+  test("tells the model not to cross the expense/income line", () => {
+    const prompt = buildCategorizationPrompt(
+      [{ id: "txn-3", description: "ALPENGROUP", normalizedAmount: -4600 }],
+      categories,
+      [],
+    );
+    expect(prompt).toMatch(/never assign an expense to an income category/i);
   });
 });
 
@@ -56,6 +92,43 @@ describe("validateAssignments", () => {
       batchTransactionIds,
     );
     expect(result).toHaveLength(0);
+  });
+
+  test("rejects an income category for an outflow", () => {
+    // Reports exclude income categories from spend, so an expense filed under
+    // one vanishes from spending and inflates income — worse than leaving it
+    // uncategorized. Seen in practice when the taxonomy has no generic
+    // expense bucket and the model reaches for "Other Income".
+    const result = validateAssignments(
+      [{ transactionId: "txn-1", categoryId: "cat-3", confidence: 0.4 }],
+      validCategoryIds,
+      batchTransactionIds,
+      new Set(["cat-3"]),
+      new Set(),
+    );
+    expect(result).toHaveLength(0);
+  });
+
+  test("allows an income category for an inflow", () => {
+    const result = validateAssignments(
+      [{ transactionId: "txn-1", categoryId: "cat-3", confidence: 0.9 }],
+      validCategoryIds,
+      batchTransactionIds,
+      new Set(["cat-3"]),
+      new Set(["txn-1"]),
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  test("allows an expense category for an inflow, so a refund can offset it", () => {
+    const result = validateAssignments(
+      [{ transactionId: "txn-1", categoryId: "cat-1", confidence: 0.9 }],
+      validCategoryIds,
+      batchTransactionIds,
+      new Set(["cat-3"]),
+      new Set(["txn-1"]),
+    );
+    expect(result).toHaveLength(1);
   });
 
   test("rejects hallucinated transactionIds", () => {

--- a/src/lib/ai/categorize.ts
+++ b/src/lib/ai/categorize.ts
@@ -6,6 +6,7 @@ import {
   transactions,
   categories,
   categoryGroups,
+  type CategorySource,
 } from "@/db/schema";
 import { notDeleted } from "@/lib/query-helpers";
 import { resolvedCategoryLabel } from "@/lib/labels";
@@ -26,7 +27,23 @@ const categorizationSchema = z.object({
 interface CategorizationInput {
   id: string;
   description: string;
-  amount: number;
+  /**
+   * Signed cents in the provider-agnostic display convention: negative is
+   * money out, positive is money in. This must be `normalized_amount`, never
+   * the raw `amount` — Plaid sends positive-for-debit and SimpleFIN sends
+   * negative-for-debit, so raw amounts label half the household's expenses as
+   * income and steer the model straight into the Income group.
+   */
+  normalizedAmount: number;
+}
+
+export interface CategorizationRun {
+  /** Rows the model assigned a category to, at any confidence. */
+  categorized: number;
+  /** Subset of `categorized` filed as `ai_low_confidence` — a best guess. */
+  lowConfidence: number;
+  /** Rows the model returned no pick for, plus rows in batches that failed. */
+  skipped: number;
 }
 
 interface CategoryInfo {
@@ -56,12 +73,17 @@ export function buildCategorizationPrompt(
 
   prompt += "\n## Transactions to categorize\n";
   for (const txn of txns) {
-    const type = txn.amount > 0 ? "expense" : "income";
-    prompt += `- ID: "${txn.id}" | "${txn.description}" | $${Math.abs(txn.amount / 100).toFixed(2)} (${type})\n`;
+    const type = txn.normalizedAmount < 0 ? "expense" : "income";
+    prompt += `- ID: "${txn.id}" | "${txn.description}" | $${Math.abs(txn.normalizedAmount / 100).toFixed(2)} (${type})\n`;
   }
 
   prompt +=
-    "\nReturn low confidence (<0.5) when uncertain. Use ONLY the exact category IDs listed above.";
+    "\nEach transaction is marked (expense) or (income) — never assign an " +
+    "expense to an income category, or the reverse. " +
+    "Return an assignment for EVERY transaction listed — never omit one because " +
+    "you are unsure. Pick the single closest category and report your genuine " +
+    "confidence (a low number is fine and useful; omitting the row is not). " +
+    "Use ONLY the exact category IDs listed above.";
   return prompt;
 }
 
@@ -69,12 +91,24 @@ export function validateAssignments(
   assignments: z.infer<typeof categorizationSchema>["assignments"],
   validCategoryIds: Set<string>,
   batchTransactionIds: Set<string>,
+  incomeCategoryIds: Set<string> = new Set(),
+  incomeTransactionIds: Set<string> = new Set(),
 ): z.infer<typeof categorizationSchema>["assignments"] {
-  return assignments.filter(
-    (a) =>
-      validCategoryIds.has(a.categoryId) &&
-      batchTransactionIds.has(a.transactionId),
-  );
+  return assignments.filter((a) => {
+    if (!validCategoryIds.has(a.categoryId)) return false;
+    if (!batchTransactionIds.has(a.transactionId)) return false;
+    // Money going out may never be filed under an income category. Reports
+    // subtract income categories from spend (queries/shared-conditions
+    // notIncome), so an expense parked in one disappears from spending
+    // entirely and inflates income — strictly worse than leaving it
+    // uncategorized, which is the whole reason low-confidence picks are kept.
+    // Asymmetric on purpose: an inflow *may* take an expense category, since
+    // that is how a refund correctly offsets the category it came from.
+    if (incomeCategoryIds.has(a.categoryId) && !incomeTransactionIds.has(a.transactionId)) {
+      return false;
+    }
+    return true;
+  });
 }
 
 export function getBatchSize(provider: string): number {
@@ -88,17 +122,17 @@ export function getBatchSize(provider: string): number {
 export function categorizeWithAi(
   householdId: string,
   db: LedgrDb = defaultDb,
-): Promise<{ categorized: number; skipped: number }> {
+): Promise<CategorizationRun> {
   return coalesce(`ai-categorize:${householdId}`, () => runCategorization(householdId, db));
 }
 
 async function runCategorization(
   householdId: string,
   db: LedgrDb,
-): Promise<{ categorized: number; skipped: number }> {
+): Promise<CategorizationRun> {
   const config = getAiConfig();
   const model = createAiModel();
-  if (!config || !model) return { categorized: 0, skipped: 0 };
+  if (!config || !model) return { categorized: 0, lowConfidence: 0, skipped: 0 };
 
   // Short-lived transaction — not held open across the batched LLM calls below.
   const initial = await withHousehold(householdId, async (tx) => {
@@ -106,7 +140,7 @@ async function runCategorization(
       .select({
         id: transactions.id,
         name: transactions.name,
-        amount: transactions.amount,
+        normalizedAmount: transactions.normalizedAmount,
       })
       .from(transactions)
       .where(
@@ -143,7 +177,7 @@ async function runCategorization(
     return { uncategorizedRows, catRows, groupRows, exampleTxnRows };
   }, db);
 
-  if (!initial) return { categorized: 0, skipped: 0 };
+  if (!initial) return { categorized: 0, lowConfidence: 0, skipped: 0 };
   const { uncategorizedRows: uncategorized, catRows: cats, groupRows: groups, exampleTxnRows: exampleRows } = initial;
 
   const groupMap = new Map(groups.map((g) => [g.id, g.name]));
@@ -154,6 +188,7 @@ async function runCategorization(
     groupName: groupMap.get(c.groupId) ?? "Other",
   }));
   const validCategoryIds = new Set(cats.map((c) => c.id));
+  const incomeCategoryIds = new Set(cats.filter((c) => c.isIncome).map((c) => c.id));
 
   const examples = exampleRows
     .filter((e) => e.categoryId)
@@ -167,6 +202,7 @@ async function runCategorization(
   const threshold = config.confidenceThreshold;
   const batchSize = getBatchSize(config.aiProvider);
   let categorized = 0;
+  let lowConfidence = 0;
   const now = new Date();
 
   for (let i = 0; i < uncategorized.length; i += batchSize) {
@@ -174,17 +210,26 @@ async function runCategorization(
     const batchInputs: CategorizationInput[] = batch.map((t) => ({
       id: t.id,
       description: t.name,
-      amount: t.amount,
+      normalizedAmount: t.normalizedAmount,
     }));
     const batchIds = new Set(batch.map((t) => t.id));
+    const incomeTxnIds = new Set(batch.filter((t) => t.normalizedAmount > 0).map((t) => t.id));
 
-    let aboveThreshold: z.infer<typeof categorizationSchema>["assignments"] = [];
+    let picks: z.infer<typeof categorizationSchema>["assignments"] = [];
+    // Only a batch the model actually answered gets stamped below. A thrown
+    // call or an unparseable response must leave aiCategorizationAttemptedAt
+    // NULL, or one transient provider blip permanently retires those rows —
+    // the uncategorized scan at the top of this function filters on that
+    // column being NULL, so a burnt row is never offered to the AI again.
+    let modelAnswered = false;
     try {
       const { output } = await generateText({
         model,
         output: Output.object({ schema: categorizationSchema }),
         instructions:
-          "You are a financial transaction categorization assistant. Be precise and conservative.",
+          "You are a financial transaction categorization assistant. Always commit " +
+          "to the closest category for every transaction, and use the confidence " +
+          "score — not omission — to express uncertainty.",
         prompt: buildCategorizationPrompt(batchInputs, categoryInfos, examples),
       });
 
@@ -193,32 +238,58 @@ async function runCategorization(
           output.assignments,
           validCategoryIds,
           batchIds,
+          incomeCategoryIds,
+          incomeTxnIds,
         );
-        aboveThreshold = validated.filter((a) => a.confidence >= threshold);
+        // Every validated pick is applied, including the unsure ones. An
+        // uncategorized row costs the user an edit regardless, so the model's
+        // closest guess can only save work: right, and they keep it; wrong,
+        // and they were going to set it by hand anyway. `threshold` no longer
+        // discards anything — it decides which provenance the pick is filed
+        // under.
+        picks = validated;
+        modelAnswered = true;
+      } else {
+        console.error(
+          "AI categorization batch returned no output — leaving rows unstamped for retry",
+        );
       }
     } catch (e) {
       console.error(`AI categorization batch failed:`, e);
     }
 
-    const idsByCategoryId = new Map<string, string[]>();
-    for (const a of aboveThreshold) {
-      const ids = idsByCategoryId.get(a.categoryId);
-      if (ids) ids.push(a.transactionId);
-      else idsByCategoryId.set(a.categoryId, [a.transactionId]);
+    // Group by (categoryId, source) so each distinct pair is one UPDATE over
+    // inArray(ids) rather than one UPDATE per transaction.
+    const groups = new Map<string, { categoryId: string; source: CategorySource; ids: string[] }>();
+    for (const a of picks) {
+      const source: CategorySource = a.confidence >= threshold ? "ai" : "ai_low_confidence";
+      const key = `${a.categoryId}\0${source}`;
+      const group = groups.get(key);
+      if (group) group.ids.push(a.transactionId);
+      else groups.set(key, { categoryId: a.categoryId, source, ids: [a.transactionId] });
     }
 
-    await withHousehold(householdId, async (tx) => {
-      for (const [categoryId, ids] of idsByCategoryId) {
-        await tx.update(transactions)
-          .set({ categoryId, categorySource: "ai", updatedAt: now })
-          .where(inArray(transactions.id, ids));
-      }
-      await tx.update(transactions)
-        .set({ aiCategorizationAttemptedAt: now })
-        .where(inArray(transactions.id, [...batchIds]));
-    }, db);
-    categorized += aboveThreshold.length;
+    if (modelAnswered || groups.size > 0) {
+      await withHousehold(householdId, async (tx) => {
+        for (const group of groups.values()) {
+          await tx.update(transactions)
+            .set({ categoryId: group.categoryId, categorySource: group.source, updatedAt: now })
+            .where(inArray(transactions.id, group.ids));
+        }
+        // A batch the model actually answered is stamped whole — including
+        // any row it returned no pick for at all, which is a real verdict and
+        // must not be resent every sync. Failed batches fall through
+        // unstamped so the next run retries them.
+        if (modelAnswered) {
+          await tx.update(transactions)
+            .set({ aiCategorizationAttemptedAt: now })
+            .where(inArray(transactions.id, [...batchIds]));
+        }
+      }, db);
+    }
+    categorized += picks.length;
+    lowConfidence += picks.filter((a) => a.confidence < threshold).length;
   }
 
-  return { categorized, skipped: uncategorized.length - categorized };
+  return { categorized, lowConfidence, skipped: uncategorized.length - categorized };
 }

--- a/src/lib/transfer-patterns.test.ts
+++ b/src/lib/transfer-patterns.test.ts
@@ -49,6 +49,39 @@ describe("classifySingleLegTransfer", () => {
     expect(classifySingleLegTransfer("Bahar Rabiei", null)).toBeNull();
   });
 
+  it("recognizes a bare points redemption as high confidence", () => {
+    // Reward credits are neither spend nor income; before this they fell
+    // through to Uncategorized and counted toward spending totals.
+    expect(classifySingleLegTransfer("Points Redeemed", null)).toBe("pattern");
+  });
+
+  it("recognizes an issuer-prefixed points redemption memo", () => {
+    expect(
+      classifySingleLegTransfer("Thankyou Points Redeemed TY OR301166076", null),
+    ).toBe("pattern");
+  });
+
+  it("does not flag a purchase at a merchant whose name contains points", () => {
+    expect(classifySingleLegTransfer("Five Points Pizza", "Five Points Pizza")).toBeNull();
+    expect(classifySingleLegTransfer("Points West Bank ATM", null)).toBeNull();
+  });
+
+  it("recognizes a retirement rollover into a named self account", () => {
+    expect(
+      classifySingleLegTransfer(
+        "Direct rollover of $ into Robinhood Traditional IRA account ending in",
+        null,
+      ),
+    ).toBe("pattern");
+  });
+
+  it("does not flag a rollover with no self-account keyword", () => {
+    // "rollover" alone is not enough — the self-account keyword is what
+    // separates moving your own money from a merchant that happens to use
+    // the word.
+    expect(classifySingleLegTransfer("Rollover Bar & Grill", null)).toBeNull();
+  });
+
   it("is case-insensitive", () => {
     expect(classifySingleLegTransfer("gsbank payment", null)).toBe("pattern");
     expect(classifySingleLegTransfer("ZELLE", null)).toBe("suggested");

--- a/src/lib/transfer-patterns.ts
+++ b/src/lib/transfer-patterns.ts
@@ -11,9 +11,24 @@ const CARD_PAYOFF_MEMOS = [
   "cc payment thank you",
 ];
 
-// Self-transfer phrasing: requires both "transfer" and a self-account keyword
-// so an unrelated "Wire Transfer Fee" merchant charge doesn't match.
-const SELF_TRANSFER_KEYWORD = /\btransfer\b/i;
+// Reward redemptions posted as a statement credit ("Points Redeemed",
+// "Thankyou Points Redeemed TY OR301166076"). Not spending and not income —
+// counting them as either skews both sides of a report, so they are excluded
+// the same way a transfer is. Anchored on the two-word phrase rather than a
+// bare "points" so a purchase at a merchant with "Points" in its name (Five
+// Points Pizza) cannot match.
+const REWARD_REDEMPTION_MEMOS = [
+  "points redeemed",
+  "points redemption",
+  "reward redemption",
+];
+
+// Self-transfer phrasing: requires both a movement verb and a self-account
+// keyword so an unrelated "Wire Transfer Fee" merchant charge doesn't match.
+// "rollover" is here because a retirement rollover is phrased as a movement
+// into an account rather than as a "transfer" ("Direct rollover of $X into
+// Robinhood Traditional IRA").
+const SELF_TRANSFER_KEYWORD = /\b(transfer|rollover)\b/i;
 const SELF_ACCOUNT_KEYWORD = /\b(savings|brokerage|ira)\b/i;
 
 // Bare P2P processor names — lower confidence than the patterns above because
@@ -28,10 +43,10 @@ function matchesAny(haystack: string, needles: string[]): boolean {
 /**
  * Classifies a single transaction (no matching leg required) as a likely
  * transfer from its name/merchant text alone. Returns "pattern" for
- * high-confidence matches (known card payoff memos, named self-transfers to
- * savings/brokerage/IRA — trusted immediately), "suggested" for low-confidence
- * matches (bare P2P processor names — routed to manual review instead), or
- * null when nothing matches.
+ * high-confidence matches (known card payoff memos, reward redemptions, and
+ * named self-transfers or rollovers to savings/brokerage/IRA — trusted
+ * immediately), "suggested" for low-confidence matches (bare P2P processor
+ * names — routed to manual review instead), or null when nothing matches.
  */
 export function classifySingleLegTransfer(
   name: string,
@@ -40,6 +55,7 @@ export function classifySingleLegTransfer(
   const text = `${name} ${merchantName ?? ""}`.toLowerCase().trim();
 
   if (matchesAny(text, CARD_PAYOFF_MEMOS)) return "pattern";
+  if (matchesAny(text, REWARD_REDEMPTION_MEMOS)) return "pattern";
   if (SELF_TRANSFER_KEYWORD.test(text) && SELF_ACCOUNT_KEYWORD.test(text)) return "pattern";
   if (matchesAny(text, P2P_PROCESSORS)) return "suggested";
 

--- a/tests/integration/ai-categorize-retry.test.ts
+++ b/tests/integration/ai-categorize-retry.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest";
+import { eq } from "drizzle-orm";
+import { v4 as uuid } from "uuid";
+import { createTestDb } from "./setup";
+import {
+  households,
+  householdMembers,
+  categoryGroups,
+  categories,
+  bankConnections,
+  accounts,
+  transactions,
+} from "@/db/schema";
+import type { LedgrDb } from "@/db";
+
+vi.mock("ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ai")>();
+  return { ...actual, generateText: vi.fn() };
+});
+
+const { generateText } = await import("ai");
+const { categorizeWithAi } = await import("@/lib/ai/categorize");
+
+const HOUSEHOLD_ID = "hh-ai-categorize-retry";
+const CATEGORY_ID = "cat-groceries";
+const CONNECTION_ID = "conn-sfin";
+const ACCOUNT_ID = "acc-sfin";
+
+function mockAssignments(assignments: unknown[]) {
+  vi.mocked(generateText).mockResolvedValue({
+    output: { assignments },
+  } as never);
+}
+
+describe("categorizeWithAi retry semantics", () => {
+  let db: LedgrDb;
+  let close: () => Promise<void>;
+
+  beforeAll(() => {
+    vi.stubEnv("AI_PROVIDER", "google");
+    vi.stubEnv("AI_MODEL", "test-model");
+    vi.stubEnv("AI_API_KEY", "test-key");
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.mocked(generateText).mockReset();
+  });
+
+  async function setup() {
+    ({ db, close } = await createTestDb());
+    const now = new Date();
+
+    await db.insert(households).values({ id: HOUSEHOLD_ID, name: "Test", createdAt: now, updatedAt: now });
+    await db.insert(householdMembers).values({ id: uuid(), householdId: HOUSEHOLD_ID, userId: "user-1", role: "owner", createdAt: now });
+    await db.insert(categoryGroups).values({ id: "grp-food", householdId: HOUSEHOLD_ID, name: "Food & Drink" });
+    await db.insert(categories).values({ id: CATEGORY_ID, householdId: HOUSEHOLD_ID, groupId: "grp-food", name: "Groceries" });
+    await db.insert(bankConnections).values({
+      id: CONNECTION_ID,
+      householdId: HOUSEHOLD_ID,
+      provider: "simplefin",
+      credential: "encrypted-cred",
+      institutionName: "Robinhood",
+      status: "active",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(accounts).values({
+      id: ACCOUNT_ID,
+      householdId: HOUSEHOLD_ID,
+      bankConnectionId: CONNECTION_ID,
+      externalAccountId: "sfin-acc-1",
+      name: "Robinhood Credit Card",
+      type: "credit",
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  async function insertTxn(id: string, name: string) {
+    await db.insert(transactions).values({
+      id,
+      accountId: ACCOUNT_ID,
+      householdId: HOUSEHOLD_ID,
+      date: "2026-08-28",
+      originalName: name,
+      name,
+      amount: 1250,
+      normalizedAmount: -1250,
+    });
+  }
+
+  async function read(id: string) {
+    const [row] = await db.select().from(transactions).where(eq(transactions.id, id));
+    return row;
+  }
+
+  it("leaves a thrown batch unstamped so the next sync retries it", async () => {
+    // Regression: the attempt stamp used to be written unconditionally, so a
+    // single transient provider error permanently retired the batch — the
+    // uncategorized scan filters on aiCategorizationAttemptedAt IS NULL.
+    await setup();
+    await insertTxn("txn-1", "Seven-Eleven");
+
+    vi.mocked(generateText).mockRejectedValue(new Error("503 upstream unavailable"));
+    const first = await categorizeWithAi(HOUSEHOLD_ID, db);
+    expect(first.categorized).toBe(0);
+
+    const afterFailure = await read("txn-1");
+    expect(afterFailure.aiCategorizationAttemptedAt).toBeNull();
+    expect(afterFailure.categoryId).toBeNull();
+
+    mockAssignments([{ transactionId: "txn-1", categoryId: CATEGORY_ID, confidence: 0.95 }]);
+    const second = await categorizeWithAi(HOUSEHOLD_ID, db);
+    expect(second.categorized).toBe(1);
+
+    const afterRetry = await read("txn-1");
+    expect(afterRetry.categoryId).toBe(CATEGORY_ID);
+    expect(afterRetry.categorySource).toBe("ai");
+
+    await close();
+  });
+
+  it("applies a low-confidence pick instead of discarding it", async () => {
+    // An uncategorized row costs an edit either way, so the closest guess is
+    // strictly better than leaving it blank — it is just filed under its own
+    // provenance. Previously anything under the threshold was thrown away.
+    await setup();
+    await insertTxn("txn-2", "Shoyukai");
+
+    mockAssignments([{ transactionId: "txn-2", categoryId: CATEGORY_ID, confidence: 0.2 }]);
+    const result = await categorizeWithAi(HOUSEHOLD_ID, db);
+    expect(result).toMatchObject({ categorized: 1, lowConfidence: 1 });
+
+    const row = await read("txn-2");
+    expect(row.categoryId).toBe(CATEGORY_ID);
+    expect(row.categorySource).toBe("ai_low_confidence");
+
+    await close();
+  });
+
+  it("files a confident pick as plain ai", async () => {
+    await setup();
+    await insertTxn("txn-2b", "Safeway");
+
+    mockAssignments([{ transactionId: "txn-2b", categoryId: CATEGORY_ID, confidence: 0.93 }]);
+    const result = await categorizeWithAi(HOUSEHOLD_ID, db);
+    expect(result).toMatchObject({ categorized: 1, lowConfidence: 0 });
+
+    const row = await read("txn-2b");
+    expect(row.categorySource).toBe("ai");
+
+    await close();
+  });
+
+  it("stamps a row the model returned no pick for, so it is not resent forever", async () => {
+    // The counterpart guarantee: the model answering and simply not naming a
+    // row is a real verdict. Without this, rows the model keeps skipping
+    // would be resent on every single sync.
+    await setup();
+    await insertTxn("txn-2c", "Hankiyuhanshin Shiyogi Osaka JPN");
+
+    mockAssignments([]);
+    const result = await categorizeWithAi(HOUSEHOLD_ID, db);
+    expect(result.categorized).toBe(0);
+
+    const row = await read("txn-2c");
+    expect(row.categoryId).toBeNull();
+    expect(row.aiCategorizationAttemptedAt).not.toBeNull();
+
+    vi.mocked(generateText).mockClear();
+    await categorizeWithAi(HOUSEHOLD_ID, db);
+    expect(generateText).not.toHaveBeenCalled();
+
+    await close();
+  });
+
+  it("leaves an unparseable response unstamped so the next sync retries it", async () => {
+    await setup();
+    await insertTxn("txn-3", "Ekimo Umeda");
+
+    vi.mocked(generateText).mockResolvedValue({ output: undefined } as never);
+    await categorizeWithAi(HOUSEHOLD_ID, db);
+
+    const row = await read("txn-3");
+    expect(row.aiCategorizationAttemptedAt).toBeNull();
+
+    await close();
+  });
+
+  it("stamps only the batches that succeeded when one of several fails", async () => {
+    // getBatchSize("custom") is 20, so 21 rows split into two batches: the
+    // first answers, the second throws. Only the first may be stamped.
+    await setup();
+    vi.stubEnv("AI_PROVIDER", "custom");
+    vi.stubEnv("AI_BASE_URL", "http://localhost:1/v1");
+    for (let i = 0; i < 21; i++) await insertTxn(`txn-b${i}`, `Merchant ${i}`);
+
+    vi.mocked(generateText)
+      .mockResolvedValueOnce({ output: { assignments: [] } } as never)
+      .mockRejectedValueOnce(new Error("429 rate limited"));
+
+    await categorizeWithAi(HOUSEHOLD_ID, db);
+
+    const rows = await db.select().from(transactions).where(eq(transactions.householdId, HOUSEHOLD_ID));
+    const stamped = rows.filter((r) => r.aiCategorizationAttemptedAt !== null);
+    expect(stamped).toHaveLength(20);
+
+    vi.stubEnv("AI_PROVIDER", "google");
+    vi.stubEnv("AI_BASE_URL", "");
+    await close();
+  });
+});


### PR DESCRIPTION
Most transactions in the Transactions tab were showing as **Uncategorized**. Checking the four-tier pipeline against a real 814-transaction household turned up four separate defects — one of which was silently writing wrong data rather than no data.

On that household this takes the visible Uncategorized count from **171 to 3**.

## What was wrong

**1. Expenses were announced to the AI as income.**

`buildCategorizationPrompt` read the raw `amount` column using Plaid's positive-is-debit rule:

```js
const type = txn.amount > 0 ? "expense" : "income";
```

But `normalized_amount` is the provider-agnostic convention — Plaid flips the sign (`plaid/sync.ts`), SimpleFIN stores negative-is-debit and doesn't (`simplefin/sync.ts:134`). So **every SimpleFIN expense was labelled `(income)` in the prompt.** Since the default taxonomy's only generic bucket is `Other Income`, unknown expenses landed there and counted as income in reports. Before the fix: `Alpengroup -$46 → Other Income`, `Drivers License Center -$25.76 → Other Income`. After: Entertainment, and Public Transit / Home Goods for their neighbours.

**2. A failed AI batch permanently retired its rows.**

`aiCategorizationAttemptedAt` was stamped on the whole batch regardless of outcome — including when `generateText` threw. The uncategorized scan filters on that column being `NULL`, so one transient provider blip meant those rows were **never offered to the AI again**. In the live database all 245 uncategorized rows were already stamped, 145 of them within a single minute.

**3. Low-confidence picks were thrown away.**

An uncategorized row costs the user an edit either way, so the model's closest guess can only save work: right and they keep it, wrong and they were going to set it by hand anyway.

**4. Reward redemptions and rollovers counted as spending.**

`Points Redeemed` is the single largest uncategorized name in a real household. It's neither spend nor income.

## What changed

- **Prompt reads `normalized_amount`**, and states the expense/income split explicitly.
- **Stamp only on a batch the model actually answered.** Thrown calls and unparseable responses fall through unstamped and retry.
- **Every validated pick is applied.** `AI_CONFIDENCE_THRESHOLD` no longer discards anything — it decides whether a pick is filed as `ai` or the new `ai_low_confidence` provenance, which keeps unsure guesses findable and leaves room for a later tier to overwrite them.
- **`validateAssignments` refuses an income category for an outflow**, keyed off the existing `categories.is_income` flag. This is the guard that makes "always guess" safe: reports subtract income categories from spend, so an expense parked in one vanishes from spending *and* inflates income — strictly worse than leaving it uncategorized. Asymmetric on purpose: an inflow may still take an expense category, which is how a refund offsets the category it came from.
- **Reward redemptions and `rollover`** added to the single-leg transfer patterns, still gated on the existing savings/brokerage/IRA keyword.
- `category_source` is plain text with no DB constraint, so the new provenance value **needs no migration**.

## Verification

Against a real 814-transaction household:

| | Before | After |
|---|---|---|
| Shown as Uncategorized | 171 | **3** |
| Transfers detected | 82 | 101 |
| Expenses filed as income | 34 | 34 (**zero new**) |

The 3 remaining refusals are exactly the no-fitting-category cases — `Alpaca Securitie Othr`, `California Secretary of State`, `CAT fee for proceed of trades` — where the guard correctly declined an income category rather than corrupt the reports.

The new transfer patterns were dry-run over all 163 real uncategorized names: **16 caught, 0 false positives.**

Tests: 1152 pass. 11 new (6 integration covering retry/stamp semantics, 5 unit covering the sign convention and the income guard). The single failure, `investment-queries > returns dayChange from holdings_history`, **also fails on clean `main`** — verified by checkout — and is hardcoded-date rot, unrelated to this diff.

## Deliberately not in scope

- **34 rows mis-filed as income by the old code** (31 brokerage fills → Investment Income, plus 3 others) are not repaired here. This stops new ones; the existing ones still skew reports and want a backfill.
- **The default taxonomy has no miscellaneous *expense* category** — every "other" is `Other Income`, in the Income group. That gap is what blocks the last 3 rows, and it's a data change on the household rather than a code fix.
- **Failed batches now retry indefinitely** if a provider stays down, where before they were capped at one attempt ever. Bounding it properly needs a retry-count column and a migration; permanent data loss on a blip is clearly the worse failure, so this takes the simple fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
